### PR TITLE
chore: update cluster-agent dependency to Stackdome/cluster-agent v0.…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -204,4 +204,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 )
 
-replace stackdome.io/cluster-agent => github.com/ashishmax31/cluster-agent v0.4.9-alpha
+replace stackdome.io/cluster-agent => github.com/Stackdome/cluster-agent v0.5.1-alpha


### PR DESCRIPTION
…5.1-alpha

Move the replace directive from the personal fork (ashishmax31/cluster-agent) to the organization repo (Stackdome/cluster-agent) at v0.5.1-alpha.