### PR TITLE
fix: use controller factory functions to isolate clusters

### DIFF
--- a/cmd/environment/development_environment.go
+++ b/cmd/environment/development_environment.go
@@ -198,48 +198,64 @@ func (d *developmentEnvironment) initializeClusterManager(ctx context.Context) e
 	d.LeadershipFlag = leadershipFlag
 	d.ClusterManager = clustermanager.NewClusterManager(clustermanager.ClusterManagerConfig{
 		LeadershipFlag: leadershipFlag,
-		ControllersToRegister: []clustermanager.Controller{
-			volumecontroller.NewVolumeReconciler(volumecontroller.VolumeReconcilerSpec{
-				Log:            applogger.NewLoggerWithPrefix(ctx, "volume-controller").SetLevel(d.Logger.GetLevel()),
-				StorageService: d.Services.StackStorageService,
-				VolumeService:  d.Services.VolumeService,
-				Env:            d.Env.Name,
-			}),
-			workspaceusercontroller.NewWorkspaceUserReconciler(workspaceusercontroller.WorkspaceUserReconcilerSpec{
-				Log:                  applogger.NewLoggerWithPrefix(ctx, "workspace-user-controller").SetLevel(d.Logger.GetLevel()),
-				WorkspaceUserService: d.Services.WorkspaceUserService,
-				ClusterService:       d.Services.ClusterService,
-				Env:                  d.Env.Name,
-			}),
-			stackcontroller.NewStackReconciler(stackcontroller.StackReconcilerSpec{
-				Log:          applogger.NewLoggerWithPrefix(ctx, "stack-controller").SetLevel(d.Logger.GetLevel()),
-				StackService: d.Services.StackService,
-				Env:          d.Env.Name,
-			}),
-			stackresourcecontroller.NewStackResourceReconciler(stackresourcecontroller.StackResourceReconcilerSpec{
-				Log:                  applogger.NewLoggerWithPrefix(ctx, "stack-resource-controller").SetLevel(d.Logger.GetLevel()),
-				StackService:         d.Services.StackService,
-				StackResourceService: d.Services.StackResourceService,
-				Env:                  d.Env.Name,
-			}),
-			imagebuildcontroller.NewImageBuildReconciler(imagebuildcontroller.ImageBuildReconcilerSpec{
-				Log:                 applogger.NewLoggerWithPrefix(ctx, "image-build-controller").SetLevel(d.Logger.GetLevel()),
-				DBImageBuildService: d.Services.ImageBuildService,
-				DBResourceService:   d.Services.StackResourceService,
-			}),
-			clusterimageregistry.NewClusterImageRegistryReconciler(clusterimageregistry.ClusterImageRegistryReconcilerSpec{
-				Logger:                 applogger.NewLoggerWithPrefix(ctx, "cluster-image-registry-controller").SetLevel(d.Logger.GetLevel()),
-				DBImageRegistryService: d.Services.ClusterImageRegistryService,
-			}),
-			postgresaddoncontroller.NewPostgresAddonReconciler(postgresaddoncontroller.PostgresAddonReconcilerSpec{
-				Log:                  applogger.NewLoggerWithPrefix(ctx, "postgres-addon-controller").SetLevel(d.Logger.GetLevel()),
-				PostgresAddonService: d.Services.PostgresAddonService,
-				Env:                  d.Env.Name,
-			}),
-			postgresbackupcontroller.NewPostgresBackupReconciler(postgresbackupcontroller.PostgresBackupReconcilerSpec{
-				Log:                   applogger.NewLoggerWithPrefix(ctx, "postgres-backup-controller").SetLevel(d.Logger.GetLevel()),
-				PostgresBackupService: d.Services.PostgresBackupService,
-			}),
+		ControllersToRegister: []clustermanager.ControllerFn{
+			func() clustermanager.Controller {
+				return volumecontroller.NewVolumeReconciler(volumecontroller.VolumeReconcilerSpec{
+					Log:            applogger.NewLoggerWithPrefix(ctx, "volume-controller").SetLevel(d.Logger.GetLevel()),
+					StorageService: d.Services.StackStorageService,
+					VolumeService:  d.Services.VolumeService,
+					Env:            d.Env.Name,
+				})
+			},
+			func() clustermanager.Controller {
+				return workspaceusercontroller.NewWorkspaceUserReconciler(workspaceusercontroller.WorkspaceUserReconcilerSpec{
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "workspace-user-controller").SetLevel(d.Logger.GetLevel()),
+					WorkspaceUserService: d.Services.WorkspaceUserService,
+					ClusterService:       d.Services.ClusterService,
+					Env:                  d.Env.Name,
+				})
+			},
+			func() clustermanager.Controller {
+				return stackcontroller.NewStackReconciler(stackcontroller.StackReconcilerSpec{
+					Log:          applogger.NewLoggerWithPrefix(ctx, "stack-controller").SetLevel(d.Logger.GetLevel()),
+					StackService: d.Services.StackService,
+					Env:          d.Env.Name,
+				})
+			},
+			func() clustermanager.Controller {
+				return stackresourcecontroller.NewStackResourceReconciler(stackresourcecontroller.StackResourceReconcilerSpec{
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "stack-resource-controller").SetLevel(d.Logger.GetLevel()),
+					StackService:         d.Services.StackService,
+					StackResourceService: d.Services.StackResourceService,
+					Env:                  d.Env.Name,
+				})
+			},
+			func() clustermanager.Controller {
+				return imagebuildcontroller.NewImageBuildReconciler(imagebuildcontroller.ImageBuildReconcilerSpec{
+					Log:                 applogger.NewLoggerWithPrefix(ctx, "image-build-controller").SetLevel(d.Logger.GetLevel()),
+					DBImageBuildService: d.Services.ImageBuildService,
+					DBResourceService:   d.Services.StackResourceService,
+				})
+			},
+			func() clustermanager.Controller {
+				return clusterimageregistry.NewClusterImageRegistryReconciler(clusterimageregistry.ClusterImageRegistryReconcilerSpec{
+					Logger:                 applogger.NewLoggerWithPrefix(ctx, "cluster-image-registry-controller").SetLevel(d.Logger.GetLevel()),
+					DBImageRegistryService: d.Services.ClusterImageRegistryService,
+				})
+			},
+			func() clustermanager.Controller {
+				return postgresaddoncontroller.NewPostgresAddonReconciler(postgresaddoncontroller.PostgresAddonReconcilerSpec{
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "postgres-addon-controller").SetLevel(d.Logger.GetLevel()),
+					PostgresAddonService: d.Services.PostgresAddonService,
+					Env:                  d.Env.Name,
+				})
+			},
+			func() clustermanager.Controller {
+				return postgresbackupcontroller.NewPostgresBackupReconciler(postgresbackupcontroller.PostgresBackupReconcilerSpec{
+					Log:                   applogger.NewLoggerWithPrefix(ctx, "postgres-backup-controller").SetLevel(d.Logger.GetLevel()),
+					PostgresBackupService: d.Services.PostgresBackupService,
+				})
+			},
 		},
 	})
 	d.Services.ClusterService.InjectClusterManager(d.ClusterManager)

--- a/cmd/environment/test_environment.go
+++ b/cmd/environment/test_environment.go
@@ -471,48 +471,64 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 	te.LeadershipFlag = leadershipFlag
 	te.ClusterManager = clustermanager.NewClusterManager(clustermanager.ClusterManagerConfig{
 		LeadershipFlag: leadershipFlag,
-		ControllersToRegister: []clustermanager.Controller{
-			volumecontroller.NewVolumeReconciler(volumecontroller.VolumeReconcilerSpec{
-				Log:            applogger.NewLoggerWithPrefix(ctx, "test-volume-controller").SetLevel(te.Logger.GetLevel()),
-				StorageService: te.Services.StackStorageService,
-				VolumeService:  te.Services.VolumeService,
-				Env:            te.Env.Name,
-			}),
-			workspaceusercontroller.NewWorkspaceUserReconciler(workspaceusercontroller.WorkspaceUserReconcilerSpec{
-				Log:                  applogger.NewLoggerWithPrefix(ctx, "test-workspace-user-controller").SetLevel(te.Logger.GetLevel()),
-				WorkspaceUserService: te.Services.WorkspaceUserService,
-				ClusterService:       te.Services.ClusterService,
-				Env:                  te.Env.Name,
-			}),
-			stackcontroller.NewStackReconciler(stackcontroller.StackReconcilerSpec{
-				Log:          applogger.NewLoggerWithPrefix(ctx, "test-stack-controller").SetLevel(te.Logger.GetLevel()),
-				StackService: te.Services.StackService,
-				Env:          te.Env.Name,
-			}),
-			stackresourcecontroller.NewStackResourceReconciler(stackresourcecontroller.StackResourceReconcilerSpec{
-				Log:                  applogger.NewLoggerWithPrefix(ctx, "test-stack-resource-controller").SetLevel(te.Logger.GetLevel()),
-				StackService:         te.Services.StackService,
-				StackResourceService: te.Services.StackResourceService,
-				Env:                  te.Env.Name,
-			}),
-			imagebuildcontroller.NewImageBuildReconciler(imagebuildcontroller.ImageBuildReconcilerSpec{
-				Log:                 applogger.NewLoggerWithPrefix(ctx, "test-image-build-controller").SetLevel(te.Logger.GetLevel()),
-				DBImageBuildService: te.Services.ImageBuildService,
-				DBResourceService:   te.Services.StackResourceService,
-			}),
-			clusterimageregistry.NewClusterImageRegistryReconciler(clusterimageregistry.ClusterImageRegistryReconcilerSpec{
-				Logger:                 applogger.NewLoggerWithPrefix(ctx, "test-cluster-image-registry-controller").SetLevel(te.Logger.GetLevel()),
-				DBImageRegistryService: te.Services.ClusterImageRegistryService,
-			}),
-			postgresaddoncontroller.NewPostgresAddonReconciler(postgresaddoncontroller.PostgresAddonReconcilerSpec{
-				Log:                  applogger.NewLoggerWithPrefix(ctx, "test-postgres-addon-controller").SetLevel(te.Logger.GetLevel()),
-				PostgresAddonService: te.Services.PostgresAddonService,
-				Env:                  te.Env.Name,
-			}),
-			postgresbackupcontroller.NewPostgresBackupReconciler(postgresbackupcontroller.PostgresBackupReconcilerSpec{
-				Log:                   applogger.NewLoggerWithPrefix(ctx, "test-postgres-backup-controller").SetLevel(te.Logger.GetLevel()),
-				PostgresBackupService: te.Services.PostgresBackupService,
-			}),
+		ControllersToRegister: []clustermanager.ControllerFn{
+			func() clustermanager.Controller {
+				return volumecontroller.NewVolumeReconciler(volumecontroller.VolumeReconcilerSpec{
+					Log:            applogger.NewLoggerWithPrefix(ctx, "test-volume-controller").SetLevel(te.Logger.GetLevel()),
+					StorageService: te.Services.StackStorageService,
+					VolumeService:  te.Services.VolumeService,
+					Env:            te.Env.Name,
+				})
+			},
+			func() clustermanager.Controller {
+				return workspaceusercontroller.NewWorkspaceUserReconciler(workspaceusercontroller.WorkspaceUserReconcilerSpec{
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-workspace-user-controller").SetLevel(te.Logger.GetLevel()),
+					WorkspaceUserService: te.Services.WorkspaceUserService,
+					ClusterService:       te.Services.ClusterService,
+					Env:                  te.Env.Name,
+				})
+			},
+			func() clustermanager.Controller {
+				return stackcontroller.NewStackReconciler(stackcontroller.StackReconcilerSpec{
+					Log:          applogger.NewLoggerWithPrefix(ctx, "test-stack-controller").SetLevel(te.Logger.GetLevel()),
+					StackService: te.Services.StackService,
+					Env:          te.Env.Name,
+				})
+			},
+			func() clustermanager.Controller {
+				return stackresourcecontroller.NewStackResourceReconciler(stackresourcecontroller.StackResourceReconcilerSpec{
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-stack-resource-controller").SetLevel(te.Logger.GetLevel()),
+					StackService:         te.Services.StackService,
+					StackResourceService: te.Services.StackResourceService,
+					Env:                  te.Env.Name,
+				})
+			},
+			func() clustermanager.Controller {
+				return imagebuildcontroller.NewImageBuildReconciler(imagebuildcontroller.ImageBuildReconcilerSpec{
+					Log:                 applogger.NewLoggerWithPrefix(ctx, "test-image-build-controller").SetLevel(te.Logger.GetLevel()),
+					DBImageBuildService: te.Services.ImageBuildService,
+					DBResourceService:   te.Services.StackResourceService,
+				})
+			},
+			func() clustermanager.Controller {
+				return clusterimageregistry.NewClusterImageRegistryReconciler(clusterimageregistry.ClusterImageRegistryReconcilerSpec{
+					Logger:                 applogger.NewLoggerWithPrefix(ctx, "test-cluster-image-registry-controller").SetLevel(te.Logger.GetLevel()),
+					DBImageRegistryService: te.Services.ClusterImageRegistryService,
+				})
+			},
+			func() clustermanager.Controller {
+				return postgresaddoncontroller.NewPostgresAddonReconciler(postgresaddoncontroller.PostgresAddonReconcilerSpec{
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-postgres-addon-controller").SetLevel(te.Logger.GetLevel()),
+					PostgresAddonService: te.Services.PostgresAddonService,
+					Env:                  te.Env.Name,
+				})
+			},
+			func() clustermanager.Controller {
+				return postgresbackupcontroller.NewPostgresBackupReconciler(postgresbackupcontroller.PostgresBackupReconcilerSpec{
+					Log:                   applogger.NewLoggerWithPrefix(ctx, "test-postgres-backup-controller").SetLevel(te.Logger.GetLevel()),
+					PostgresBackupService: te.Services.PostgresBackupService,
+				})
+			},
 		},
 	})
 	te.Services.ClusterService.InjectClusterManager(te.ClusterManager)

--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -66,7 +66,7 @@ type ClusterManagerImpl struct {
 	supervisor            *suture.Supervisor
 	leadershipFlag        *leadership.Flag
 	registeredClusters    map[string]*ClusterControl
-	controllersToRegister []Controller
+	controllersToRegister []ControllerFn
 	supervisorCancelFn    context.CancelFunc
 	supervisorErr         error
 	isRunning             bool
@@ -127,7 +127,7 @@ func (cc *ClusterControl) String() string {
 // ClusterManagerConfig holds configuration for creating a new ClusterManager
 type ClusterManagerConfig struct {
 	LeadershipFlag        *leadership.Flag
-	ControllersToRegister []Controller
+	ControllersToRegister []ControllerFn
 }
 
 // NewClusterManager creates a new ClusterManager instance
@@ -164,12 +164,17 @@ func (cm *ClusterManagerImpl) RegisterCluster(cluster *models.Cluster) error {
 		return fmt.Errorf("failed to create client for cluster %s: %w", cluster.ID, err)
 	}
 
+	controllers := make([]Controller, len(cm.controllersToRegister))
+	for i, fn := range cm.controllersToRegister {
+		controllers[i] = fn()
+	}
+
 	clusterCtrl := &ClusterControl{
 		cluster:     cluster,
 		clusterID:   cluster.ID,
 		client:      client,
 		restConfig:  restConfig,
-		controllers: cm.controllersToRegister,
+		controllers: controllers,
 	}
 
 	serviceID := cm.supervisor.Add(clusterCtrl)


### PR DESCRIPTION
Each cluster registration now creates fresh controller instances via factory functions instead of sharing a single slice. Previously, registering cluster B would overwrite cluster A's controller clients, silently breaking multi-cluster reconciliation.

Fixes #43