### PR TITLE
fix: encrypt cluster credentials (Token, ClusterCAData) at rest

### DIFF
--- a/cmd/environment/development_environment.go
+++ b/cmd/environment/development_environment.go
@@ -197,7 +197,8 @@ func (d *developmentEnvironment) initializeClusterManager(ctx context.Context) e
 
 	d.LeadershipFlag = leadershipFlag
 	d.ClusterManager = clustermanager.NewClusterManager(clustermanager.ClusterManagerConfig{
-		LeadershipFlag: leadershipFlag,
+		LeadershipFlag:      leadershipFlag,
+		CredentialDecryptor: d.EncryptionService,
 		ControllersToRegister: []clustermanager.ControllerFn{
 			func() clustermanager.Controller {
 				return volumecontroller.NewVolumeReconciler(volumecontroller.VolumeReconcilerSpec{
@@ -300,6 +301,7 @@ func (d *developmentEnvironment) loadServices(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create encryption service: %w", err)
 	}
+	d.EncryptionService = encryptionService
 	stackDomainService := services.NewStackDomainsService(services.StackDomainsServiceSpec{
 		SessionFactory: d.DBSession,
 		Logger:         d.Logger,
@@ -363,6 +365,7 @@ func (d *developmentEnvironment) loadServices(ctx context.Context) error {
 		SessionFactory:       d.DBSession,
 		Logger:               d.Logger,
 		Permissions:          d.PermissionService,
+		EncryptionService:    encryptionService,
 	})
 
 	workspaceUserService := services.NewWorkspaceUserService(services.WorkspaceUserServiceSpec{

--- a/cmd/environment/environment.go
+++ b/cmd/environment/environment.go
@@ -39,6 +39,7 @@ type Env struct {
 	OAuthStateStore             stores.OAuthStateStore
 	EmailService                emailpkg.EmailService
 	LeadershipFlag              *leadership.Flag
+	EncryptionService           services.EncryptionService
 	Logger                      applogger.Logger
 }
 

--- a/cmd/environment/test_environment.go
+++ b/cmd/environment/test_environment.go
@@ -228,6 +228,7 @@ func (te *testEnvironment) loadServices(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create encryption service: %w", err)
 	}
+	te.EncryptionService = encryptionService
 	stackDomainService := services.NewStackDomainsService(services.StackDomainsServiceSpec{
 		SessionFactory: te.DBSession,
 		Logger:         te.Logger,
@@ -291,6 +292,7 @@ func (te *testEnvironment) loadServices(ctx context.Context) error {
 		SessionFactory:       te.DBSession,
 		Logger:               te.Logger,
 		Permissions:          te.PermissionService,
+		EncryptionService:    encryptionService,
 	})
 
 	workspaceUserService := services.NewWorkspaceUserService(services.WorkspaceUserServiceSpec{
@@ -470,7 +472,8 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 
 	te.LeadershipFlag = leadershipFlag
 	te.ClusterManager = clustermanager.NewClusterManager(clustermanager.ClusterManagerConfig{
-		LeadershipFlag: leadershipFlag,
+		LeadershipFlag:      leadershipFlag,
+		CredentialDecryptor: te.EncryptionService,
 		ControllersToRegister: []clustermanager.ControllerFn{
 			func() clustermanager.Controller {
 				return volumecontroller.NewVolumeReconciler(volumecontroller.VolumeReconcilerSpec{

--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -30,6 +30,10 @@ import (
 	usersv1alpha1 "stackdome.io/cluster-agent/api/users/v1alpha1"
 )
 
+type CredentialDecryptor interface {
+	DecryptData(in string) ([]byte, error)
+}
+
 // ClusterManager defines the interface for managing clusters
 type ClusterManager interface {
 	RegisterCluster(cluster *models.Cluster) error
@@ -67,6 +71,7 @@ type ClusterManagerImpl struct {
 	leadershipFlag        *leadership.Flag
 	registeredClusters    map[string]*ClusterControl
 	controllersToRegister []ControllerFn
+	credentialDecryptor   CredentialDecryptor
 	supervisorCancelFn    context.CancelFunc
 	supervisorErr         error
 	isRunning             bool
@@ -128,6 +133,7 @@ func (cc *ClusterControl) String() string {
 type ClusterManagerConfig struct {
 	LeadershipFlag        *leadership.Flag
 	ControllersToRegister []ControllerFn
+	CredentialDecryptor   CredentialDecryptor
 }
 
 // NewClusterManager creates a new ClusterManager instance
@@ -135,6 +141,7 @@ func NewClusterManager(config ClusterManagerConfig) ClusterManager {
 	return &ClusterManagerImpl{
 		leadershipFlag:        config.LeadershipFlag,
 		controllersToRegister: config.ControllersToRegister,
+		credentialDecryptor:   config.CredentialDecryptor,
 		registeredClusters:    make(map[string]*ClusterControl),
 		supervisor:            suture.NewSimple("cluster-manager"),
 	}
@@ -147,6 +154,10 @@ func (cm *ClusterManagerImpl) RegisterCluster(cluster *models.Cluster) error {
 
 	if _, exists := cm.registeredClusters[cluster.ID]; exists {
 		return nil
+	}
+
+	if err := cm.decryptClusterCredentials(cluster); err != nil {
+		return fmt.Errorf("failed to decrypt credentials for cluster %s: %w", cluster.ID, err)
 	}
 
 	restConfig, err := createRestConfig(cluster)
@@ -180,6 +191,26 @@ func (cm *ClusterManagerImpl) RegisterCluster(cluster *models.Cluster) error {
 	serviceID := cm.supervisor.Add(clusterCtrl)
 	clusterCtrl.serviceID = serviceID
 	cm.registeredClusters[cluster.ID] = clusterCtrl
+	return nil
+}
+
+func (cm *ClusterManagerImpl) decryptClusterCredentials(cluster *models.Cluster) error {
+	if cluster.Token != "" && cluster.ClusterCAData != "" {
+		return nil
+	}
+	if cluster.EncryptedToken == "" || cluster.EncryptedClusterCAData == "" {
+		return fmt.Errorf("cluster %s has no encrypted credentials", cluster.ID)
+	}
+	token, err := cm.credentialDecryptor.DecryptData(cluster.EncryptedToken)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt token: %w", err)
+	}
+	caData, err := cm.credentialDecryptor.DecryptData(cluster.EncryptedClusterCAData)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt CA data: %w", err)
+	}
+	cluster.Token = string(token)
+	cluster.ClusterCAData = string(caData)
 	return nil
 }
 

--- a/pkg/db/migrations/202605140001_encrypt_cluster_credentials.go
+++ b/pkg/db/migrations/202605140001_encrypt_cluster_credentials.go
@@ -1,0 +1,35 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func encryptClusterCredentials() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202605140001_encrypt_cluster_credentials",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.Exec("ALTER TABLE clusters ADD COLUMN IF NOT EXISTS encrypted_token TEXT NOT NULL DEFAULT ''").Error; err != nil {
+				return fmt.Errorf("error adding encrypted_token column: %w", err)
+			}
+			if err := tx.Exec("ALTER TABLE clusters ADD COLUMN IF NOT EXISTS encrypted_cluster_ca_data TEXT NOT NULL DEFAULT ''").Error; err != nil {
+				return fmt.Errorf("error adding encrypted_cluster_ca_data column: %w", err)
+			}
+			if err := tx.Exec("ALTER TABLE clusters DROP CONSTRAINT IF EXISTS clusters_token_check").Error; err != nil {
+				return fmt.Errorf("error dropping token check constraint: %w", err)
+			}
+			if err := tx.Exec("ALTER TABLE clusters DROP CONSTRAINT IF EXISTS clusters_cluster_ca_data_check").Error; err != nil {
+				return fmt.Errorf("error dropping cluster_ca_data check constraint: %w", err)
+			}
+			if err := tx.Exec("ALTER TABLE clusters DROP COLUMN IF EXISTS token").Error; err != nil {
+				return fmt.Errorf("error dropping token column: %w", err)
+			}
+			if err := tx.Exec("ALTER TABLE clusters DROP COLUMN IF EXISTS cluster_ca_data").Error; err != nil {
+				return fmt.Errorf("error dropping cluster_ca_data column: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -51,4 +51,5 @@ var MigrationList = []*gormigrate.Migration{
 	createOAuthStatesTable(),
 	createOrgInvitesTable(),
 	addInviteTokenToOAuthStates(),
+	encryptClusterCredentials(),
 }

--- a/pkg/models/cluster.go
+++ b/pkg/models/cluster.go
@@ -5,15 +5,19 @@ import (
 )
 
 type Cluster struct {
-	ID              string `gorm:"primary_key;default:gen_random_uuid()"`
-	OrganisationID  string `gorm:"unique;not null"`
-	Name            string `gorm:"not null;check:name <> ''"`
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
-	Default         bool
-	ClusterURL      string `gorm:"not null;check:cluster_url <> ''"`
-	ClusterCAData   string `gorm:"not null;check:cluster_ca_data <> ''"`
-	Token           string `gorm:"not null;check:token <> ''"`
-	ManagerRunning  bool
-	ImageRegistries []*ClusterImageRegistry `gorm:"foreignKey:ClusterID"`
+	ID                     string `gorm:"primary_key;default:gen_random_uuid()"`
+	OrganisationID         string `gorm:"unique;not null"`
+	Name                   string `gorm:"not null;check:name <> ''"`
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	Default                bool
+	ClusterURL             string `gorm:"not null;check:cluster_url <> ''"`
+	EncryptedClusterCAData string `gorm:"not null"`
+	EncryptedToken         string `gorm:"not null"`
+	ManagerRunning         bool
+	ImageRegistries        []*ClusterImageRegistry `gorm:"foreignKey:ClusterID"`
+
+	// Transient fields — populated by service layer after decryption, never persisted
+	ClusterCAData string `gorm:"-"`
+	Token         string `gorm:"-"`
 }

--- a/pkg/services/cluster_service.go
+++ b/pkg/services/cluster_service.go
@@ -35,6 +35,7 @@ type clusterService struct {
 	clusterManager       clustermanager.ClusterManager
 	imageRegistryService ImageRegistryService
 	permissions          auth.PermissionService
+	encryptionService    EncryptionService
 }
 
 func NewClusterService(spec ClusterServiceSpec) ClusterService {
@@ -46,6 +47,7 @@ func NewClusterService(spec ClusterServiceSpec) ClusterService {
 		logger:               spec.Logger,
 		imageRegistryService: spec.ImageRegistryService,
 		permissions:          spec.Permissions,
+		encryptionService:    spec.EncryptionService,
 	}
 }
 
@@ -54,6 +56,7 @@ type ClusterServiceSpec struct {
 	ClusterManager       clustermanager.ClusterManager
 	ImageRegistryService ImageRegistryService
 	Permissions          auth.PermissionService
+	EncryptionService    EncryptionService
 	Logger               logger.Logger
 }
 
@@ -68,6 +71,12 @@ func (s *clusterService) InternalListAllClusters(ctx context.Context) ([]*models
 	if err != nil {
 		s.logger.Errorf("failed to list all clusters: %v", err)
 		return nil, err
+	}
+	for _, cluster := range clusters {
+		if decErr := s.decryptClusterCredentials(cluster); decErr != nil {
+			s.logger.Errorf("failed to decrypt cluster credentials for cluster %s: %v", cluster.ID, decErr)
+			return nil, decErr
+		}
 	}
 	return clusters, nil
 }
@@ -97,14 +106,17 @@ func (s *clusterService) AddCluster(ctx context.Context, cluster *models.Cluster
 		return nil, err
 	}
 
+	if encErr := s.encryptClusterCredentials(cluster); encErr != nil {
+		s.logger.Errorf("failed to encrypt cluster credentials: %v", encErr)
+		return nil, encErr
+	}
+
 	cerr := s.clusterStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
-		// Create the cluster in the database
 		createdCluster, createdErr = s.clusterStore.CreateWithTx(ctx, cluster)
 		if createdErr != nil {
 			return createdErr
 		}
 
-		// Register the cluster with the cluster manager
 		merr := s.clusterManager.RegisterCluster(createdCluster)
 		if merr != nil {
 			return errors.GeneralError("failed to register cluster with manager")
@@ -131,7 +143,6 @@ func (s *clusterService) AddCluster(ctx context.Context, cluster *models.Cluster
 }
 
 func (s *clusterService) Delete(ctx context.Context, ID string) *errors.ServiceError {
-	// Get the cluster from the database
 	cluster, err := s.clusterStore.Get(ctx, ID)
 	if err != nil {
 		s.logger.Errorf("failed to get cluster: %v", err)
@@ -265,6 +276,10 @@ func (s *clusterService) GetClusterForOrg(ctx context.Context, orgID string) (*m
 		s.logger.Errorf("failed to get cluster for org: %v", err)
 		return nil, err
 	}
+	if decErr := s.decryptClusterCredentials(cluster); decErr != nil {
+		s.logger.Errorf("failed to decrypt cluster credentials: %v", decErr)
+		return nil, decErr
+	}
 	return cluster, nil
 }
 
@@ -273,6 +288,10 @@ func (s *clusterService) GetDefaultCluster(ctx context.Context) (*models.Cluster
 	if err != nil {
 		s.logger.Errorf("failed to get default cluster: %v", err)
 		return nil, err
+	}
+	if decErr := s.decryptClusterCredentials(cluster); decErr != nil {
+		s.logger.Errorf("failed to decrypt cluster credentials: %v", decErr)
+		return nil, decErr
 	}
 	return cluster, nil
 }
@@ -286,11 +305,50 @@ func (s *clusterService) Get(ctx context.Context, ID string) (*models.Cluster, *
 	if permErr := s.permissions.Check(ctx, cluster.OrganisationID, auth.ResourceClusters, ID, auth.ActionRead); permErr != nil {
 		return nil, permErr
 	}
+	if decErr := s.decryptClusterCredentials(cluster); decErr != nil {
+		s.logger.Errorf("failed to decrypt cluster credentials: %v", decErr)
+		return nil, decErr
+	}
 	return cluster, nil
 }
 
 func (s *clusterService) InternalGet(ctx context.Context, ID string) (*models.Cluster, *errors.ServiceError) {
-	return s.clusterStore.Get(ctx, ID)
+	cluster, err := s.clusterStore.Get(ctx, ID)
+	if err != nil {
+		return nil, err
+	}
+	if decErr := s.decryptClusterCredentials(cluster); decErr != nil {
+		return nil, decErr
+	}
+	return cluster, nil
+}
+
+func (s *clusterService) encryptClusterCredentials(cluster *models.Cluster) *errors.ServiceError {
+	encryptedToken, err := s.encryptionService.EncryptData([]byte(cluster.Token))
+	if err != nil {
+		return errors.GeneralError("failed to encrypt cluster token: %v", err)
+	}
+	encryptedCAData, err := s.encryptionService.EncryptData([]byte(cluster.ClusterCAData))
+	if err != nil {
+		return errors.GeneralError("failed to encrypt cluster CA data: %v", err)
+	}
+	cluster.EncryptedToken = encryptedToken
+	cluster.EncryptedClusterCAData = encryptedCAData
+	return nil
+}
+
+func (s *clusterService) decryptClusterCredentials(cluster *models.Cluster) *errors.ServiceError {
+	token, err := s.encryptionService.DecryptData(cluster.EncryptedToken)
+	if err != nil {
+		return errors.GeneralError("failed to decrypt cluster token: %v", err)
+	}
+	caData, err := s.encryptionService.DecryptData(cluster.EncryptedClusterCAData)
+	if err != nil {
+		return errors.GeneralError("failed to decrypt cluster CA data: %v", err)
+	}
+	cluster.Token = string(token)
+	cluster.ClusterCAData = string(caData)
+	return nil
 }
 
 func IsBase64(s string) bool {


### PR DESCRIPTION
Cluster credentials were stored as base64-encoded plaintext in PostgreSQL. A DB compromise would expose service account tokens and CA certificates for all managed clusters.

Reuses the existing AES-256-GCM EncryptionService to encrypt credentials in the service layer before writing to the store, and decrypt after reading. The cluster manager also decrypts via a CredentialDecryptor interface in RegisterCluster so any caller is safe regardless of whether credentials were pre-decrypted.

Migration adds encrypted columns and drops the old plaintext columns.

Closes #42