### PR TITLE
feat: add env_from_addons validation, superuser support, and addon usage sync

### DIFF
--- a/cmd/environment/development_environment.go
+++ b/cmd/environment/development_environment.go
@@ -334,28 +334,9 @@ func (d *developmentEnvironment) loadServices(ctx context.Context) error {
 		SessionFactory: d.DBSession,
 		Logger:         d.Logger,
 	})
-	stackService := services.NewStackService(services.StackServiceSpec{
-		SessionFactory:         d.DBSession,
-		Logger:                 d.Logger,
-		VolumeService:          volumeService,
-		OrganisationService:    organisationService,
-		StackResourceService:   stackResourceService,
-		ClusterService:         clusterService,
-		ClusterRegistryService: imageRegistryService,
-		NamespaceService:       namespaceService,
-		SecretService:          secretService,
-	})
-
 	loggingService := services.NewLoggingService(services.LoggingServiceSpec{
 		ClusterService:       clusterService,
 		StackResourceService: stackResourceService,
-		Logger:               d.Logger,
-	})
-
-	metricsService := services.NewMetricsService(services.MetricsServiceSpec{
-		ClusterService:       clusterService,
-		StackResourceService: stackResourceService,
-		StackService:         stackService,
 		Logger:               d.Logger,
 	})
 
@@ -384,6 +365,26 @@ func (d *developmentEnvironment) loadServices(ctx context.Context) error {
 		ObjectStoreService:    objectStoreService,
 		ClusterManager:        d.ClusterManager,
 		Logger:                d.Logger,
+	})
+
+	stackService := services.NewStackService(services.StackServiceSpec{
+		SessionFactory:         d.DBSession,
+		Logger:                 d.Logger,
+		VolumeService:          volumeService,
+		OrganisationService:    organisationService,
+		StackResourceService:   stackResourceService,
+		ClusterService:         clusterService,
+		ClusterRegistryService: imageRegistryService,
+		NamespaceService:       namespaceService,
+		SecretService:          secretService,
+		PostgresAddonService:   postgresAddonService,
+	})
+
+	metricsService := services.NewMetricsService(services.MetricsServiceSpec{
+		ClusterService:       clusterService,
+		StackResourceService: stackResourceService,
+		StackService:         stackService,
+		Logger:               d.Logger,
 	})
 
 	d.Services = Services{

--- a/cmd/environment/test_environment.go
+++ b/cmd/environment/test_environment.go
@@ -301,28 +301,9 @@ func (te *testEnvironment) loadServices(ctx context.Context) error {
 		Logger:         te.Logger,
 	})
 
-	stackService := services.NewStackService(services.StackServiceSpec{
-		SessionFactory:         te.DBSession,
-		Logger:                 te.Logger,
-		VolumeService:          volumeService,
-		OrganisationService:    organisationService,
-		StackResourceService:   stackResourceService,
-		ClusterService:         clusterService,
-		ClusterRegistryService: imageRegistryService,
-		NamespaceService:       namespaceService,
-		SecretService:          secretService,
-	})
-
 	loggingService := services.NewLoggingService(services.LoggingServiceSpec{
 		ClusterService:       clusterService,
 		StackResourceService: stackResourceService,
-		Logger:               te.Logger,
-	})
-
-	metricsService := services.NewMetricsService(services.MetricsServiceSpec{
-		ClusterService:       clusterService,
-		StackResourceService: stackResourceService,
-		StackService:         stackService,
 		Logger:               te.Logger,
 	})
 
@@ -351,6 +332,26 @@ func (te *testEnvironment) loadServices(ctx context.Context) error {
 		ObjectStoreService:    objectStoreService,
 		ClusterManager:        te.ClusterManager,
 		Logger:                te.Logger,
+	})
+
+	stackService := services.NewStackService(services.StackServiceSpec{
+		SessionFactory:         te.DBSession,
+		Logger:                 te.Logger,
+		VolumeService:          volumeService,
+		OrganisationService:    organisationService,
+		StackResourceService:   stackResourceService,
+		ClusterService:         clusterService,
+		ClusterRegistryService: imageRegistryService,
+		NamespaceService:       namespaceService,
+		SecretService:          secretService,
+		PostgresAddonService:   postgresAddonService,
+	})
+
+	metricsService := services.NewMetricsService(services.MetricsServiceSpec{
+		ClusterService:       clusterService,
+		StackResourceService: stackResourceService,
+		StackService:         stackService,
+		Logger:               te.Logger,
 	})
 
 	te.Services = Services{

--- a/config/openapi/stackdome_api.yaml
+++ b/config/openapi/stackdome_api.yaml
@@ -4001,13 +4001,17 @@ components:
       type: object
       required:
         - addon_id
-        - database
         - env_mapping
       properties:
         addon_id:
           type: string
         database:
           type: string
+          description: Target database name. Required when superuser is false. Defaults to 'postgres' when superuser is true and omitted.
+        superuser:
+          type: boolean
+          default: false
+          description: When true, use superuser credentials. The addon must have enableSuperuserAccess enabled.
         env_mapping:
           type: object
           additionalProperties:

--- a/pkg/api/openapi/api/openapi.yaml
+++ b/pkg/api/openapi/api/openapi.yaml
@@ -3842,11 +3842,13 @@ components:
                   database: database
                   env_mapping:
                     key: env_mapping
+                  superuser: false
                   addon_id: addon_id
               - postgres:
                   database: database
                   env_mapping:
                     key: env_mapping
+                  superuser: false
                   addon_id: addon_id
               command:
               - command
@@ -3977,11 +3979,13 @@ components:
                   database: database
                   env_mapping:
                     key: env_mapping
+                  superuser: false
                   addon_id: addon_id
               - postgres:
                   database: database
                   env_mapping:
                     key: env_mapping
+                  superuser: false
                   addon_id: addon_id
               command:
               - command
@@ -4318,11 +4322,13 @@ components:
                     database: database
                     env_mapping:
                       key: env_mapping
+                    superuser: false
                     addon_id: addon_id
                 - postgres:
                     database: database
                     env_mapping:
                       key: env_mapping
+                    superuser: false
                     addon_id: addon_id
                 command:
                 - command
@@ -4453,11 +4459,13 @@ components:
                     database: database
                     env_mapping:
                       key: env_mapping
+                    superuser: false
                     addon_id: addon_id
                 - postgres:
                     database: database
                     env_mapping:
                       key: env_mapping
+                    superuser: false
                     addon_id: addon_id
                 command:
                 - command
@@ -4748,11 +4756,13 @@ components:
                     database: database
                     env_mapping:
                       key: env_mapping
+                    superuser: false
                     addon_id: addon_id
                 - postgres:
                     database: database
                     env_mapping:
                       key: env_mapping
+                    superuser: false
                     addon_id: addon_id
                 command:
                 - command
@@ -4883,11 +4893,13 @@ components:
                     database: database
                     env_mapping:
                       key: env_mapping
+                    superuser: false
                     addon_id: addon_id
                 - postgres:
                     database: database
                     env_mapping:
                       key: env_mapping
+                    superuser: false
                     addon_id: addon_id
                 command:
                 - command
@@ -5175,11 +5187,13 @@ components:
                 database: database
                 env_mapping:
                   key: env_mapping
+                superuser: false
                 addon_id: addon_id
             - postgres:
                 database: database
                 env_mapping:
                   key: env_mapping
+                superuser: false
                 addon_id: addon_id
             command:
             - command
@@ -5310,11 +5324,13 @@ components:
                 database: database
                 env_mapping:
                   key: env_mapping
+                superuser: false
                 addon_id: addon_id
             - postgres:
                 database: database
                 env_mapping:
                   key: env_mapping
+                superuser: false
                 addon_id: addon_id
             command:
             - command
@@ -5612,11 +5628,13 @@ components:
               database: database
               env_mapping:
                 key: env_mapping
+              superuser: false
               addon_id: addon_id
           - postgres:
               database: database
               env_mapping:
                 key: env_mapping
+              superuser: false
               addon_id: addon_id
           command:
           - command
@@ -5800,11 +5818,13 @@ components:
                 database: database
                 env_mapping:
                   key: env_mapping
+                superuser: false
                 addon_id: addon_id
             - postgres:
                 database: database
                 env_mapping:
                   key: env_mapping
+                superuser: false
                 addon_id: addon_id
             command:
             - command
@@ -5935,11 +5955,13 @@ components:
                 database: database
                 env_mapping:
                   key: env_mapping
+                superuser: false
                 addon_id: addon_id
             - postgres:
                 database: database
                 env_mapping:
                   key: env_mapping
+                superuser: false
                 addon_id: addon_id
             command:
             - command
@@ -6763,11 +6785,13 @@ components:
             database: database
             env_mapping:
               key: env_mapping
+            superuser: false
             addon_id: addon_id
         - postgres:
             database: database
             env_mapping:
               key: env_mapping
+            superuser: false
             addon_id: addon_id
         command:
         - command
@@ -8156,6 +8180,7 @@ components:
           database: database
           env_mapping:
             key: env_mapping
+          superuser: false
           addon_id: addon_id
       properties:
         postgres:
@@ -8166,12 +8191,20 @@ components:
         database: database
         env_mapping:
           key: env_mapping
+        superuser: false
         addon_id: addon_id
       properties:
         addon_id:
           type: string
         database:
+          description: Target database name. Required when superuser is false. Defaults
+            to 'postgres' when superuser is true and omitted.
           type: string
+        superuser:
+          default: false
+          description: "When true, use superuser credentials. The addon must have\
+            \ enableSuperuserAccess enabled."
+          type: boolean
         env_mapping:
           additionalProperties:
             type: string
@@ -8181,7 +8214,6 @@ components:
           type: object
       required:
       - addon_id
-      - database
       - env_mapping
       type: object
     _api_v1_organizations__org_id__clusters__cluster_id__image_registries_get_200_response:

--- a/pkg/api/openapi/docs/PostgresAddonEnvSource.md
+++ b/pkg/api/openapi/docs/PostgresAddonEnvSource.md
@@ -5,14 +5,15 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **AddonId** | **string** |  | 
-**Database** | **string** |  | 
+**Database** | Pointer to **string** | Target database name. Required when superuser is false. Defaults to &#39;postgres&#39; when superuser is true and omitted. | [optional] 
+**Superuser** | Pointer to **bool** | When true, use superuser credentials. The addon must have enableSuperuserAccess enabled. | [optional] [default to false]
 **EnvMapping** | **map[string]string** | Maps addon credential fields to environment variable names. Valid fields are host, port, username, password, database, sslmode, connectionString, caCertificate. | 
 
 ## Methods
 
 ### NewPostgresAddonEnvSource
 
-`func NewPostgresAddonEnvSource(addonId string, database string, envMapping map[string]string, ) *PostgresAddonEnvSource`
+`func NewPostgresAddonEnvSource(addonId string, envMapping map[string]string, ) *PostgresAddonEnvSource`
 
 NewPostgresAddonEnvSource instantiates a new PostgresAddonEnvSource object
 This constructor will assign default values to properties that have it defined,
@@ -66,6 +67,36 @@ and a boolean to check if the value has been set.
 
 SetDatabase sets Database field to given value.
 
+### HasDatabase
+
+`func (o *PostgresAddonEnvSource) HasDatabase() bool`
+
+HasDatabase returns a boolean if a field has been set.
+
+### GetSuperuser
+
+`func (o *PostgresAddonEnvSource) GetSuperuser() bool`
+
+GetSuperuser returns the Superuser field if non-nil, zero value otherwise.
+
+### GetSuperuserOk
+
+`func (o *PostgresAddonEnvSource) GetSuperuserOk() (*bool, bool)`
+
+GetSuperuserOk returns a tuple with the Superuser field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSuperuser
+
+`func (o *PostgresAddonEnvSource) SetSuperuser(v bool)`
+
+SetSuperuser sets Superuser field to given value.
+
+### HasSuperuser
+
+`func (o *PostgresAddonEnvSource) HasSuperuser() bool`
+
+HasSuperuser returns a boolean if a field has been set.
 
 ### GetEnvMapping
 

--- a/pkg/api/openapi/model_postgres_addon_env_source.go
+++ b/pkg/api/openapi/model_postgres_addon_env_source.go
@@ -16,8 +16,11 @@ import (
 
 // PostgresAddonEnvSource struct for PostgresAddonEnvSource
 type PostgresAddonEnvSource struct {
-	AddonId  string `json:"addon_id"`
-	Database string `json:"database"`
+	AddonId string `json:"addon_id"`
+	// Target database name. Required when superuser is false. Defaults to 'postgres' when superuser is true and omitted.
+	Database *string `json:"database,omitempty"`
+	// When true, use superuser credentials. The addon must have enableSuperuserAccess enabled.
+	Superuser *bool `json:"superuser,omitempty"`
 	// Maps addon credential fields to environment variable names. Valid fields are host, port, username, password, database, sslmode, connectionString, caCertificate.
 	EnvMapping map[string]string `json:"env_mapping"`
 }
@@ -26,10 +29,11 @@ type PostgresAddonEnvSource struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewPostgresAddonEnvSource(addonId string, database string, envMapping map[string]string) *PostgresAddonEnvSource {
+func NewPostgresAddonEnvSource(addonId string, envMapping map[string]string) *PostgresAddonEnvSource {
 	this := PostgresAddonEnvSource{}
 	this.AddonId = addonId
-	this.Database = database
+	var superuser bool = false
+	this.Superuser = &superuser
 	this.EnvMapping = envMapping
 	return &this
 }
@@ -39,6 +43,8 @@ func NewPostgresAddonEnvSource(addonId string, database string, envMapping map[s
 // but it doesn't guarantee that properties required by API are set
 func NewPostgresAddonEnvSourceWithDefaults() *PostgresAddonEnvSource {
 	this := PostgresAddonEnvSource{}
+	var superuser bool = false
+	this.Superuser = &superuser
 	return &this
 }
 
@@ -66,28 +72,68 @@ func (o *PostgresAddonEnvSource) SetAddonId(v string) {
 	o.AddonId = v
 }
 
-// GetDatabase returns the Database field value
+// GetDatabase returns the Database field value if set, zero value otherwise.
 func (o *PostgresAddonEnvSource) GetDatabase() string {
-	if o == nil {
+	if o == nil || o.Database == nil {
 		var ret string
 		return ret
 	}
-
-	return o.Database
+	return *o.Database
 }
 
-// GetDatabaseOk returns a tuple with the Database field value
+// GetDatabaseOk returns a tuple with the Database field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *PostgresAddonEnvSource) GetDatabaseOk() (*string, bool) {
-	if o == nil {
+	if o == nil || o.Database == nil {
 		return nil, false
 	}
-	return &o.Database, true
+	return o.Database, true
 }
 
-// SetDatabase sets field value
+// HasDatabase returns a boolean if a field has been set.
+func (o *PostgresAddonEnvSource) HasDatabase() bool {
+	if o != nil && o.Database != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetDatabase gets a reference to the given string and assigns it to the Database field.
 func (o *PostgresAddonEnvSource) SetDatabase(v string) {
-	o.Database = v
+	o.Database = &v
+}
+
+// GetSuperuser returns the Superuser field value if set, zero value otherwise.
+func (o *PostgresAddonEnvSource) GetSuperuser() bool {
+	if o == nil || o.Superuser == nil {
+		var ret bool
+		return ret
+	}
+	return *o.Superuser
+}
+
+// GetSuperuserOk returns a tuple with the Superuser field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PostgresAddonEnvSource) GetSuperuserOk() (*bool, bool) {
+	if o == nil || o.Superuser == nil {
+		return nil, false
+	}
+	return o.Superuser, true
+}
+
+// HasSuperuser returns a boolean if a field has been set.
+func (o *PostgresAddonEnvSource) HasSuperuser() bool {
+	if o != nil && o.Superuser != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSuperuser gets a reference to the given bool and assigns it to the Superuser field.
+func (o *PostgresAddonEnvSource) SetSuperuser(v bool) {
+	o.Superuser = &v
 }
 
 // GetEnvMapping returns the EnvMapping field value
@@ -119,8 +165,11 @@ func (o PostgresAddonEnvSource) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["addon_id"] = o.AddonId
 	}
-	if true {
+	if o.Database != nil {
 		toSerialize["database"] = o.Database
+	}
+	if o.Superuser != nil {
+		toSerialize["superuser"] = o.Superuser
 	}
 	if true {
 		toSerialize["env_mapping"] = o.EnvMapping

--- a/pkg/models/stack_resource.go
+++ b/pkg/models/stack_resource.go
@@ -136,7 +136,8 @@ type AddonEnvSource struct {
 
 type PostgresAddonEnvSource struct {
 	AddonID    string            `json:"addon_id"`
-	Database   string            `json:"database"`
+	Database   string            `json:"database,omitempty"`
+	Superuser  bool              `json:"superuser,omitempty"`
 	EnvMapping map[string]string `json:"env_mapping"`
 }
 

--- a/pkg/presenters/stack.go
+++ b/pkg/presenters/stack.go
@@ -215,12 +215,18 @@ func presentEnvFromAddons(sources []models.AddonEnvSource) []openapi.AddonEnvSou
 	result := make([]openapi.AddonEnvSource, len(sources))
 	for i, s := range sources {
 		if s.Postgres != nil {
+			pgSource := &openapi.PostgresAddonEnvSource{
+				AddonId:    s.Postgres.AddonID,
+				EnvMapping: s.Postgres.EnvMapping,
+			}
+			if s.Postgres.Database != "" {
+				pgSource.SetDatabase(s.Postgres.Database)
+			}
+			if s.Postgres.Superuser {
+				pgSource.SetSuperuser(true)
+			}
 			result[i] = openapi.AddonEnvSource{
-				Postgres: &openapi.PostgresAddonEnvSource{
-					AddonId:    s.Postgres.AddonID,
-					Database:   s.Postgres.Database,
-					EnvMapping: s.Postgres.EnvMapping,
-				},
+				Postgres: pgSource,
 			}
 		}
 	}
@@ -475,7 +481,8 @@ func convertEnvFromAddons(sources []openapi.AddonEnvSource) []models.AddonEnvSou
 			result[i] = models.AddonEnvSource{
 				Postgres: &models.PostgresAddonEnvSource{
 					AddonID:    s.Postgres.AddonId,
-					Database:   s.Postgres.Database,
+					Database:   s.Postgres.GetDatabase(),
+					Superuser:  s.Postgres.GetSuperuser(),
 					EnvMapping: s.Postgres.EnvMapping,
 				},
 			}

--- a/pkg/services/stack_service.go
+++ b/pkg/services/stack_service.go
@@ -45,6 +45,7 @@ type StackServiceSpec struct {
 	ClusterRegistryService ImageRegistryService
 	NamespaceService       NamespaceService
 	SecretService          SecretService
+	PostgresAddonService   PostgresAddonService
 	Logger                 logger.Logger
 }
 
@@ -87,8 +88,9 @@ func NewStackService(spec StackServiceSpec) StackService {
 		logger:              spec.Logger,
 		sessionFactory:      spec.SessionFactory,
 		stackValidator: stackvalidator.NewStackValidator(stackvalidator.StackValidatorSpec{
-			DomainService: organisationDomainService,
-			SecretService: spec.SecretService,
+			DomainService:        organisationDomainService,
+			SecretService:        spec.SecretService,
+			PostgresAddonService: spec.PostgresAddonService,
 		}),
 		stackResourceService:   spec.StackResourceService,
 		clusterRegistryService: spec.ClusterRegistryService,

--- a/pkg/validator/stack/stack_validator.go
+++ b/pkg/validator/stack/stack_validator.go
@@ -21,6 +21,10 @@ type secretService interface {
 	InternalGetByID(ctx context.Context, ID string) (*models.Secret, *errors.ServiceError)
 }
 
+type postgresAddonService interface {
+	GetPostgresAddon(ctx context.Context, id string) (*models.PostgresAddon, *errors.ServiceError)
+}
+
 // Add only validations that take reasonable time to complete.
 // Avoid validations that require network calls or long-running operations.
 // Long running validations should be handled in the stack worker.
@@ -28,11 +32,13 @@ type stackValidator struct {
 	interpolationValidator validator.InterpolationValidation
 	domainService          organisationDomainService
 	secretService          secretService
+	postgresAddonService   postgresAddonService
 }
 
 type StackValidatorSpec struct {
-	DomainService organisationDomainService
-	SecretService secretService
+	DomainService        organisationDomainService
+	SecretService        secretService
+	PostgresAddonService postgresAddonService
 }
 
 func NewStackValidator(
@@ -42,6 +48,7 @@ func NewStackValidator(
 		interpolationValidator: NewInterpolationValidation(),
 		domainService:          spec.DomainService,
 		secretService:          spec.SecretService,
+		postgresAddonService:   spec.PostgresAddonService,
 	}
 }
 
@@ -65,6 +72,9 @@ func (v *stackValidator) ValidateForCreate(ctx context.Context, spec *models.Sta
 		return err
 	}
 	if err := v.validateBuildSourceVolumes(spec); err != nil {
+		return err
+	}
+	if err := v.validateEnvFromAddons(ctx, spec); err != nil {
 		return err
 	}
 
@@ -102,6 +112,9 @@ func (v *stackValidator) ValidateForUpdate(ctx context.Context, existing *models
 		return err
 	}
 	if err := v.validateBuildSourceVolumes(spec); err != nil {
+		return err
+	}
+	if err := v.validateEnvFromAddons(ctx, spec); err != nil {
 		return err
 	}
 	return nil
@@ -324,6 +337,61 @@ func (v *stackValidator) validateStackEnvVars(spec *models.Stack) *errors.Servic
 		return errors.BadRequest("stack resource '%s' has invalid interpolation: %s", spec.Name, err.Error())
 	}
 
+	return nil
+}
+
+func (v *stackValidator) validateEnvFromAddons(ctx context.Context, spec *models.Stack) *errors.ServiceError {
+	validFields := make(map[string]struct{}, len(models.PostgresAddonEnvFields))
+	for _, f := range models.PostgresAddonEnvFields {
+		validFields[f] = struct{}{}
+	}
+
+	for i := range spec.StackResources {
+		resource := spec.StackResources[i]
+		if resource.ExecutionConfig == nil || len(resource.ExecutionConfig.EnvFromAddons) == 0 {
+			continue
+		}
+		for _, addonEnv := range resource.ExecutionConfig.EnvFromAddons {
+			if addonEnv.Postgres == nil {
+				continue
+			}
+			pgSource := addonEnv.Postgres
+
+			if pgSource.AddonID == "" {
+				return errors.BadRequest("stack resource '%s' has empty postgres addon ID in env_from_addons", resource.Name)
+			}
+			if !pgSource.Superuser && pgSource.Database == "" {
+				return errors.BadRequest("stack resource '%s' has empty database name in env_from_addons for addon '%s'", resource.Name, pgSource.AddonID)
+			}
+			if len(pgSource.EnvMapping) == 0 {
+				return errors.BadRequest("stack resource '%s' has empty env_mapping in env_from_addons for addon '%s'", resource.Name, pgSource.AddonID)
+			}
+
+			for field, envName := range pgSource.EnvMapping {
+				if _, ok := validFields[field]; !ok {
+					return errors.BadRequest("stack resource '%s' has invalid field '%s' in env_mapping for addon '%s'", resource.Name, field, pgSource.AddonID)
+				}
+				if envName == "" {
+					return errors.BadRequest("stack resource '%s' has empty env var name for field '%s' in env_mapping for addon '%s'", resource.Name, field, pgSource.AddonID)
+				}
+			}
+
+			addon, err := v.postgresAddonService.GetPostgresAddon(ctx, pgSource.AddonID)
+			if err != nil {
+				return errors.BadRequest("stack resource '%s' references non-existent postgres addon '%s'", resource.Name, pgSource.AddonID)
+			}
+
+			if pgSource.Superuser {
+				if !addon.Configuration.EnableSuperuserAccess {
+					return errors.BadRequest("stack resource '%s' requests superuser access but addon '%s' does not have superuser access enabled", resource.Name, pgSource.AddonID)
+				}
+			} else {
+				if !addon.HasDatabase(pgSource.Database) {
+					return errors.BadRequest("stack resource '%s' references non-existent database '%s' in postgres addon '%s'", resource.Name, pgSource.Database, pgSource.AddonID)
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/worker/stack/addon_env_reconciler.go
+++ b/pkg/worker/stack/addon_env_reconciler.go
@@ -39,6 +39,7 @@ func (r *addonEnvReconciler) Reconcile(ctx context.Context, stack *models.Stack)
 		return resultNil, nil
 	}
 
+	var desiredAddonUsages []*models.AddonUsage
 	for _, resource := range stack.StackResources {
 		if resource.ExecutionConfig == nil || len(resource.ExecutionConfig.EnvFromAddons) == 0 {
 			continue
@@ -52,15 +53,24 @@ func (r *addonEnvReconciler) Reconcile(ctx context.Context, stack *models.Stack)
 			return *requeueResult, nil
 		}
 
-		if len(resolvedEnvVars) == 0 {
-			continue
+		for _, addonSource := range resource.ExecutionConfig.EnvFromAddons {
+			if addonSource.Postgres != nil {
+				desiredAddonUsages = append(desiredAddonUsages, &models.AddonUsage{
+					AddonType:       models.AddonTypePostgres,
+					AddonID:         addonSource.Postgres.AddonID,
+					StackID:         stack.ID,
+					StackResourceID: resource.ID,
+				})
+			}
 		}
 
-		resource.ExecutionConfig.Env = appendWithoutDuplicates(resource.ExecutionConfig.Env, resolvedEnvVars)
-
-		if err := r.syncAddonUsages(ctx, stack.ID, resource); err != nil {
-			return resultNil, fmt.Errorf("failed to sync addon usages for resource '%s': %w", resource.Name, err)
+		if len(resolvedEnvVars) > 0 {
+			resource.ExecutionConfig.Env = appendWithoutDuplicates(resource.ExecutionConfig.Env, resolvedEnvVars)
 		}
+	}
+
+	if err := r.syncAddonUsages(ctx, stack.ID, desiredAddonUsages); err != nil {
+		return resultNil, fmt.Errorf("failed to sync addon usages: %w", err)
 	}
 
 	return resultNil, nil
@@ -75,8 +85,9 @@ func (r *addonEnvReconciler) resolveAddonEnvVars(ctx context.Context, stackID st
 		}
 		pg := addonSource.Postgres
 
-		creds, credErr := r.postgresAddonService.GetCredentials(ctx, pg.AddonID, pg.Database, false)
+		creds, credErr := r.postgresAddonService.GetCredentials(ctx, pg.AddonID, pg.Database, pg.Superuser)
 		if credErr != nil {
+			r.logger.Errorf("failed to fetch db: '%s' credentials, got err: %s", pg.Database, credErr.Error())
 			// Check if credentials were resolved in a prior reconciliation.
 			// If yes, the CR already has valid env vars — proceed without blocking.
 			previouslyResolved, lookupErr := r.addonUsageService.ExistsByStackResourceAndAddon(ctx, stackID, resource.ID, pg.AddonID)
@@ -113,20 +124,40 @@ func (r *addonEnvReconciler) resolveAddonEnvVars(ctx context.Context, stackID st
 	return envVars, nil, nil
 }
 
-func (r *addonEnvReconciler) syncAddonUsages(ctx context.Context, stackID string, resource *models.StackResource) error {
-	for _, addonSource := range resource.ExecutionConfig.EnvFromAddons {
-		if addonSource.Postgres == nil {
-			continue
-		}
-		if err := r.addonUsageService.Create(ctx, &models.AddonUsage{
-			AddonType:       models.AddonTypePostgres,
-			AddonID:         addonSource.Postgres.AddonID,
-			StackID:         stackID,
-			StackResourceID: resource.ID,
-		}); err != nil {
-			return fmt.Errorf("failed to create addon usage for addon '%s': %w", addonSource.Postgres.AddonID, err)
+func addonUsageKey(resourceID, addonID string, addonType models.AddonType) string {
+	return resourceID + ":" + addonID + ":" + string(addonType)
+}
+
+func (r *addonEnvReconciler) syncAddonUsages(ctx context.Context, stackID string, desiredAddonUsages []*models.AddonUsage) error {
+	existing, err := r.addonUsageService.GetByStackID(ctx, stackID)
+	if err != nil {
+		return fmt.Errorf("failed to list addon usages for stack '%s': %w", stackID, err)
+	}
+
+	existingKeys := make(map[string]struct{}, len(existing))
+	for _, u := range existing {
+		existingKeys[addonUsageKey(u.StackResourceID, u.AddonID, u.AddonType)] = struct{}{}
+	}
+
+	desiredKeys := make(map[string]struct{}, len(desiredAddonUsages))
+	for _, u := range desiredAddonUsages {
+		key := addonUsageKey(u.StackResourceID, u.AddonID, u.AddonType)
+		desiredKeys[key] = struct{}{}
+		if _, ok := existingKeys[key]; !ok {
+			if err := r.addonUsageService.Create(ctx, u); err != nil {
+				return fmt.Errorf("failed to create addon usage for addon '%s': %w", u.AddonID, err)
+			}
 		}
 	}
+
+	for _, u := range existing {
+		if _, ok := desiredKeys[addonUsageKey(u.StackResourceID, u.AddonID, u.AddonType)]; !ok {
+			if err := r.addonUsageService.Delete(ctx, u.AddonType, u.AddonID, stackID, u.StackResourceID); err != nil {
+				return fmt.Errorf("failed to delete stale addon usage for addon '%s': %w", u.AddonID, err)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/worker/stack/types.go
+++ b/pkg/worker/stack/types.go
@@ -62,6 +62,8 @@ type postgresAddonService interface {
 
 type addonUsageService interface {
 	Create(ctx context.Context, usage *models.AddonUsage) error
+	Delete(ctx context.Context, addonType models.AddonType, addonID, stackID, resourceID string) error
+	GetByStackID(ctx context.Context, stackID string) ([]*models.AddonUsage, error)
 	ExistsByStackResourceAndAddon(ctx context.Context, stackID, resourceID, addonID string) (bool, error)
 	DeleteByStackID(ctx context.Context, stackID string) error
 }

--- a/test/int/shared/cluster_helpers.go
+++ b/test/int/shared/cluster_helpers.go
@@ -170,6 +170,19 @@ func ConnectToPostgres(host string, port int32, username, password, dbName, sslM
 	return db
 }
 
+// GetSuperuserCredentials fetches JIT superuser credentials for an addon via the API.
+// The database path param is required by the route but ignored by the service in superuser mode.
+func GetSuperuserCredentials(apiClient *openapi.APIClient, orgID, addonID string) *openapi.PostgresCredentials {
+	ctx := context.Background()
+	resp, httpResp, err := apiClient.DefaultApi.ApiV1OrganizationsOrgIdAddonsPostgresIdCredentialsDatabaseGet(ctx, orgID, addonID, "postgres").
+		Superuser(true).
+		Execute()
+	Expect(err).NotTo(HaveOccurred(), "failed to get superuser credentials")
+	Expect(httpResp.StatusCode).To(Equal(200))
+	Expect(resp).NotTo(BeNil())
+	return resp
+}
+
 // CnpgClusterName returns the CNPG Cluster CR name derived from addon name and PG major version.
 func CnpgClusterName(addonName string, majorVersion int) string {
 	return fmt.Sprintf("%s-%d", addonName, majorVersion)

--- a/test/int/shared/fixtures.go
+++ b/test/int/shared/fixtures.go
@@ -101,6 +101,16 @@ func CreatePostgresAddonWithResources(name string) *openapi.PostgresAddon {
 	return addon
 }
 
+func CreatePostgresAddonWithSuperuser(name string) *openapi.PostgresAddon {
+	addon := CreatePostgresAddonWithResources(name)
+
+	config := openapi.NewPostgresConfiguration()
+	config.SetEnableSuperuserAccess(true)
+	addon.Spec.SetConfiguration(*config)
+
+	return addon
+}
+
 func CreatePostgresAddonForUpdate(name string) *openapi.PostgresAddon {
 	addon := CreateMinimalPostgresAddon(name)
 
@@ -392,7 +402,29 @@ func CreateStackWithPostgresAddon(name string, addonID string, database string) 
 		*openapi.NewPort(8080, false),
 	})
 
-	pgEnvSource := openapi.NewPostgresAddonEnvSource(addonID, database, PostgresEnvMapping)
+	pgEnvSource := openapi.NewPostgresAddonEnvSource(addonID, PostgresEnvMapping)
+	pgEnvSource.SetDatabase(database)
+	addonEnvSource := openapi.NewAddonEnvSource()
+	addonEnvSource.SetPostgres(*pgEnvSource)
+
+	exec := openapi.NewExecutionConfig()
+	exec.SetEnvFromAddons([]openapi.AddonEnvSource{*addonEnvSource})
+	resource.SetExecutionConfig(*exec)
+
+	spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
+	return openapi.NewStack(name, *spec)
+}
+
+func CreateStackWithPostgresAddonSuperuser(name string, addonID string) *openapi.Stack {
+	resource := openapi.NewStackResource("app")
+	image := openapi.NewImageSpec("nginx:1.25-alpine")
+	resource.SetImageSpec(*image)
+	resource.SetPorts([]openapi.Port{
+		*openapi.NewPort(8080, false),
+	})
+
+	pgEnvSource := openapi.NewPostgresAddonEnvSource(addonID, PostgresEnvMapping)
+	pgEnvSource.SetSuperuser(true)
 	addonEnvSource := openapi.NewAddonEnvSource()
 	addonEnvSource.SetPostgres(*pgEnvSource)
 

--- a/test/int/stack_e2e_test.go
+++ b/test/int/stack_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/ashishmax31/stackdome-api-server/pkg/api/openapi"
+	"github.com/ashishmax31/stackdome-api-server/pkg/models"
 	"github.com/ashishmax31/stackdome-api-server/test/int/shared"
 )
 
@@ -363,6 +364,119 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			dbURL, _ := shared.GetContainerEnvVar(deploy, shared.PostgresEnvMapping["connectionString"])
 			Expect(dbURL).To(HavePrefix("postgresql://"), "DATABASE_URL should be a postgresql:// connection string")
 			Expect(dbURL).To(ContainSubstring("testdb"), "DATABASE_URL should reference the requested database")
+		})
+	})
+
+	Context("Stack with PostgresAddon Superuser", func() {
+		It("should inject superuser credentials and allow privileged database operations", func() {
+			testEnv := GetEnvironment()
+			clusterClient := testEnv.Cluster.GetClient()
+			ctx := context.Background()
+
+			By("Creating a postgres addon with superuser access enabled")
+			addon := shared.CreatePostgresAddonWithSuperuser("test-stack-pg-su")
+			createdAddon := shared.CreatePostgresAddon(client, orgID, addon)
+			addonID := createdAddon.GetId()
+			addonName := createdAddon.GetName()
+			addonNamespace := createdAddon.GetNamespace()
+
+			DeferCleanup(func() {
+				shared.DeletePostgresAddon(client, orgID, addonID)
+			})
+
+			By("Waiting for the postgres addon to become Ready")
+			shared.WaitForAddonReady(client, orgID, addonID, 10*time.Minute)
+
+			By("Waiting for databases to be applied")
+			shared.WaitForConditionTrue(client, orgID, addonID, string(models.PostgresAddonConditionDatabasesApplied), 2*time.Minute)
+
+			By("Creating a stack that references the addon with superuser mode")
+			stack := shared.CreateStackWithPostgresAddonSuperuser("test-su-stack", addonID)
+			created := shared.CreateStack(client, orgID, stack)
+			stackID := created.GetId()
+			namespace := created.GetNamespace()
+
+			DeferCleanup(func() {
+				shared.DeleteStack(client, orgID, stackID)
+				shared.WaitForStackDeleted(client, orgID, stackID, 1*time.Minute)
+			})
+
+			By("Waiting for stack to become Ready")
+			shared.WaitForStackReady(client, orgID, stackID, 5*time.Minute)
+
+			By("Verifying Deployment has all postgres env vars from the mapping")
+			deploy, err := shared.GetDeploymentForStackResource(ctx, clusterClient, namespace, "app")
+			Expect(err).NotTo(HaveOccurred())
+
+			for credField, envName := range shared.PostgresEnvMapping {
+				val, found := shared.GetContainerEnvVar(deploy, envName)
+				Expect(found).To(BeTrue(), "env var %s (mapped from %s) should be injected", envName, credField)
+				Expect(val).NotTo(BeEmpty(), "env var %s should have a non-empty value", envName)
+			}
+
+			By("Verifying superuser credential values on deployment")
+			pgUser, _ := shared.GetContainerEnvVar(deploy, shared.PostgresEnvMapping["username"])
+			Expect(pgUser).To(Equal("postgres"), "superuser username should be 'postgres'")
+
+			dbURL, _ := shared.GetContainerEnvVar(deploy, shared.PostgresEnvMapping["connectionString"])
+			Expect(dbURL).To(HavePrefix("postgresql://"), "DATABASE_URL should be a postgresql:// connection string")
+
+			By("Fetching superuser credentials via API")
+			creds := shared.GetSuperuserCredentials(client, orgID, addonID)
+			Expect(creds.GetUsername()).To(Equal("postgres"), "superuser username should be 'postgres'")
+			Expect(creds.GetPassword()).NotTo(BeEmpty())
+
+			By("Port-forwarding to the primary postgres pod")
+			clientset, err := testEnv.Cluster.GetKubeClient()
+			Expect(err).NotTo(HaveOccurred())
+
+			cnpgName := shared.CnpgClusterName(addonName, int(addon.Spec.Version.Major))
+			localPort, stopChan := shared.PortForwardPostgres(ctx, testEnv.Cluster.GetRESTConfig(), clientset, addonNamespace, cnpgName)
+			defer close(stopChan)
+
+			By("Verifying superuser can read and write to testdb")
+			testDB := shared.ConnectToPostgres("127.0.0.1", localPort, creds.GetUsername(), creds.GetPassword(), "testdb", "disable")
+			defer testDB.Close()
+
+			_, err = testDB.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS e2e_su_test (id serial PRIMARY KEY, val text)")
+			Expect(err).NotTo(HaveOccurred(), "superuser should be able to create tables in testdb")
+
+			_, err = testDB.ExecContext(ctx, "INSERT INTO e2e_su_test (val) VALUES ('superuser_write')")
+			Expect(err).NotTo(HaveOccurred(), "superuser should be able to insert into testdb")
+
+			var val string
+			err = testDB.QueryRowContext(ctx, "SELECT val FROM e2e_su_test WHERE val = 'superuser_write'").Scan(&val)
+			Expect(err).NotTo(HaveOccurred(), "superuser should be able to read from testdb")
+			Expect(val).To(Equal("superuser_write"))
+
+			By("Verifying superuser can read and write to the default app database")
+			appDB := shared.ConnectToPostgres("127.0.0.1", localPort, creds.GetUsername(), creds.GetPassword(), "app", "disable")
+			defer appDB.Close()
+
+			_, err = appDB.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS e2e_su_test (id serial PRIMARY KEY, val text)")
+			Expect(err).NotTo(HaveOccurred(), "superuser should be able to create tables in app database")
+
+			_, err = appDB.ExecContext(ctx, "INSERT INTO e2e_su_test (val) VALUES ('superuser_write')")
+			Expect(err).NotTo(HaveOccurred(), "superuser should be able to insert into app database")
+
+			err = appDB.QueryRowContext(ctx, "SELECT val FROM e2e_su_test WHERE val = 'superuser_write'").Scan(&val)
+			Expect(err).NotTo(HaveOccurred(), "superuser should be able to read from app database")
+			Expect(val).To(Equal("superuser_write"))
+
+			By("Verifying superuser can create a new database")
+			postgresDB := shared.ConnectToPostgres("127.0.0.1", localPort, creds.GetUsername(), creds.GetPassword(), "postgres", "disable")
+			defer postgresDB.Close()
+
+			_, err = postgresDB.ExecContext(ctx, "CREATE DATABASE e2e_superuser_created")
+			Expect(err).NotTo(HaveOccurred(), "superuser should be able to create new databases")
+
+			newDB := shared.ConnectToPostgres("127.0.0.1", localPort, creds.GetUsername(), creds.GetPassword(), "e2e_superuser_created", "disable")
+			defer newDB.Close()
+
+			var result int
+			err = newDB.QueryRowContext(ctx, "SELECT 1").Scan(&result)
+			Expect(err).NotTo(HaveOccurred(), "superuser should be able to connect to the newly created database")
+			Expect(result).To(Equal(1))
 		})
 	})
 


### PR DESCRIPTION


- Add validateEnvFromAddons to stack validator with postgresAddonService dependency for verifying addon existence and database references
- Add Superuser boolean to PostgresAddonEnvSource across all layers (model, OpenAPI spec, generated client, presenters, validator, reconciler)
- When Superuser=true, Database becomes optional (defaults to 'postgres') and validator checks EnableSuperuserAccess on the addon
- Rework addon usage sync to be declarative with proper create/delete
- Add superuser e2e test verifying credential injection and privileged database operations (read/write to existing DBs, create new database)