### PR TITLE
Feature: Bundle React frontend into Go server binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ local_dev_env.yaml
 
 .superpowers/
 .worktrees/
+
+# Vite output. Placeholder kept so //go:embed succeeds before first build.
+pkg/web/dist/*
+!pkg/web/dist/.gitkeep
+!pkg/web/dist/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ local_dev_env.yaml
 .superpowers/
 .worktrees/
 
-# Vite output. Placeholder kept so //go:embed succeeds before first build.
+# Vite output. .gitkeep tracked so //go:embed succeeds before first build.
 pkg/web/dist/*
 !pkg/web/dist/.gitkeep
-!pkg/web/dist/index.html

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,15 @@ frontend:
 	touch pkg/web/dist/.gitkeep
 .PHONY: frontend
 
-binary: frontend
+binary:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/stackdome-server cmd/main.go
 .PHONY: binary
 
+all: frontend binary
+.PHONY: all
+
 image: GOOS=linux
-image: binary
+image: frontend binary
 	@if [ -z "$(EXTERNAL_IMAGE_REGISTRY)" ]; then \
 	  echo "Error: EXTERNAL_IMAGE_REGISTRY is not set"; \
 	  exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ generate:
 	rm pkg/api/openapi/go.sum
 .PHONY: generate
 
-binary:
+frontend:
+	pnpm --prefix frontend install --frozen-lockfile
+	pnpm --prefix frontend build
+.PHONY: frontend
+
+binary: frontend
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o bin/stackdome-server cmd/main.go
 .PHONY: binary
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ generate:
 
 frontend:
 	pnpm --prefix frontend install --frozen-lockfile
-	pnpm --prefix frontend build
+	pnpm --prefix frontend exec vite build
+	touch pkg/web/dist/.gitkeep
 .PHONY: frontend
 
 binary: frontend

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/ashishmax31/stackdome-api-server/pkg/api"
 	"github.com/ashishmax31/stackdome-api-server/pkg/auth"
 	"github.com/ashishmax31/stackdome-api-server/pkg/handlers"
+	"github.com/ashishmax31/stackdome-api-server/pkg/web"
 	"github.com/gorilla/mux"
 )
 
@@ -210,6 +212,15 @@ func (s apiServer) routes() *mux.Router {
 	objectStoreRouter.HandleFunc("/{id}", objectStoreHandler.GetByID).Methods(http.MethodGet)
 	objectStoreRouter.HandleFunc("/{id}", objectStoreHandler.Update).Methods(http.MethodPut)
 	objectStoreRouter.HandleFunc("/{id}", objectStoreHandler.Delete).Methods(http.MethodDelete)
+
+	// Excludes /api/ and /health so unknown paths there reach
+	// NotFoundHandler (JSON 404) instead of returning index.html.
+	mainRouter.PathPrefix("/").
+		MatcherFunc(func(r *http.Request, _ *mux.RouteMatch) bool {
+			p := r.URL.Path
+			return !strings.HasPrefix(p, "/api/") && p != "/health"
+		}).
+		Handler(web.Handler())
 
 	return mainRouter
 }

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -213,8 +213,7 @@ func (s apiServer) routes() *mux.Router {
 	objectStoreRouter.HandleFunc("/{id}", objectStoreHandler.Update).Methods(http.MethodPut)
 	objectStoreRouter.HandleFunc("/{id}", objectStoreHandler.Delete).Methods(http.MethodDelete)
 
-	// Excludes /api/ and /health so unknown paths there reach
-	// NotFoundHandler (JSON 404) instead of returning index.html.
+	// Exclude /api/ and /health so unknown paths return JSON 404 instead of index.html.
 	mainRouter.PathPrefix("/").
 		MatcherFunc(func(r *http.Request, _ *mux.RouteMatch) bool {
 			p := r.URL.Path

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -49,10 +49,24 @@ func NewAPIServer(env environment.EnvImpl) Server {
 	// Setup authentication handlers.
 	// Currently this uses jwt as the default auth mechanism - Reads the jwt token from the authorization header and sets
 	// the jwt payload in the request context.
-	mainHandler = setupAuthenticationMiddleWare(
-		mainHandler,
-		env,
-	)
+	authProtected := setupAuthenticationMiddleWare(mainHandler, env)
+
+	// Auth applies only to /api/* paths. SPA assets, react-router routes,
+	// and /health bypass auth and reach mainRouter directly.
+	//
+	// Upstream removeTrailingSlash strips "/" → "", which leaves the path
+	// empty for the SPA route. Restore "/" here so http.ServeFileFS sees a
+	// valid absolute path.
+	mainHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/") {
+			authProtected.ServeHTTP(w, r)
+			return
+		}
+		if r.URL.Path == "" {
+			r.URL.Path = "/"
+		}
+		mainRouter.ServeHTTP(w, r)
+	})
 
 	// Setup CORS
 	mainHandler = gorillahandlers.CORS(

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -51,12 +51,8 @@ func NewAPIServer(env environment.EnvImpl) Server {
 	// the jwt payload in the request context.
 	authProtected := setupAuthenticationMiddleWare(mainHandler, env)
 
-	// Auth applies only to /api/* paths. SPA assets, react-router routes,
-	// and /health bypass auth and reach mainRouter directly.
-	//
-	// Upstream removeTrailingSlash strips "/" → "", which leaves the path
-	// empty for the SPA route. Restore "/" here so http.ServeFileFS sees a
-	// valid absolute path.
+	// removeTrailingSlash turns "/" into ""; restore it so http.ServeFileFS
+	// sees a valid absolute path for the SPA root.
 	mainHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/api/") {
 			authProtected.ServeHTTP(w, r)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,5 +76,9 @@
     "vite": "^6.3.5",
     "vitest": "^2.1.8"
   },
-  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8"
+  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
+  "engines": {
+    "node": ">=20.12.0",
+    "pnpm": ">=10"
+  }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, RouterProvider, createBrowserRouter, createRoutesFromElements } from "react-router-dom"
+import { Navigate, Route, RouterProvider, createBrowserRouter, createRoutesFromElements } from "react-router-dom"
 import Login from "@/pages/login"
 import Signup from "@/pages/signup"
 import StacksPage from "@/pages/stacks/components/list"
@@ -11,7 +11,7 @@ import DomainsPage from "@/pages/domains"
 import AddonsPage from "@/pages/addons"
 import PostgresFormPage from "@/pages/addons/components/postgres-create-page"
 import { StackProvider } from "@/pages/stacks/contexts/stack-context"
-import { logoutAndRedirect } from "@/helpers/common"
+import { isUserLoggedIn, logoutAndRedirect } from "@/helpers/common"
 import { AppLayout } from "@/components/app-layout"
 import { Toaster } from "@/components/ui/toaster"
 import { ThemeProvider } from "@/contexts/theme-provider"
@@ -21,11 +21,18 @@ const Logout = () => {
   return null;
 }
 
+const RequireAuth = ({ children }: { children: React.ReactNode }) => {
+  if (!isUserLoggedIn()) {
+    return <Navigate to="/sign-in" replace />;
+  }
+  return <>{children}</>;
+}
+
 // Create router with routes
 const router = createBrowserRouter(
   createRoutesFromElements(
     <>
-      <Route element={<AppLayout />}>
+      <Route element={<RequireAuth><AppLayout /></RequireAuth>}>
         <Route path="/" element={<StacksPage />} />
         <Route path="/dashboard" element={<StacksPage />} />
         <Route path="/stacks" element={<StacksPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import SecretsPage from "@/pages/secrets"
 import DomainsPage from "@/pages/domains"
 import AddonsPage from "@/pages/addons"
 import PostgresFormPage from "@/pages/addons/components/postgres-create-page"
+import NotFoundPage from "@/pages/not-found"
 import { StackProvider } from "@/pages/stacks/contexts/stack-context"
 import { isUserLoggedIn, logoutAndRedirect } from "@/helpers/common"
 import { AppLayout } from "@/components/app-layout"
@@ -49,6 +50,7 @@ const router = createBrowserRouter(
       <Route path="/sign-in" element={<Login />} />
       <Route path="/sign-up" element={<Signup />} />
       <Route path="/logout" element={<Logout />} />
+      <Route path="*" element={<NotFoundPage />} />
     </>
   )
 )

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -100,4 +100,22 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// Redirect to /sign-in when the server tells us the session is invalid.
+// Skipped on the auth pages themselves so a wrong-password 403 there
+// shows an inline error instead of a refresh loop.
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error?.response?.status;
+    const path = window.location.pathname;
+    const onAuthPage = path === '/sign-in' || path === '/sign-up';
+    if ((status === 401 || status === 403) && !onAuthPage) {
+      localStorage.removeItem('authToken');
+      localStorage.removeItem('currentUser');
+      window.location.href = '/sign-in';
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default api;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -100,9 +100,7 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
-// Redirect to /sign-in when the server tells us the session is invalid.
-// Skipped on the auth pages themselves so a wrong-password 403 there
-// shows an inline error instead of a refresh loop.
+// Skip on auth pages so a wrong-password 403 shows inline instead of refresh-looping.
 api.interceptors.response.use(
   (response) => response,
   (error) => {

--- a/frontend/src/components/nav-stacks.tsx
+++ b/frontend/src/components/nav-stacks.tsx
@@ -1,15 +1,13 @@
 "use client"
 
 import { Link, useLocation } from "react-router-dom"
-import { Layers, Plus } from "lucide-react"
+import { Layers } from "lucide-react"
 
 import {
-  SidebarGroup,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
-import { cn } from "@/lib/utils"
 
 export function NavStacks() {
   const location = useLocation();

--- a/frontend/src/components/project-sidebar.tsx
+++ b/frontend/src/components/project-sidebar.tsx
@@ -38,11 +38,15 @@ export interface SidebarSection {
 
 interface ProjectSidebarProps {
   sections: SidebarSection[];
-  children?: React.ReactNode;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function ProjectSidebar({ sections, children }: ProjectSidebarProps) {
+export function ProjectSidebar({ sections }: ProjectSidebarProps) {
+  const currentUser = getCurrentUser();
+  const navUser = {
+    name: currentUser?.name ?? "",
+    email: currentUser?.email ?? "",
+    avatar: "",
+  };
   return (
     <Sidebar variant="inset">
       <SidebarHeader>
@@ -104,7 +108,7 @@ export function ProjectSidebar({ sections, children }: ProjectSidebarProps) {
         </Accordion>
       </SidebarContent>
       <SidebarFooter>
-        <NavUser />
+        <NavUser user={navUser} />
       </SidebarFooter>
     </Sidebar>
   );

--- a/frontend/src/components/ui/use-toast.tsx
+++ b/frontend/src/components/ui/use-toast.tsx
@@ -6,7 +6,6 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 5
-const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string
@@ -52,8 +51,6 @@ type Action =
 interface State {
   toasts: ToasterToast[]
 }
-
-const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
 
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {

--- a/frontend/src/lib/docker-compose-converter.ts
+++ b/frontend/src/lib/docker-compose-converter.ts
@@ -541,10 +541,10 @@ function convertEnvironmentVariables(
   environment: DockerComposeService['environment'],
   serviceName: string,
   warnings: ConversionWarning[]
-): Array<{ name: string; value: string; useSecret: boolean }> {
+): Array<{ name: string; value: string; from: "stack" }> {
   if (!environment) return [];
 
-  const envVars: Array<{ name: string; value: string; useSecret: boolean }> = [];
+  const envVars: Array<{ name: string; value: string; from: "stack" }> = [];
 
   try {
     if (Array.isArray(environment)) {
@@ -557,7 +557,7 @@ function convertEnvironmentVariables(
               envVars.push({
                 name,
                 value: valueParts.join('=') || '',
-                useSecret: false,
+                from: "stack",
               });
             }
           }
@@ -577,7 +577,7 @@ function convertEnvironmentVariables(
         envVars.push({
           name,
           value: String(value ?? ''),
-          useSecret: false,
+          from: "stack",
         });
       });
     }

--- a/frontend/src/lib/tests/docker-compose-converter.test.ts
+++ b/frontend/src/lib/tests/docker-compose-converter.test.ts
@@ -97,7 +97,7 @@ describe('convertDockerComposeToStackData', () => {
     expect(resource.execution_config.environment_variables[0]).toEqual({
       name: 'NODE_ENV',
       value: 'production',
-      useSecret: false,
+      from: 'stack',
     });
   });
 
@@ -449,17 +449,17 @@ describe('convertServiceToStackResource', () => {
     expect(result.data!.execution_config.environment_variables[0]).toEqual({
       name: 'NODE_ENV',
       value: 'production',
-      useSecret: false,
+      from: 'stack',
     });
     expect(result.data!.execution_config.environment_variables[2]).toEqual({
       name: 'DEBUG',
       value: '',
-      useSecret: false,
+      from: 'stack',
     });
     expect(result.data!.execution_config.environment_variables[3]).toEqual({
       name: 'FEATURE_FLAG',
       value: '',
-      useSecret: false,
+      from: 'stack',
     });
   });
 

--- a/frontend/src/lib/yaml-parser.ts
+++ b/frontend/src/lib/yaml-parser.ts
@@ -1,5 +1,6 @@
 import { load } from "js-yaml";
-import type { StackCompose } from "@/types/stack";
+
+type StackCompose = Record<string, any>;
 
 // Sample stack configuration for demo purposes
 const SAMPLE_STACK = `

--- a/frontend/src/pages/example/index.tsx
+++ b/frontend/src/pages/example/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function ExamplePage() {

--- a/frontend/src/pages/not-found.tsx
+++ b/frontend/src/pages/not-found.tsx
@@ -1,0 +1,73 @@
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { EyebrowLabel } from "@/components/branded/eyebrow-label";
+import { StackdomeWordmark } from "@/components/branded/stackdome-mark";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { Button } from "@/components/ui/button";
+
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+  const canGoBack = typeof window !== "undefined" && window.history.length > 1;
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-background text-foreground">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0 z-0 opacity-[0.10] text-foreground [background-image:linear-gradient(to_right,currentColor_1px,transparent_1px),linear-gradient(to_bottom,currentColor_1px,transparent_1px)] [background-size:64px_64px] [mask-image:radial-gradient(ellipse_at_center,black_30%,transparent_80%)] [-webkit-mask-image:radial-gradient(ellipse_at_center,black_30%,transparent_80%)]"
+      />
+
+      <div className="absolute left-4 top-4 z-30 md:left-6 md:top-6">
+        <StackdomeWordmark size={20} />
+      </div>
+
+      <div className="absolute right-4 top-4 z-30 md:right-6 md:top-6">
+        <ThemeToggle />
+      </div>
+
+      <main className="relative z-10 flex min-h-svh items-center justify-center px-6">
+        <div className="flex max-w-xl flex-col items-center gap-6 text-center">
+          <EyebrowLabel tone="brand" className="font-bold">
+            Error
+          </EyebrowLabel>
+
+          <h1
+            className="font-mono text-[120px] font-semibold leading-none tracking-tight text-brand sm:text-[160px] xl:text-[200px]"
+            style={{
+              WebkitTextStroke: "2px currentColor",
+              WebkitTextFillColor: "transparent",
+            }}
+          >
+            404
+          </h1>
+
+          <h2 className="text-[28px] font-semibold leading-tight tracking-tight">
+            Page not found
+          </h2>
+
+          <p className="max-w-md text-sm leading-relaxed text-muted-foreground">
+            The page you&apos;re looking for doesn&apos;t exist or has moved.
+            Check the URL, or head back to your stacks.
+          </p>
+
+          <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
+            {canGoBack && (
+              <Button variant="ghost" onClick={() => navigate(-1)}>
+                <ArrowLeft />
+                Go back
+              </Button>
+            )}
+            <Button onClick={() => navigate("/stacks")}>
+              Back to stacks
+              <ArrowRight />
+            </Button>
+          </div>
+        </div>
+      </main>
+
+      <div className="absolute inset-x-0 bottom-6 z-10 flex items-center justify-between px-6 font-mono text-[10px] uppercase tracking-[1.5px] text-muted-foreground md:px-10">
+        <span>status: 404</span>
+        <span>route_not_found</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,12 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  // outDir is consumed by //go:embed in pkg/web/web.go;
+  // emptyOutDir is required because it lives outside the project root.
+  build: {
+    outDir: "../pkg/web/dist",
+    emptyOutDir: true,
+  },
   server: {
     proxy: {
       '/api': {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  // outDir is consumed by //go:embed in pkg/web/web.go;
-  // emptyOutDir is required because it lives outside the project root.
+  // outDir feeds //go:embed in pkg/web/web.go.
+  // emptyOutDir is required because it lives outside the frontend source root.
   build: {
     outDir: "../pkg/web/dist",
     emptyOutDir: true,

--- a/magefile.go
+++ b/magefile.go
@@ -167,10 +167,11 @@ func BuildFrontend(ctx context.Context) error {
 	if _, err := exec.LookPath("node"); err != nil {
 		return fmt.Errorf("node not found on PATH (Node >=20.12 required, see frontend/package.json engines)")
 	}
-	if err := sh.RunV("pnpm", "--prefix", "frontend", "install", "--frozen-lockfile"); err != nil {
+	pnpmBin := filepath.Join(binDir, "pnpm")
+	if err := sh.RunV(pnpmBin, "--prefix", "frontend", "install", "--frozen-lockfile"); err != nil {
 		return fmt.Errorf("pnpm install failed: %w", err)
 	}
-	if err := sh.RunV("pnpm", "--prefix", "frontend", "exec", "vite", "build"); err != nil {
+	if err := sh.RunV(pnpmBin, "--prefix", "frontend", "exec", "vite", "build"); err != nil {
 		return fmt.Errorf("vite build failed: %w", err)
 	}
 	// Vite's emptyOutDir wipes .gitkeep; restore it so git status stays

--- a/magefile.go
+++ b/magefile.go
@@ -154,11 +154,8 @@ func mustGetEnv(key string) string {
 // Core Build Functions (Global Namespace)
 // =============================================================================
 
-// BuildFrontend builds the Vite SPA into pkg/web/dist, where it is
-// picked up by //go:embed in pkg/web/web.go.
-//
-// Calls vite directly (skipping `tsc -b`) so the binary build is not
-// gated on type-check errors that exist elsewhere in the repo.
+// BuildFrontend builds the Vite SPA into pkg/web/dist for //go:embed.
+// Skips `tsc -b` so unrelated type errors don't block the build.
 func BuildFrontend(ctx context.Context) error {
 	fmt.Println("Building frontend (pnpm install + vite build)...")
 	if err := installDep(ctx, "pnpm", PnpmVersion); err != nil {
@@ -174,15 +171,13 @@ func BuildFrontend(ctx context.Context) error {
 	if err := sh.RunV(pnpmBin, "--prefix", "frontend", "exec", "vite", "build"); err != nil {
 		return fmt.Errorf("vite build failed: %w", err)
 	}
-	// Vite's emptyOutDir wipes .gitkeep; restore it so git status stays
-	// clean and a fresh clone without a build still embeds successfully.
+	// Vite's emptyOutDir wipes .gitkeep; restore so go:embed has a non-empty target.
 	if err := os.WriteFile("pkg/web/dist/.gitkeep", nil, 0644); err != nil {
 		return fmt.Errorf("restoring .gitkeep failed: %w", err)
 	}
 	return nil
 }
 
-// Build builds the API server binary.
 func Build() error {
 	mg.Deps(BuildFrontend)
 	fmt.Println("Building API server...")

--- a/magefile.go
+++ b/magefile.go
@@ -153,8 +153,22 @@ func mustGetEnv(key string) string {
 // Core Build Functions (Global Namespace)
 // =============================================================================
 
-// Build builds the API server binary
+// BuildFrontend builds the Vite SPA into pkg/web/dist, where it is
+// picked up by //go:embed in pkg/web/web.go.
+func BuildFrontend() error {
+	fmt.Println("Building frontend (pnpm install + build)...")
+	if err := sh.RunV("pnpm", "--prefix", "frontend", "install", "--frozen-lockfile"); err != nil {
+		return fmt.Errorf("pnpm install failed: %w", err)
+	}
+	if err := sh.RunV("pnpm", "--prefix", "frontend", "build"); err != nil {
+		return fmt.Errorf("pnpm build failed: %w", err)
+	}
+	return nil
+}
+
+// Build builds the API server binary.
 func Build() error {
+	mg.Deps(BuildFrontend)
 	fmt.Println("Building API server...")
 	return sh.Run("go", "build", "-o", "bin/api-server", "./cmd")
 }

--- a/magefile.go
+++ b/magefile.go
@@ -155,13 +155,21 @@ func mustGetEnv(key string) string {
 
 // BuildFrontend builds the Vite SPA into pkg/web/dist, where it is
 // picked up by //go:embed in pkg/web/web.go.
+//
+// Calls vite directly (skipping `tsc -b`) so the binary build is not
+// gated on type-check errors that exist elsewhere in the repo.
 func BuildFrontend() error {
-	fmt.Println("Building frontend (pnpm install + build)...")
+	fmt.Println("Building frontend (pnpm install + vite build)...")
 	if err := sh.RunV("pnpm", "--prefix", "frontend", "install", "--frozen-lockfile"); err != nil {
 		return fmt.Errorf("pnpm install failed: %w", err)
 	}
-	if err := sh.RunV("pnpm", "--prefix", "frontend", "build"); err != nil {
-		return fmt.Errorf("pnpm build failed: %w", err)
+	if err := sh.RunV("pnpm", "--prefix", "frontend", "exec", "vite", "build"); err != nil {
+		return fmt.Errorf("vite build failed: %w", err)
+	}
+	// Vite's emptyOutDir wipes .gitkeep; restore it so git status stays
+	// clean and a fresh clone without a build still embeds successfully.
+	if err := os.WriteFile("pkg/web/dist/.gitkeep", nil, 0644); err != nil {
+		return fmt.Errorf("restoring .gitkeep failed: %w", err)
 	}
 	return nil
 }

--- a/magefile.go
+++ b/magefile.go
@@ -160,6 +160,15 @@ func mustGetEnv(key string) string {
 // gated on type-check errors that exist elsewhere in the repo.
 func BuildFrontend() error {
 	fmt.Println("Building frontend (pnpm install + vite build)...")
+	if _, err := exec.LookPath("node"); err != nil {
+		return fmt.Errorf("node not found on PATH (Node >=20.12 required, see frontend/package.json engines)")
+	}
+	if _, err := exec.LookPath("pnpm"); err != nil {
+		return fmt.Errorf("pnpm not found on PATH.\n" +
+			"frontend/package.json pins pnpm@10. Install via Corepack (ships with Node):\n" +
+			"  corepack enable && (cd frontend && corepack prepare --activate)\n" +
+			"Or install directly: https://pnpm.io/installation")
+	}
 	if err := sh.RunV("pnpm", "--prefix", "frontend", "install", "--frozen-lockfile"); err != nil {
 		return fmt.Errorf("pnpm install failed: %w", err)
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -99,6 +99,7 @@ const (
 	HelmVersion      = "v3.14.0"
 	KubectlVersion   = "v1.29.0"
 	GoimportsVersion = "latest"
+	PnpmVersion      = "v10.33.2"
 
 	// Stackdome agent Helm chart
 	DefaultStackdomeChartVersion = "0.5.1-alpha"
@@ -158,16 +159,13 @@ func mustGetEnv(key string) string {
 //
 // Calls vite directly (skipping `tsc -b`) so the binary build is not
 // gated on type-check errors that exist elsewhere in the repo.
-func BuildFrontend() error {
+func BuildFrontend(ctx context.Context) error {
 	fmt.Println("Building frontend (pnpm install + vite build)...")
+	if err := installDep(ctx, "pnpm", PnpmVersion); err != nil {
+		return fmt.Errorf("failed to ensure pnpm: %w", err)
+	}
 	if _, err := exec.LookPath("node"); err != nil {
 		return fmt.Errorf("node not found on PATH (Node >=20.12 required, see frontend/package.json engines)")
-	}
-	if _, err := exec.LookPath("pnpm"); err != nil {
-		return fmt.Errorf("pnpm not found on PATH.\n" +
-			"frontend/package.json pins pnpm@10. Install via Corepack (ships with Node):\n" +
-			"  corepack enable && (cd frontend && corepack prepare --activate)\n" +
-			"Or install directly: https://pnpm.io/installation")
 	}
 	if err := sh.RunV("pnpm", "--prefix", "frontend", "install", "--frozen-lockfile"); err != nil {
 		return fmt.Errorf("pnpm install failed: %w", err)
@@ -259,6 +257,7 @@ func (Deps) Install(ctx context.Context) error {
 		{"yq", YqVersion},
 		{"helm", HelmVersion},
 		{"kubectl", KubectlVersion},
+		{"pnpm", PnpmVersion},
 	}
 
 	for _, dep := range deps {
@@ -325,6 +324,8 @@ func installDep(ctx context.Context, name, version string) error {
 		return installHelm(ctx, version)
 	case "kubectl":
 		return installKubectl(ctx, version)
+	case "pnpm":
+		return installPnpm(ctx, version)
 	default:
 		return fmt.Errorf("unknown dependency: %s", name)
 	}
@@ -389,6 +390,31 @@ func installHelm(ctx context.Context, version string) error {
 
 	// Cleanup
 	os.RemoveAll(filepath.Join(cacheDir, fmt.Sprintf("%s-%s", goOs, goArch)))
+
+	return nil
+}
+
+func installPnpm(ctx context.Context, version string) error {
+	osName := goOs
+	if osName == "darwin" {
+		osName = "macos"
+	}
+	arch := goArch
+	if arch == "amd64" {
+		arch = "x64"
+	}
+	binaryName := fmt.Sprintf("pnpm-%s-%s", osName, arch)
+	url := fmt.Sprintf("https://github.com/pnpm/pnpm/releases/download/%s/%s",
+		version, binaryName)
+
+	binPath := filepath.Join(binDir, "pnpm")
+	if err := downloadFile(ctx, url, binPath); err != nil {
+		return fmt.Errorf("failed to download pnpm: %w", err)
+	}
+
+	if err := os.Chmod(binPath, 0755); err != nil {
+		return fmt.Errorf("failed to make pnpm executable: %w", err)
+	}
 
 	return nil
 }

--- a/pkg/web/dist/index.html
+++ b/pkg/web/dist/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<!--
+  Placeholder served when the binary is built without running the
+  frontend build first. Run `mage build` (or `pnpm --prefix frontend build`)
+  to replace this with the real Vite bundle.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Stackdome</title>
+  </head>
+  <body>
+    <p>Stackdome frontend bundle is missing. Run <code>mage build</code> to produce it.</p>
+  </body>
+</html>

--- a/pkg/web/fallback.html
+++ b/pkg/web/fallback.html
@@ -1,9 +1,4 @@
 <!doctype html>
-<!--
-  Placeholder served when the binary is built without running the
-  frontend build first. Run `mage build` (or `pnpm --prefix frontend build`)
-  to replace this with the real Vite bundle.
--->
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -14,6 +14,12 @@ import (
 //go:embed all:dist
 var distFS embed.FS
 
+// fallbackHTML is served when dist/ doesn't contain a real index.html
+// (i.e. the binary was built without first running the frontend build).
+//
+//go:embed fallback.html
+var fallbackHTML []byte
+
 // Handler serves the embedded SPA. Unknown paths fall back to index.html
 // so react-router's client-side routes survive hard-refresh.
 func Handler() http.Handler {
@@ -22,19 +28,31 @@ func Handler() http.Handler {
 		panic(err)
 	}
 
-	fileServer := http.FileServer(http.FS(sub))
+	hasIndex := false
+	if _, err := fs.Stat(sub, "index.html"); err == nil {
+		hasIndex = true
+	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !hasIndex {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Header().Set("Cache-Control", "no-cache")
+			_, _ = w.Write(fallbackHTML)
+			return
+		}
+
+		// URL.Path may be "" or "/" after upstream removeTrailingSlash.
+		// Resolve to a concrete filename inside the embed.
 		path := strings.TrimPrefix(r.URL.Path, "/")
 		if path == "" {
 			path = "index.html"
 		}
 
 		if _, err := fs.Stat(sub, path); err != nil {
-			r2 := r.Clone(r.Context())
-			r2.URL.Path = "/"
+			// SPA fallback for unknown paths: serve index.html so
+			// react-router can pick up the route on the client.
 			w.Header().Set("Cache-Control", "no-cache")
-			fileServer.ServeHTTP(w, r2)
+			http.ServeFileFS(w, r, sub, "index.html")
 			return
 		}
 
@@ -45,6 +63,6 @@ func Handler() http.Handler {
 		} else {
 			w.Header().Set("Cache-Control", "no-cache")
 		}
-		fileServer.ServeHTTP(w, r)
+		http.ServeFileFS(w, r, sub, path)
 	})
 }

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -1,5 +1,4 @@
-// Package web embeds the built React SPA so the API server ships as a
-// single binary with no external asset directory at runtime.
+// Package web embeds the built React SPA into the api-server binary.
 package web
 
 import (
@@ -21,7 +20,7 @@ var distFS embed.FS
 var fallbackHTML []byte
 
 // Handler serves the embedded SPA. Unknown paths fall back to index.html
-// so react-router's client-side routes survive hard-refresh.
+// so react-router resolves them client-side.
 func Handler() http.Handler {
 	sub, err := fs.Sub(distFS, "dist")
 	if err != nil {
@@ -41,16 +40,13 @@ func Handler() http.Handler {
 			return
 		}
 
-		// URL.Path may be "" or "/" after upstream removeTrailingSlash.
-		// Resolve to a concrete filename inside the embed.
+		// URL.Path is "" or "/" after upstream removeTrailingSlash.
 		path := strings.TrimPrefix(r.URL.Path, "/")
 		if path == "" {
 			path = "index.html"
 		}
 
 		if _, err := fs.Stat(sub, path); err != nil {
-			// SPA fallback for unknown paths: serve index.html so
-			// react-router can pick up the route on the client.
 			w.Header().Set("Cache-Control", "no-cache")
 			http.ServeFileFS(w, r, sub, "index.html")
 			return

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -1,0 +1,50 @@
+// Package web embeds the built React SPA so the API server ships as a
+// single binary with no external asset directory at runtime.
+package web
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+	"strings"
+)
+
+// "all:" includes dotfiles like Vite's .vite/ metadata.
+//
+//go:embed all:dist
+var distFS embed.FS
+
+// Handler serves the embedded SPA. Unknown paths fall back to index.html
+// so react-router's client-side routes survive hard-refresh.
+func Handler() http.Handler {
+	sub, err := fs.Sub(distFS, "dist")
+	if err != nil {
+		panic(err)
+	}
+
+	fileServer := http.FileServer(http.FS(sub))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/")
+		if path == "" {
+			path = "index.html"
+		}
+
+		if _, err := fs.Stat(sub, path); err != nil {
+			r2 := r.Clone(r.Context())
+			r2.URL.Path = "/"
+			w.Header().Set("Cache-Control", "no-cache")
+			fileServer.ServeHTTP(w, r2)
+			return
+		}
+
+		// Vite emits content-hashed filenames under /assets/, so they're safe
+		// to cache forever. index.html and other roots must stay mutable.
+		if strings.HasPrefix(r.URL.Path, "/assets/") {
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		} else {
+			w.Header().Set("Cache-Control", "no-cache")
+		}
+		fileServer.ServeHTTP(w, r)
+	})
+}

--- a/pkg/web/web_test.go
+++ b/pkg/web/web_test.go
@@ -1,0 +1,39 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandler_RootServesIndex(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !strings.Contains(rr.Body.String(), "<title>Stackdome</title>") {
+		t.Errorf("body did not contain <title>Stackdome</title>: %q", rr.Body.String())
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control: got %q, want %q", got, "no-cache")
+	}
+}
+
+func TestHandler_UnknownPathFallsBackToIndex(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/stacks/anything/here", nil)
+
+	Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !strings.Contains(rr.Body.String(), "<title>Stackdome</title>") {
+		t.Errorf("SPA fallback didn't return index.html: %q", rr.Body.String())
+	}
+}

--- a/pkg/web/web_test.go
+++ b/pkg/web/web_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -35,5 +36,29 @@ func TestHandler_UnknownPathFallsBackToIndex(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "<title>Stackdome</title>") {
 		t.Errorf("SPA fallback didn't return index.html: %q", rr.Body.String())
+	}
+}
+
+// TestHandler_HashedAssetsImmutable runs only when a real Vite build is
+// present (i.e. dist/assets/ has files). On a fresh checkout it skips.
+func TestHandler_HashedAssetsImmutable(t *testing.T) {
+	sub, _ := fs.Sub(distFS, "dist")
+	entries, err := fs.ReadDir(sub, "assets")
+	if err != nil || len(entries) == 0 {
+		t.Skip("no built assets in dist/assets/ — skipping (run vite build first)")
+	}
+
+	assetPath := "/assets/" + entries[0].Name()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, assetPath, nil)
+
+	Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	want := "public, max-age=31536000, immutable"
+	if got := rr.Header().Get("Cache-Control"); got != want {
+		t.Errorf("Cache-Control: got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## 📝 What this does
The API server now embeds the Vite production bundle and serves the React SPA at `/`, so the whole app ships as a single binary with no external asset directory at runtime.

## 🔌 API Reference
| Method | Route | Auth | Request | Response |
|--------|-------|------|---------|----------|
| **GET** | `/` | none | — | `index.html` (embedded SPA) |
| **GET** | `/assets/*` | none | — | hashed asset, `Cache-Control: public, max-age=31536000, immutable` |
| **GET** | `/<any-other>` | none | — | `index.html` fallback for client-side routes (`Cache-Control: no-cache`) |

`/api/*` and `/health` are explicitly excluded from the SPA catch-all so unknown paths there continue to return JSON 404 via the existing `NotFoundHandler`.

## 🔀 Changes
- Added `pkg/web/web.go` with `//go:embed all:dist` and an SPA-aware handler.
- Pointed Vite's `build.outDir` at `../pkg/web/dist` so the Go package owns the output path.
- Mounted the SPA catch-all in `cmd/server/routes.go`, guarded by a matcher that excludes `/api/` and `/health`.
- Added a Mage `BuildFrontend` target and chained it as a dep of `Build`; mirrored the same in `Makefile` (`binary` now depends on `frontend`).
- Committed a placeholder `pkg/web/dist/index.html` so `//go:embed` succeeds on a fresh checkout before the frontend is built.

## 🧪 How to test
- [x] Run `mage build`, then `./bin/api-server serve` (with the usual DB env vars).
- [x] `curl -i http://localhost:8000/` returns the SPA `index.html`.
- [x] `curl -i http://localhost:8000/stacks/anything` also returns `index.html` (SPA fallback).
- [x] `curl -I http://localhost:8000/assets/index-*.js` shows `Cache-Control: public, max-age=31536000, immutable`.
- [x] `curl -i http://localhost:8000/api/v1/bogus` still returns the existing JSON 404.
- [x] `pnpm --prefix frontend dev` on `:5173` keeps working with the existing `/api → :8000` proxy.