### PR TITLE
refactor: migrate test infra to unified stackdome-agent helm chart

### DIFF
--- a/pkg/testutil/cluster.go
+++ b/pkg/testutil/cluster.go
@@ -5,21 +5,21 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
 	"github.com/mt-sre/devkube/dev"
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	kindv1alpha4 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
-	"sigs.k8s.io/yaml"
 
 	// Import all CRD schemes from cluster-agent dependency
 	addonsv1alpha1 "stackdome.io/cluster-agent/api/addons/v1alpha1"
@@ -57,6 +57,7 @@ type TestCluster struct {
 	config      *ClusterConfig
 	environment *dev.Environment
 	logger      logr.Logger
+	restConfig  *rest.Config
 }
 
 // NewTestCluster creates a new test cluster manager
@@ -73,53 +74,73 @@ func NewTestCluster(config *ClusterConfig) *TestCluster {
 	}
 }
 
+// NewTestClusterFromKubeconfig creates a TestCluster backed by an existing kubeconfig file.
+func NewTestClusterFromKubeconfig(kubeconfigPath string, logger logr.Logger) (*TestCluster, error) {
+	if logger.GetSink() == nil {
+		logger = stdr.New(log.New(os.Stdout, "", log.LstdFlags))
+	}
+
+	restCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading kubeconfig %s: %w", kubeconfigPath, err)
+	}
+
+	return NewTestClusterFromRESTConfig(restCfg, logger), nil
+}
+
+// NewTestClusterFromRESTConfig creates a TestCluster from an existing REST config.
+func NewTestClusterFromRESTConfig(cfg *rest.Config, logger logr.Logger) *TestCluster {
+	if logger.GetSink() == nil {
+		logger = stdr.New(log.New(os.Stdout, "", log.LstdFlags))
+	}
+
+	return &TestCluster{
+		config: &ClusterConfig{
+			Logger: logger,
+		},
+		logger:     logger,
+		restConfig: cfg,
+	}
+}
+
 // Setup creates and initializes the test cluster
 func (tc *TestCluster) Setup(ctx context.Context) error {
 	tc.logger.Info("Setting up test cluster", "name", tc.config.Name)
 
-	// Prepare cluster initializers
-	var clusterInitializers []dev.ClusterInitializer
+	helmBin, err := EnsureHelm(ctx)
+	if err != nil {
+		return fmt.Errorf("ensuring helm is available: %w", err)
+	}
+	tc.logger.Info("Using helm", "path", helmBin)
 
-	// We use GitHubLoader and httpObjectApplier since github loader uses
-	// a client which can use gh personal access token for authentication and thus can handle private repositories,
-	// while httpObjectApplier is a simple initializer that applies manifests from given URLs and does not require authentication.
-	// We use GitHubLoader for the cluster agent since it is a private repository, and httpObjectApplier for the Barman Cloud plugin since it is public.
-	// Load cluster agent manifests from GitHub
-	clusterAgentInitializer := NewGitHubLoader(
-		ctx,
-		WithCacheDir(tc.config.CacheDir),
-		WithRepoOwner(clusterAgentOwner),
-		WithRepoName(clusterAgentRepo),
-		WithRepoTag(GetClusterAgentVersion()),
-		WithPathsToLoad([]string{
-			"config/deploy/00-namespace.yaml",
-			"config/deploy/01-rbac.yaml",
-			// Trailing slash is important as it tells the loader to load all manifests in the folder.
-			"config/deploy/crds/",
+	chartVersion := GetChartVersion()
+	tc.logger.Info("Using stackdome-agent chart", "version", chartVersion)
+
+	clusterInitializers := []dev.ClusterInitializer{
+		dev.ClusterInitFn(func(ctx context.Context, cluster *dev.Cluster) error {
+			args := []string{
+				"upgrade", "--install", ChartReleaseName, ChartRepo,
+				"--version", chartVersion,
+				"--namespace", ChartNamespace,
+				"--create-namespace",
+			}
+
+			tc.logger.Info("Installing stackdome-agent chart", "args", args)
+			cmd := exec.CommandContext(ctx, helmBin, args...)
+			cmd.Env = append(os.Environ(), "KUBECONFIG="+cluster.Kubeconfig())
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("installing stackdome-agent chart: %w", err)
+			}
+			return nil
 		}),
-	)
-	clusterInitializers = append(clusterInitializers, clusterAgentInitializer)
-	// install dependent operators, like cnpg, traefik, cert-manager
-	if tc.config.InstallOperators {
-		clusterInitializers = append(clusterInitializers, tc.getClusterDependencies()...)
 	}
 
-	// Load Barman Cloud plugin from GitHub
-	clusterInitializers = append(clusterInitializers,
-		httpObjectApplier(
-			fmt.Sprintf(
-				"https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/%s/manifest.yaml",
-				GetBarmanCloudVersion(),
-			),
-		),
-	)
-
-	// Configure Kind cluster
 	kindConfig := kindv1alpha4.Cluster{
 		Nodes: tc.getNodeConfig(),
 	}
 
-	// Detect container runtime if set to auto
 	containerRuntime := tc.config.ContainerRuntime
 	if containerRuntime == "auto" {
 		cr, err := dev.DetectContainerRuntime()
@@ -130,7 +151,6 @@ func (tc *TestCluster) Setup(ctx context.Context) error {
 		tc.logger.Info("Detected container runtime", "runtime", containerRuntime)
 	}
 
-	// Create development environment
 	tc.environment = dev.NewEnvironment(
 		tc.config.Name,
 		path.Join(tc.config.CacheDir, tc.config.Name),
@@ -145,7 +165,6 @@ func (tc *TestCluster) Setup(ctx context.Context) error {
 		dev.WithClusterInitializers(clusterInitializers),
 	)
 
-	// Initialize the cluster
 	if err := tc.environment.Init(ctx); err != nil {
 		return fmt.Errorf("initializing test environment: %w", err)
 	}
@@ -156,12 +175,8 @@ func (tc *TestCluster) Setup(ctx context.Context) error {
 
 // GetClient returns a Kubernetes client for the test cluster
 func (tc *TestCluster) GetClient() client.Client {
-	if tc.environment == nil || tc.environment.Cluster == nil {
-		return nil
-	}
-	// Create client from REST config
-	config := tc.environment.Cluster.RestConfig
-	if config == nil {
+	cfg := tc.GetRESTConfig()
+	if cfg == nil {
 		return nil
 	}
 
@@ -172,7 +187,7 @@ func (tc *TestCluster) GetClient() client.Client {
 		return nil
 	}
 
-	c, err := client.New(config, client.Options{Scheme: scheme})
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
 		tc.logger.Error(err, "Failed to create client")
 		return nil
@@ -182,6 +197,9 @@ func (tc *TestCluster) GetClient() client.Client {
 
 // GetRESTConfig returns the REST config for the test cluster
 func (tc *TestCluster) GetRESTConfig() *rest.Config {
+	if tc.restConfig != nil {
+		return tc.restConfig
+	}
 	if tc.environment == nil || tc.environment.Cluster == nil {
 		return nil
 	}
@@ -190,16 +208,12 @@ func (tc *TestCluster) GetRESTConfig() *rest.Config {
 
 // GetKubeClient returns a kubernetes.Interface client for the test cluster
 func (tc *TestCluster) GetKubeClient() (*kubernetes.Clientset, error) {
-	if tc.environment == nil || tc.environment.Cluster == nil {
+	cfg := tc.GetRESTConfig()
+	if cfg == nil {
 		return nil, fmt.Errorf("cluster not initialized")
 	}
 
-	config := tc.environment.Cluster.RestConfig
-	if config == nil {
-		return nil, fmt.Errorf("rest config not available")
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
+	clientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
@@ -209,10 +223,11 @@ func (tc *TestCluster) GetKubeClient() (*kubernetes.Clientset, error) {
 
 // GetKubeConfig returns the REST config for the test cluster (alias for GetRESTConfig)
 func (tc *TestCluster) GetKubeConfig() (*rest.Config, error) {
-	if tc.environment == nil || tc.environment.Cluster == nil {
+	cfg := tc.GetRESTConfig()
+	if cfg == nil {
 		return nil, fmt.Errorf("cluster not initialized")
 	}
-	return tc.environment.Cluster.RestConfig, nil
+	return cfg, nil
 }
 
 // LoadImage loads a container image into the cluster
@@ -221,51 +236,6 @@ func (tc *TestCluster) LoadImage(imagePath string) error {
 		return fmt.Errorf("cluster not initialized")
 	}
 	return tc.environment.LoadImageFromTar(imagePath)
-}
-
-// DeployClusterAgent fetches the deployment manifest from the cluster-agent
-// GitHub repository, patches the container image, and deploys it.
-func (tc *TestCluster) DeployClusterAgent(ctx context.Context, imageTag string) error {
-	if tc.environment == nil || tc.environment.Cluster == nil {
-		return fmt.Errorf("cluster not initialized")
-	}
-
-	loader := NewGitHubLoader(
-		ctx,
-		WithCacheDir(tc.config.CacheDir),
-		WithRepoOwner(clusterAgentOwner),
-		WithRepoName(clusterAgentRepo),
-		WithRepoTag(GetClusterAgentVersion()),
-	)
-
-	manifestBytes, err := loader.FetchManifest(ctx, clusterAgentDeploymentManifestPath)
-	if err != nil {
-		return fmt.Errorf("fetching deployment manifest: %w", err)
-	}
-
-	deployment := &appsv1.Deployment{}
-	if err := yaml.Unmarshal(manifestBytes, deployment); err != nil {
-		return fmt.Errorf("parsing deployment manifest: %w", err)
-	}
-
-	tag := imageTag
-	if tag == "" {
-		tag = GetClusterAgentVersion()
-	}
-	image := fmt.Sprintf("%s:%s", clusterAgentImage, tag)
-	for i := range deployment.Spec.Template.Spec.Containers {
-		if deployment.Spec.Template.Spec.Containers[i].Name == "manager" {
-			deployment.Spec.Template.Spec.Containers[i].Image = image
-			break
-		}
-	}
-
-	if err := tc.environment.Cluster.CreateAndWaitForReadiness(ctx, deployment); err != nil {
-		return fmt.Errorf("deploying cluster agent manager: %w", err)
-	}
-
-	tc.logger.Info("Cluster agent deployed", "image", image)
-	return nil
 }
 
 // Teardown destroys the test cluster
@@ -303,34 +273,5 @@ func (tc *TestCluster) getSchemeBuilder() runtime.SchemeBuilder {
 		storagev1alpha1.AddToScheme,
 		usersv1alpha1.AddToScheme,
 		clientgoscheme.AddToScheme,
-	}
-}
-
-func (tc *TestCluster) getClusterDependencies() []dev.ClusterInitializer {
-	return []dev.ClusterInitializer{
-		dev.ClusterHelmInstall{
-			RepoName:    "traefik",
-			RepoURL:     TraefikChartRepo,
-			PackageName: "traefik",
-			Namespace:   "traefik-v2",
-			ReleaseName: "traefik",
-		},
-		dev.ClusterHelmInstall{
-			RepoName:    "cnpg",
-			RepoURL:     CNPGChartRepo,
-			PackageName: "cloudnative-pg",
-			Namespace:   "cnpg-system",
-			ReleaseName: "cnpg",
-		},
-		dev.ClusterHelmInstall{
-			RepoName:    "jetstack",
-			RepoURL:     CertManagerChartRepo,
-			PackageName: "cert-manager",
-			Namespace:   "cert-manager",
-			ReleaseName: "cert-manager",
-			SetVars: []string{
-				"crds.enabled=true",
-			},
-		},
 	}
 }

--- a/pkg/testutil/deps.go
+++ b/pkg/testutil/deps.go
@@ -1,20 +1,20 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 )
 
 const (
-	// Cluster agent
-	clusterAgentVersion                = "v0.4.8-alpha"
-	clusterAgentRepo                   = "cluster-agent"
-	clusterAgentOwner                  = "ashishmax31"
-	clusterAgentImage                  = "quay.io/stackdome/cluster-agent/cluster-agent-manager"
-	clusterAgentDeploymentManifestPath = "config/deploy/deployment.yaml"
-
-	// Barman Cloud plugin
-	barmanCloudVersion = "v0.5.0"
+	// Stackdome agent Helm chart (bundles cluster-agent + all dependencies)
+	DefaultChartVersion = "0.5.1-alpha"
+	ChartRepo           = "oci://quay.io/stackdome/charts/stackdome-agent"
+	ChartReleaseName    = "stackdome-agent"
+	ChartNamespace      = "stackdome-control-plane"
 
 	// MinIO (S3-compatible object storage for backup tests)
 	MinIOImage       = "minio/minio:latest"
@@ -25,11 +25,6 @@ const (
 	MinIOAccessKey   = "minioadmin"
 	MinIOSecretKey   = "minioadmin"
 	MinIOBucket      = "backups"
-
-	// Helm chart repositories
-	TraefikChartRepo     = "https://traefik.github.io/charts"
-	CNPGChartRepo        = "https://cloudnative-pg.github.io/charts"
-	CertManagerChartRepo = "https://charts.jetstack.io"
 )
 
 // MinIOEndpoint returns the in-cluster endpoint for the MinIO service.
@@ -37,18 +32,72 @@ func MinIOEndpoint() string {
 	return fmt.Sprintf("http://%s.%s.svc:%d", MinIOName, MinIONamespace, MinIOServicePort)
 }
 
-// GetClusterAgentVersion returns the version to use, checking environment variables
-func GetClusterAgentVersion() string {
-	if version := os.Getenv("CLUSTER_AGENT_VERSION"); version != "" {
+const (
+	HelmVersion = "v3.14.0"
+)
+
+// GetChartVersion returns the stackdome-agent chart version, checking environment variables.
+func GetChartVersion() string {
+	if version := os.Getenv("STACKDOME_CHART_VERSION"); version != "" {
 		return version
 	}
-	return clusterAgentVersion
+	return DefaultChartVersion
 }
 
-// GetBarmanCloudVersion returns the version to use, checking environment variables
-func GetBarmanCloudVersion() string {
-	if version := os.Getenv("BARMAN_CLOUD_VERSION"); version != "" {
-		return version
+func cacheDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		homeDir = os.Getenv("HOME")
 	}
-	return barmanCloudVersion
+	return filepath.Join(homeDir, ".cache", "stackdome-api-server")
+}
+
+// EnsureHelm returns the path to a working helm binary, installing it if necessary.
+func EnsureHelm(ctx context.Context) (string, error) {
+	if p, err := exec.LookPath("helm"); err == nil {
+		return p, nil
+	}
+
+	binDir := filepath.Join(cacheDir(), "bin")
+	helmPath := filepath.Join(binDir, "helm")
+	if _, err := os.Stat(helmPath); err == nil {
+		return helmPath, nil
+	}
+
+	if err := installHelm(ctx, binDir); err != nil {
+		return "", err
+	}
+	return helmPath, nil
+}
+
+func installHelm(ctx context.Context, binDir string) error {
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return fmt.Errorf("creating bin directory: %w", err)
+	}
+
+	cache := cacheDir()
+	archiveName := fmt.Sprintf("helm-%s-%s-%s.tar.gz", HelmVersion, runtime.GOOS, runtime.GOARCH)
+	url := fmt.Sprintf("https://get.helm.sh/%s", archiveName)
+	tempFile := filepath.Join(cache, archiveName)
+
+	dl := exec.CommandContext(ctx, "curl", "-L", "-o", tempFile, url)
+	if output, err := dl.CombinedOutput(); err != nil {
+		return fmt.Errorf("downloading helm: %w\n%s", err, output)
+	}
+	defer os.Remove(tempFile)
+
+	extract := exec.CommandContext(ctx, "tar", "-xzf", tempFile, "-C", cache,
+		fmt.Sprintf("%s-%s/helm", runtime.GOOS, runtime.GOARCH))
+	if output, err := extract.CombinedOutput(); err != nil {
+		return fmt.Errorf("extracting helm: %w\n%s", err, output)
+	}
+
+	src := filepath.Join(cache, fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH), "helm")
+	dst := filepath.Join(binDir, "helm")
+	if err := os.Rename(src, dst); err != nil {
+		return fmt.Errorf("moving helm to bin: %w", err)
+	}
+	os.RemoveAll(filepath.Join(cache, fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)))
+
+	return nil
 }

--- a/test/int/bootstrap/cluster.go
+++ b/test/int/bootstrap/cluster.go
@@ -11,8 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	kindcluster "sigs.k8s.io/kind/pkg/cluster"
 )
@@ -56,21 +54,19 @@ func (cm *ClusterManager) Bootstrap(ctx context.Context) error {
 }
 
 func (cm *ClusterManager) useExistingCluster(ctx context.Context, kubeconfig string) error {
-	// Verify kubeconfig file exists
 	if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
-		return fmt.Errorf("kubeconfig file does not exist at %s\n\nTo create cluster, run:\n  cd /Users/asnaraya/projects/skysync/cluster-agent\n  ./mage Dev.Deploy\n\nOr unset TEST_KUBECONFIG to create temporary cluster", kubeconfig)
+		return fmt.Errorf("kubeconfig file does not exist at %s\n\nTo create cluster, run:\n  mage cluster:setup\n\nOr unset TEST_KUBECONFIG to create temporary cluster", kubeconfig)
 	}
 
 	cm.logger.Info("Kubeconfig file found, connecting to external cluster", "path", kubeconfig)
 
-	// Load REST config from kubeconfig to verify cluster is accessible
-	restConfig, err := cm.loadKubeconfig(kubeconfig)
+	cluster, err := testutil.NewTestClusterFromKubeconfig(kubeconfig, cm.logger)
 	if err != nil {
 		return fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
 	// Verify cluster connectivity
-	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	kubeClient, err := cluster.GetKubeClient()
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
@@ -82,90 +78,53 @@ func (cm *ClusterManager) useExistingCluster(ctx context.Context, kubeconfig str
 
 	cm.logger.Info("Successfully connected to external cluster", "kubernetes-version", version.String())
 
-	// Create TestCluster using testutil but pointing to external cluster
-	// We'll use a special config that references the existing kubeconfig
-	config := &testutil.ClusterConfig{
-		Name:             "external-cluster",
-		CacheDir:         ".cache/test-clusters",
-		NodeCount:        1,     // Not used for external cluster
-		InstallOperators: false, // Don't install, assume already there
-		ContainerRuntime: "docker",
-		Logger:           cm.logger,
-	}
-
-	cm.cluster = testutil.NewTestCluster(config)
-
 	// Verify cluster agent is deployed
-	cm.logger.Info("Verifying cluster agent deployment")
-
-	// Check if cluster-agent-manager deployment exists in stackdome-system namespace
 	deploymentsClient := kubeClient.AppsV1().Deployments("stackdome-system")
 	deployment, err := deploymentsClient.Get(ctx, "cluster-agent-manager", metav1.GetOptions{})
 	if err != nil {
 		cm.logger.Info("Cluster agent not found - this is OK if it will be deployed by mage", "error", err.Error())
-		// Don't fail here - assume mage will deploy it or it's already there with different name
 	} else {
 		cm.logger.Info("Found cluster agent deployment", "replicas", deployment.Status.ReadyReplicas)
 	}
 
+	cm.cluster = cluster
 	cm.logger.Info("External cluster verification complete")
 	return nil
 }
 
-func (cm *ClusterManager) loadKubeconfig(kubeconfig string) (*rest.Config, error) {
-	// Use client-go to load kubeconfig from file
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.ExplicitPath = kubeconfig
-
-	configOverrides := &clientcmd.ConfigOverrides{}
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-
-	return kubeConfig.ClientConfig()
-}
-
 func (cm *ClusterManager) createNewCluster(ctx context.Context) error {
-	cm.logger.Info("Creating new Kind cluster for integration tests")
+	cm.logger.Info("Creating new Kind cluster for integration tests", "name", testClusterName)
 
-	// Delete existing cluster if it exists to ensure clean state
-	cm.logger.Info("Checking for existing cluster", "name", testClusterName)
 	if err := cm.deleteClusterIfExists(ctx); err != nil {
 		cm.logger.Info("Warning: failed to delete existing cluster", "error", err.Error())
-		// Continue anyway - cluster might not exist
 	}
 
-	// Create cluster configuration
 	config := testutil.DefaultClusterConfig(testClusterName, cm.logger)
+	tc := testutil.NewTestCluster(config)
 
-	// Create test cluster instance
-	cm.cluster = testutil.NewTestCluster(config)
-
-	// Bootstrap context with timeout
 	bootstrapCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	// Clear the cache directory
-	if err := os.RemoveAll(config.CacheDir); err != nil {
-		cm.logger.Info("Warning: failed to clear cache directory", "path", config.CacheDir, "error", err.Error())
-	}
-	cm.logger.Info("Cache directory cleared", "path", config.CacheDir)
-
-	// Create cluster and deploy all dependencies (operators + CRDs)
-	cm.logger.Info("Setting up test cluster (this may take 5-10 minutes)")
-	if err := cm.cluster.Setup(bootstrapCtx); err != nil {
+	cm.logger.Info("Setting up test cluster with helm chart (this may take 5-10 minutes)")
+	if err := tc.Setup(bootstrapCtx); err != nil {
 		return fmt.Errorf("failed to setup test cluster: %w", err)
 	}
 
-	cm.logger.Info("Test cluster created successfully")
-
-	// Deploy cluster agent
-	cm.logger.Info("Deploying cluster agent")
-	imageTag := getClusterAgentImageTag()
-	if err := cm.cluster.DeployClusterAgent(bootstrapCtx, imageTag); err != nil {
-		return fmt.Errorf("failed to deploy cluster agent: %w", err)
+	// Get kubeconfig from kind rather than relying on devkube's internal paths
+	provider := kindcluster.NewProvider()
+	kubeconfigData, err := provider.KubeConfig(testClusterName, false)
+	if err != nil {
+		return fmt.Errorf("getting kubeconfig from kind: %w", err)
 	}
 
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfigData))
+	if err != nil {
+		return fmt.Errorf("parsing kubeconfig: %w", err)
+	}
+
+	cm.cluster = testutil.NewTestClusterFromRESTConfig(restCfg, cm.logger)
+	cm.createdCluster = true
 	cm.logger.Info("Cluster bootstrap completed successfully")
-	cm.createdCluster = true // Mark that we created this cluster
 	return nil
 }
 
@@ -174,26 +133,20 @@ func (cm *ClusterManager) GetCluster() *testutil.TestCluster {
 }
 
 func (cm *ClusterManager) Cleanup(ctx context.Context) error {
-	if cm.cluster == nil {
-		return nil
-	}
-
-	// Only cleanup if we created the cluster (not external)
 	if !cm.createdCluster {
-		cm.logger.Info("Skipping cluster cleanup - using external cluster managed by Mage")
+		cm.logger.Info("Skipping cluster cleanup - using external cluster")
 		return nil
 	}
 
-	// Check if user wants to keep cluster for debugging
 	if os.Getenv("KEEP_CLUSTER") == "true" {
 		cm.logger.Info("KEEP_CLUSTER=true, preserving test cluster for debugging")
 		cm.logger.Info("To delete later, run: kind delete cluster --name", "name", testClusterName)
 		return nil
 	}
 
-	// Cleanup cluster we created
-	cm.logger.Info("Cleaning up test cluster")
-	return cm.cluster.Teardown(ctx)
+	cm.logger.Info("Cleaning up test cluster", "name", testClusterName)
+	provider := kindcluster.NewProvider()
+	return provider.Delete(testClusterName, "")
 }
 
 func (cm *ClusterManager) deleteClusterIfExists(ctx context.Context) error {
@@ -216,8 +169,4 @@ func (cm *ClusterManager) deleteClusterIfExists(ctx context.Context) error {
 
 	cm.logger.Info("No existing cluster found", "name", testClusterName)
 	return nil
-}
-
-func getClusterAgentImageTag() string {
-	return testutil.GetClusterAgentVersion()
 }


### PR DESCRIPTION
Replace individual operator installations (traefik, cnpg, cert-manager, barman-cloud) and GitHub-fetched cluster-agent manifests with a single stackdome-agent helm chart that bundles everything.

- Replace GitHubLoader and individual ClusterHelmInstall entries with a single helm upgrade --install of oci://quay.io/stackdome/charts/stackdome-agent
- Add EnsureHelm() to auto-install helm if not on PATH or in mage cache
- Add NewTestClusterFromKubeconfig/NewTestClusterFromRESTConfig constructors so TestCluster works with both devkube-managed and external clusters
- Fix useExistingCluster() which previously created a TestCluster with nil environment, causing nil clients
- Use kind library (Provider.KubeConfig) to extract kubeconfig instead of relying on devkube internal paths
- Use kind library (Provider.Delete) for cluster cleanup
- Remove DeployClusterAgent, getClusterDependencies, loadKubeconfig