### PR TITLE
fix: deduplicate addon usages to prevent unique constraint violation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	golang.org/x/crypto v0.46.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/time v0.14.0
-	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/gorm v1.25.12
 	k8s.io/api v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -33,12 +33,12 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/Stackdome/cluster-agent v0.5.1-alpha h1:QgA/DTBVaWH/wFs+pGlZ4XyWTAQr/HMhwiHY/zhkUOk=
+github.com/Stackdome/cluster-agent v0.5.1-alpha/go.mod h1:CciYwheTTL7tnMKnKY8bbOthTAIttbV4/OTNLvTYI14=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ashishmax31/cluster-agent v0.4.9-alpha h1:uG8uhDRhyu8rWLKZ8gTGw5LLfV0L5hrjyh1i0wpryO0=
-github.com/ashishmax31/cluster-agent v0.4.9-alpha/go.mod h1:CciYwheTTL7tnMKnKY8bbOthTAIttbV4/OTNLvTYI14=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -590,7 +590,6 @@ gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/worker/stack/addon_env_reconciler.go
+++ b/pkg/worker/stack/addon_env_reconciler.go
@@ -142,6 +142,9 @@ func (r *addonEnvReconciler) syncAddonUsages(ctx context.Context, stackID string
 	desiredKeys := make(map[string]struct{}, len(desiredAddonUsages))
 	for _, u := range desiredAddonUsages {
 		key := addonUsageKey(u.StackResourceID, u.AddonID, u.AddonType)
+		if _, ok := desiredKeys[key]; ok {
+			continue
+		}
 		desiredKeys[key] = struct{}{}
 		if _, ok := existingKeys[key]; !ok {
 			if err := r.addonUsageService.Create(ctx, u); err != nil {


### PR DESCRIPTION
When a stack resource references the same addon for multiple databases, syncAddonUsages builds duplicate entries with identical keys and attempts to insert each one, causing a "uq_addon_usages" constraint violation.