### PR TITLE
refactor: extract SignupService and improve invite system architecture

### DIFF
--- a/cmd/environment/development_environment.go
+++ b/cmd/environment/development_environment.go
@@ -467,8 +467,11 @@ func (d *developmentEnvironment) loadServices(ctx context.Context) error {
 	}
 	d.EmailService = emailSvc
 
+	orgInviteStore := pgstore.NewOrgInviteStore(pgstore.OrgInviteStoreSpec{
+		SessionFactory: d.DBSession,
+	})
 	orgInviteService := services.NewOrgInviteService(services.OrgInviteServiceSpec{
-		SessionFactory:    d.DBSession,
+		InviteStore:       orgInviteStore,
 		TeamService:       teamService,
 		UserService:       userService,
 		EncryptionService: encryptionService,
@@ -476,7 +479,17 @@ func (d *developmentEnvironment) loadServices(ctx context.Context) error {
 		Logger:            d.Logger,
 	})
 
-	userService.SetOrgInviteService(orgInviteService)
+	signupService := services.NewSignupService(services.SignupServiceSpec{
+		UserService:         userService,
+		OrgInviteService:    orgInviteService,
+		OrganisationService: organisationService,
+		TeamService:         teamService,
+		PolicyManager:       d.ResourceAccessPolicyManager,
+		RefreshTokenStore:   d.RefreshTokenStore,
+		JWTSecretKey:        d.Config.JwtSecret,
+		JWTClaimsBuilder:    auth.NewJWTClaimsBuilder(),
+		Logger:              d.Logger,
+	})
 
 	d.OAuthStateStore = pgstore.NewOAuthStateStore(pgstore.OAuthStateStoreSpec{
 		SessionFactory: d.DBSession,
@@ -507,6 +520,7 @@ func (d *developmentEnvironment) loadServices(ctx context.Context) error {
 		APITokenService:             apiTokenService,
 		TeamService:                 teamService,
 		OrgInviteService:            orgInviteService,
+		SignupService:               signupService,
 	}
 
 	return nil

--- a/cmd/environment/environment.go
+++ b/cmd/environment/environment.go
@@ -75,4 +75,5 @@ type Services struct {
 	APITokenService             services.APITokenService
 	TeamService                 services.TeamService
 	OrgInviteService            services.OrgInviteService
+	SignupService               services.SignupService
 }

--- a/cmd/environment/test_environment.go
+++ b/cmd/environment/test_environment.go
@@ -396,8 +396,11 @@ func (te *testEnvironment) loadServices(ctx context.Context) error {
 
 	te.EmailService = emailpkg.NewNoopEmailService(applogger.NewLoggerWithPrefix(ctx, "test-email-service").SetLevel(te.Logger.GetLevel()))
 
+	orgInviteStore := pgstore.NewOrgInviteStore(pgstore.OrgInviteStoreSpec{
+		SessionFactory: te.DBSession,
+	})
 	orgInviteService := services.NewOrgInviteService(services.OrgInviteServiceSpec{
-		SessionFactory:    te.DBSession,
+		InviteStore:       orgInviteStore,
 		TeamService:       teamService,
 		UserService:       userService,
 		EncryptionService: encryptionService,
@@ -405,7 +408,17 @@ func (te *testEnvironment) loadServices(ctx context.Context) error {
 		Logger:            te.Logger,
 	})
 
-	userService.SetOrgInviteService(orgInviteService)
+	signupService := services.NewSignupService(services.SignupServiceSpec{
+		UserService:         userService,
+		OrgInviteService:    orgInviteService,
+		OrganisationService: organisationService,
+		TeamService:         teamService,
+		PolicyManager:       te.ResourceAccessPolicyManager,
+		RefreshTokenStore:   te.RefreshTokenStore,
+		JWTSecretKey:        te.Config.JwtSecret,
+		JWTClaimsBuilder:    auth.NewJWTClaimsBuilder(),
+		Logger:              te.Logger,
+	})
 
 	te.OAuthStateStore = pgstore.NewOAuthStateStore(pgstore.OAuthStateStoreSpec{
 		SessionFactory: te.DBSession,
@@ -436,6 +449,7 @@ func (te *testEnvironment) loadServices(ctx context.Context) error {
 		APITokenService:             apiTokenService,
 		TeamService:                 teamService,
 		OrgInviteService:            orgInviteService,
+		SignupService:               signupService,
 	}
 
 	return nil

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -25,7 +25,8 @@ func (s apiServer) routes() *mux.Router {
 	logger := s.environment.Environment().Logger
 
 	userHandler := handlers.NewUserServiceHandler(handlers.UserServiceHandlerSpec{
-		UserService: services.UserService,
+		UserService:   services.UserService,
+		SignupService: services.SignupService,
 	})
 
 	refreshHandler := auth.NewRefreshHandler(auth.RefreshHandlerSpec{

--- a/pkg/handlers/user_handler.go
+++ b/pkg/handlers/user_handler.go
@@ -14,16 +14,19 @@ import (
 
 func NewUserServiceHandler(spec UserServiceHandlerSpec) *usersHandler {
 	return &usersHandler{
-		userService: spec.UserService,
+		userService:   spec.UserService,
+		signupService: spec.SignupService,
 	}
 }
 
 type UserServiceHandlerSpec struct {
-	UserService services.UserService
+	UserService   services.UserService
+	SignupService services.SignupService
 }
 
 type usersHandler struct {
-	userService services.UserService
+	userService   services.UserService
+	signupService services.SignupService
 }
 
 func (a usersHandler) Get(w http.ResponseWriter, r *http.Request) {
@@ -98,7 +101,7 @@ func (a usersHandler) Signup(w http.ResponseWriter, r *http.Request) {
 				inviteToken = *req.InviteToken
 			}
 
-			user, err := a.userService.Signup(ctx, convertedUser, inviteToken)
+			user, err := a.signupService.Signup(ctx, convertedUser, inviteToken)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/services/org_invite_service.go
+++ b/pkg/services/org_invite_service.go
@@ -10,12 +10,10 @@ import (
 	"time"
 
 	"github.com/ashishmax31/stackdome-api-server/pkg/auth"
-	"github.com/ashishmax31/stackdome-api-server/pkg/db"
 	"github.com/ashishmax31/stackdome-api-server/pkg/errors"
 	"github.com/ashishmax31/stackdome-api-server/pkg/logger"
 	"github.com/ashishmax31/stackdome-api-server/pkg/models"
 	"github.com/ashishmax31/stackdome-api-server/pkg/stores"
-	"github.com/ashishmax31/stackdome-api-server/pkg/stores/pgstore"
 )
 
 const (
@@ -40,10 +38,11 @@ type OrgInviteService interface {
 	InternalDecryptToken(ctx context.Context, encryptedToken string) (string, *errors.ServiceError)
 	InternalListExpiredOrPastDue(ctx context.Context, now time.Time, params stores.ListParams) (*stores.PaginatedResult[*models.OrgInvite], *errors.ServiceError)
 	InternalMarkExpiredAndDelete(ctx context.Context, invites []*models.OrgInvite) *errors.ServiceError
+	InternalWithTransaction(ctx context.Context, fn func(ctx context.Context) *errors.ServiceError) *errors.ServiceError
 }
 
 type OrgInviteServiceSpec struct {
-	SessionFactory    db.SessionFactory
+	InviteStore       stores.OrgInviteStore
 	TeamService       TeamService
 	UserService       UserService
 	EncryptionService EncryptionService
@@ -63,9 +62,7 @@ type orgInviteService struct {
 
 func NewOrgInviteService(spec OrgInviteServiceSpec) OrgInviteService {
 	return &orgInviteService{
-		inviteStore: pgstore.NewOrgInviteStore(pgstore.OrgInviteStoreSpec{
-			SessionFactory: spec.SessionFactory,
-		}),
+		inviteStore:       spec.InviteStore,
 		teamService:       spec.TeamService,
 		userService:       spec.UserService,
 		encryptionService: spec.EncryptionService,
@@ -316,4 +313,8 @@ func (s *orgInviteService) findByToken(ctx context.Context, rawToken string) (*m
 	tokenHash := hex.EncodeToString(hash[:])
 
 	return s.inviteStore.GetByTokenHash(ctx, tokenHash)
+}
+
+func (s *orgInviteService) InternalWithTransaction(ctx context.Context, fn func(ctx context.Context) *errors.ServiceError) *errors.ServiceError {
+	return s.inviteStore.WithTransaction(ctx, fn)
 }

--- a/pkg/services/user_service.go
+++ b/pkg/services/user_service.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"net/mail"
 	"time"
 
 	"github.com/ashishmax31/stackdome-api-server/pkg/api/openapi"
@@ -18,7 +17,6 @@ import (
 	"github.com/ashishmax31/stackdome-api-server/pkg/stores/pgstore"
 	"github.com/golang-jwt/jwt"
 	"golang.org/x/crypto/bcrypt"
-	"k8s.io/utils/ptr"
 )
 
 type UserService interface {
@@ -27,12 +25,11 @@ type UserService interface {
 	ListByOrgID(ctx context.Context, orgID string, params stores.ListParams) (*stores.PaginatedResult[*models.User], *errors.ServiceError)
 	InternalGet(ctx context.Context, ID string) (*models.User, *errors.ServiceError)
 	InternalGetByEmail(ctx context.Context, email string) (*models.User, *errors.ServiceError)
+	InternalCreate(ctx context.Context, user *models.User) (*models.User, *errors.ServiceError)
 	InternalCreateOAuthUser(ctx context.Context, email, name, githubID, avatarURL string) (*models.User, error)
 	InternalCreateInvitedUser(ctx context.Context, user *models.User, invite *models.OrgInvite) (*models.User, *errors.ServiceError)
 	InternalCreateInvitedOAuthUser(ctx context.Context, email, name, githubID, avatarURL string, invite *models.OrgInvite) (*models.User, error)
-	Signup(ctx context.Context, user *models.User, inviteToken string) (*openapi.UserSignupResponse, *errors.ServiceError)
 	Login(ctx context.Context, loginRequest *openapi.LoginRequest) (*openapi.LoginResponse, *errors.ServiceError)
-	SetOrgInviteService(svc OrgInviteService)
 }
 
 type jwtClaimsBuilder interface {
@@ -74,7 +71,6 @@ type UserServiceSpec struct {
 type usersService struct {
 	userStore               stores.UserStore
 	organisationService     OrganisationService
-	orgInviteService        OrgInviteService
 	logger                  logger.Logger
 	jwtSecretKey            string
 	resourceAccessPolicyMgr resourceaccess.ResourceAccessPolicyManager
@@ -82,10 +78,6 @@ type usersService struct {
 	permissions             auth.PermissionService
 	teamService             TeamService
 	refreshTokenStore       stores.RefreshTokenStore
-}
-
-func (u *usersService) SetOrgInviteService(svc OrgInviteService) {
-	u.orgInviteService = svc
 }
 
 func (u usersService) Get(ctx context.Context, ID string) (*models.User, *errors.ServiceError) {
@@ -143,105 +135,8 @@ func (u usersService) InternalGetByEmail(ctx context.Context, email string) (*mo
 	return u.userStore.GetByEmail(ctx, email)
 }
 
-func (u usersService) Signup(ctx context.Context, user *models.User, inviteToken string) (*openapi.UserSignupResponse, *errors.ServiceError) {
-	u.logger.Infof("Creating user with email: %s", user.Email)
-	if len(user.Password) < 8 {
-		return nil, errors.BadRequest("password must be at least 8 characters")
-	}
-
-	_, addrErr := mail.ParseAddress(user.Email)
-	if addrErr != nil {
-		return nil, errors.BadRequest("invalid email address")
-	}
-
-	_, gerr := u.userStore.GetByEmail(ctx, user.Email)
-	if gerr == nil {
-		return nil, errors.Conflict("user with this email already exists! Please login instead.")
-	}
-
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
-	if err != nil {
-		u.logger.Errorf("failed to hash password, %s", err.Error())
-		return nil, errors.GeneralError("failed to create user")
-	}
-	user.Password = string(hashedPassword)
-
-	// Invite-based signup
-	if inviteToken != "" {
-		invite, invErr := u.orgInviteService.ValidateAndConsume(ctx, inviteToken, user.Email)
-		if invErr != nil {
-			return nil, invErr
-		}
-
-		createdUser, createErr := u.InternalCreateInvitedUser(ctx, user, invite)
-		if createErr != nil {
-			return nil, createErr
-		}
-
-		return u.buildSignupResponse(ctx, createdUser)
-	}
-
-	if user.Organisation == nil {
-		return nil, errors.BadRequest("organisation is required")
-	}
-	createdOrganisation, orgErr := u.organisationService.InternalCreate(ctx, user.Organisation)
-	if orgErr != nil {
-		u.logger.Errorf("failed to create organisation, %s", orgErr.Error())
-		return nil, errors.GeneralError("failed to create user")
-	}
-	user.OrganisationID = createdOrganisation.ID
-	user.Role = models.OrgAdminRole
-
-	if _, teamErr := u.teamService.InternalCreateDefaultTeam(ctx, createdOrganisation.ID); teamErr != nil {
-		u.logger.Errorf("failed to create default team: %s", teamErr.Error())
-		return nil, errors.GeneralError("failed to create default team")
-	}
-
-	createdUser, serr := u.userStore.Create(ctx, user)
-	if serr != nil {
-		return nil, serr
-	}
-
-	if policyAddErr := u.resourceAccessPolicyMgr.AddGroupingPolicy(
-		createdUser.ID,
-		string(models.OrgAdminRole),
-		createdUser.OrganisationID,
-	); policyAddErr != nil {
-		u.logger.Errorf("failed to add OrgAdmin policy for user: %s", policyAddErr.Error())
-		return nil, errors.GeneralError("failed to create user")
-	}
-
-	// Org admin is also an org member, so they get both policies.
-	// This is needed because another orgadmin can demote the user from OrgAdmin.
-	if policyAddErr := u.resourceAccessPolicyMgr.AddGroupingPolicy(
-		createdUser.ID,
-		string(models.OrgMemberRole),
-		createdUser.OrganisationID,
-	); policyAddErr != nil {
-		u.logger.Errorf("failed to add OrgMember policy for user: %s", policyAddErr.Error())
-	}
-
-	return u.buildSignupResponse(ctx, createdUser)
-}
-
-func (u usersService) buildSignupResponse(ctx context.Context, createdUser *models.User) (*openapi.UserSignupResponse, *errors.ServiceError) {
-	expirationTime := time.Now().UTC().Add(auth.JwtTokenExpiry)
-	claims := u.jwtClaimsBuilder.BuildClaims(createdUser, expirationTime)
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, tokenErr := token.SignedString([]byte(u.jwtSecretKey))
-	if tokenErr != nil {
-		return nil, errors.GeneralError("failed to generate token: %s", tokenErr.Error())
-	}
-	refreshToken, refreshErr := auth.CreateRefreshToken(ctx, u.refreshTokenStore, createdUser.ID)
-	if refreshErr != nil {
-		u.logger.Errorf("failed to create refresh token: %s", refreshErr.Error())
-		return nil, errors.GeneralError("failed to generate refresh token")
-	}
-	return &openapi.UserSignupResponse{
-		User:         ptr.To(presenters.PresentUser(createdUser)),
-		JwtToken:     &tokenString,
-		RefreshToken: &refreshToken,
-	}, nil
+func (u usersService) InternalCreate(ctx context.Context, user *models.User) (*models.User, *errors.ServiceError) {
+	return u.userStore.Create(ctx, user)
 }
 
 func (u usersService) InternalCreateOAuthUser(ctx context.Context, email, name, githubID, avatarURL string) (*models.User, error) {

--- a/pkg/stores/org_invite_store.go
+++ b/pkg/stores/org_invite_store.go
@@ -10,6 +10,7 @@ import (
 
 //go:generate mockgen -source=org_invite_store.go -destination=../mocks/mock_org_invite_store.go -package=mocks
 type OrgInviteStore interface {
+	AtomicExecutor
 	Create(ctx context.Context, invite *models.OrgInvite) (*models.OrgInvite, *errors.ServiceError)
 	GetByID(ctx context.Context, id string) (*models.OrgInvite, *errors.ServiceError)
 	GetByTokenHash(ctx context.Context, tokenHash string) (*models.OrgInvite, *errors.ServiceError)

--- a/pkg/stores/pgstore/org_invite_store.go
+++ b/pkg/stores/pgstore/org_invite_store.go
@@ -13,6 +13,7 @@ import (
 
 type orgInviteStore struct {
 	sessionFactory db.SessionFactory
+	atomicExecutor
 }
 
 type OrgInviteStoreSpec struct {
@@ -20,7 +21,10 @@ type OrgInviteStoreSpec struct {
 }
 
 func NewOrgInviteStore(spec OrgInviteStoreSpec) stores.OrgInviteStore {
-	return &orgInviteStore{sessionFactory: spec.SessionFactory}
+	return &orgInviteStore{
+		sessionFactory: spec.SessionFactory,
+		atomicExecutor: atomicExecutor{sessionFactory: spec.SessionFactory},
+	}
 }
 
 func (s *orgInviteStore) Create(ctx context.Context, invite *models.OrgInvite) (*models.OrgInvite, *errors.ServiceError) {

--- a/pkg/worker/invite/invite_worker.go
+++ b/pkg/worker/invite/invite_worker.go
@@ -102,21 +102,28 @@ func (w *inviteWorker) Execute(ctx context.Context, operand worker.Operand) (wor
 
 	w.Logger().Infof("Sending invite email to %s for org %s", invite.Email, orgName)
 
-	emailErr := w.emailService.SendInviteEmail(ctx, emailpkg.InviteEmailParams{
-		ToEmail:     invite.Email,
-		OrgName:     orgName,
-		TeamName:    teamName,
-		InviterName: inviterName,
-		InviteToken: rawToken,
-		ExpiresAt:   invite.ExpiresAt,
+	txErr := w.inviteService.InternalWithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		if markErr := w.inviteService.InternalMarkEmailSent(txCtx, invite.ID); markErr != nil {
+			return markErr
+		}
+		if emailErr := w.emailService.SendInviteEmail(txCtx, emailpkg.InviteEmailParams{
+			ToEmail:     invite.Email,
+			OrgName:     orgName,
+			TeamName:    teamName,
+			InviterName: inviterName,
+			InviteToken: rawToken,
+			ExpiresAt:   invite.ExpiresAt,
+		}); emailErr != nil {
+			return errors.GeneralError("failed to send invite email: %s", emailErr.Error())
+		}
+		return nil
 	})
-	if emailErr != nil {
-		w.Logger().Errorf("failed to send invite email to %s: %s", invite.Email, emailErr.Error())
-		w.inviteService.InternalMarkEmailError(ctx, invite.ID, emailErr.Error())
+	if txErr != nil {
+		w.Logger().Errorf("failed to send invite email to %s: %s", invite.Email, txErr.Error())
+		w.inviteService.InternalMarkEmailError(ctx, invite.ID, txErr.Error())
 		return worker.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
 
-	w.inviteService.InternalMarkEmailSent(ctx, invite.ID)
 	w.Logger().Infof("Invite email sent to %s", invite.Email)
 	return worker.Result{}, nil
 }


### PR DESCRIPTION
Move signup logic from UserService into a dedicated SignupService to reduce coupling. Inject OrgInviteStore as an explicit dependency instead of creating it internally. Add transaction support to invite worker so email sending and status marking are atomic.