### PR TITLE
Fix: Resolve all frontend eslint errors

### DIFF
--- a/frontend/src/components/theme-toggle.tsx
+++ b/frontend/src/components/theme-toggle.tsx
@@ -6,10 +6,10 @@ export function ThemeToggle() {
   const { setTheme } = useTheme();
 
   return (
-    <Button 
-      variant="ghost" 
-      size="icon" 
-      className="rounded-full" 
+    <Button
+      variant="ghost"
+      size="icon"
+      className="rounded-full"
       onClick={() => setTheme(document.documentElement.classList.contains('dark') ? 'light' : 'dark')}
     >
       <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />

--- a/frontend/src/hooks/use-theme.ts
+++ b/frontend/src/hooks/use-theme.ts
@@ -2,7 +2,7 @@ import { useTheme as useThemeContext } from "@/contexts/theme-provider";
 
 /**
  * A hook to access the theme context
- * 
+ *
  * @returns {object} An object with theme and setTheme
  */
 export const useTheme = useThemeContext;

--- a/frontend/src/lib/yaml-parser.ts
+++ b/frontend/src/lib/yaml-parser.ts
@@ -1,6 +1,6 @@
 import { load } from "js-yaml";
 
-type StackCompose = Record<string, any>;
+type StackCompose = Record<string, unknown>;
 
 // Sample stack configuration for demo purposes
 const SAMPLE_STACK = `
@@ -103,23 +103,23 @@ volumes:
 
 export function parseYaml(yamlContent: string): StackCompose {
   try {
-    const parsed = load(yamlContent) as Record<string, any>;
-    
+    const parsed = load(yamlContent) as Record<string, unknown>;
+
     // Basic validation
     if (typeof parsed !== 'object' || parsed === null) {
       throw new Error("Invalid YAML: Expected an object");
     }
-    
+
     // Convert the parsed YAML to our StackCompose type
     const stackCompose: StackCompose = { ...parsed };
-    
+
     // Remove any non-object properties except for 'volumes'
     Object.keys(stackCompose).forEach(key => {
       if (key !== 'volumes' && (typeof stackCompose[key] !== 'object' || stackCompose[key] === null)) {
         delete stackCompose[key];
       }
     });
-    
+
     return stackCompose;
   } catch (error) {
     console.error("Failed to parse YAML:", error);

--- a/frontend/src/pages/stacks/components/create/index.tsx
+++ b/frontend/src/pages/stacks/components/create/index.tsx
@@ -484,73 +484,73 @@ export default function StackCreatePage() {
 
       <div className="flex flex-col gap-8">
         <Panel title="Stack Information">
-            <div className="grid gap-6 max-w-5xl">
-              <div>
-                <UILabel htmlFor="stack-name" className="text-sm font-medium flex items-center gap-1 mb-2">
+          <div className="grid gap-6 max-w-5xl">
+            <div>
+              <UILabel htmlFor="stack-name" className="text-sm font-medium flex items-center gap-1 mb-2">
                   Stack Name <span className="text-[15px] font-semibold text-brand/80 leading-none" aria-hidden>*</span>
-                </UILabel>
-                <Input
-                  id="stack-name"
-                  value={formData.name || ""}
-                  onChange={(e) => handleChange("name", e.target.value)}
-                  className={`max-w-md ${formErrors.name ? "border-danger" : ""}`}
-                  placeholder="my-application-stack"
-                  required
-                  aria-invalid={!!formErrors.name}
-                />
-                <FieldError>{formErrors.name}</FieldError>
-              </div>
-
-              <div>
-                <UILabel htmlFor="stack-labels" className="text-sm font-medium flex items-center gap-1 mb-2">
-                  Labels
-                </UILabel>
-                <div className="flex items-center">
-                  <Input
-                    id="stack-labels"
-                    value={currentLabelInput}
-                    onChange={handleLabelInputChange}
-                    onKeyDown={handleAddLabel}
-                    className={`max-w-md ${formErrors.labels ? "border-danger" : ""}`}
-                    placeholder="e.g., dev, prod, mytag (press Enter to add)"
-                    aria-invalid={!!formErrors.labels}
-                  />
-                </div>
-                <FieldError className="whitespace-pre-line">{formErrors.labels}</FieldError>
-                {(formData.labels || []).map((_label, idx) => {
-                  const keyError = formErrors[`labels.${idx}.key`];
-                  const valueError = formErrors[`labels.${idx}.value`];
-                  const itemError = formErrors[`labels.${idx}`];
-                  return (
-                    <Fragment key={`label-err-${idx}`}>
-                      <FieldError>{itemError && `Label ${idx + 1}: ${itemError}`}</FieldError>
-                      <FieldError>{keyError && `Label ${idx + 1} Key: ${keyError}`}</FieldError>
-                      <FieldError>{valueError && `Label ${idx + 1} Value: ${valueError}`}</FieldError>
-                    </Fragment>
-                  );
-                })}
-                {(formData.labels && formData.labels.length > 0) && (
-                  <div className="flex flex-wrap gap-2 mt-3">
-                    {(formData.labels).map((label, idx) => (
-                      <Badge
-                        key={idx}
-                        variant="secondary"
-                        className="flex items-center gap-1 px-2.5 py-1"
-                      >
-                        <span>{label.value}</span>
-                        <button
-                          onClick={() => removeLabel(idx)}
-                          className="ml-1 rounded-full hover:bg-secondary-foreground/20 h-4 w-4 flex items-center justify-center"
-                          type="button"
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
-                      </Badge>
-                    ))}
-                  </div>
-                )}
-              </div>
+              </UILabel>
+              <Input
+                id="stack-name"
+                value={formData.name || ""}
+                onChange={(e) => handleChange("name", e.target.value)}
+                className={`max-w-md ${formErrors.name ? "border-danger" : ""}`}
+                placeholder="my-application-stack"
+                required
+                aria-invalid={!!formErrors.name}
+              />
+              <FieldError>{formErrors.name}</FieldError>
             </div>
+
+            <div>
+              <UILabel htmlFor="stack-labels" className="text-sm font-medium flex items-center gap-1 mb-2">
+                  Labels
+              </UILabel>
+              <div className="flex items-center">
+                <Input
+                  id="stack-labels"
+                  value={currentLabelInput}
+                  onChange={handleLabelInputChange}
+                  onKeyDown={handleAddLabel}
+                  className={`max-w-md ${formErrors.labels ? "border-danger" : ""}`}
+                  placeholder="e.g., dev, prod, mytag (press Enter to add)"
+                  aria-invalid={!!formErrors.labels}
+                />
+              </div>
+              <FieldError className="whitespace-pre-line">{formErrors.labels}</FieldError>
+              {(formData.labels || []).map((_label, idx) => {
+                const keyError = formErrors[`labels.${idx}.key`];
+                const valueError = formErrors[`labels.${idx}.value`];
+                const itemError = formErrors[`labels.${idx}`];
+                return (
+                  <Fragment key={`label-err-${idx}`}>
+                    <FieldError>{itemError && `Label ${idx + 1}: ${itemError}`}</FieldError>
+                    <FieldError>{keyError && `Label ${idx + 1} Key: ${keyError}`}</FieldError>
+                    <FieldError>{valueError && `Label ${idx + 1} Value: ${valueError}`}</FieldError>
+                  </Fragment>
+                );
+              })}
+              {(formData.labels && formData.labels.length > 0) && (
+                <div className="flex flex-wrap gap-2 mt-3">
+                  {(formData.labels).map((label, idx) => (
+                    <Badge
+                      key={idx}
+                      variant="secondary"
+                      className="flex items-center gap-1 px-2.5 py-1"
+                    >
+                      <span>{label.value}</span>
+                      <button
+                        onClick={() => removeLabel(idx)}
+                        className="ml-1 rounded-full hover:bg-secondary-foreground/20 h-4 w-4 flex items-center justify-center"
+                        type="button"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
         </Panel>
         <Panel
           title="Stack Resources"
@@ -558,23 +558,23 @@ export default function StackCreatePage() {
           bodyClassName="p-0"
           invalid={!!formErrors["spec.stack_resources"]}
         >
-            <StackResourcesForm
-              resources={formData.spec?.stack_resources || []}
-              onResourcesChange={handleResourcesChange}
-              errors={resourcesErrors}
-              emptyError={formErrors["spec.stack_resources"]}
-              volumes={formData.spec?.volumes || []}
-              availableAddonIds={(() => {
-                const ids = new Set(linkedAddonIds);
-                for (const r of formData.spec?.stack_resources || []) {
-                  const envs = (r?.execution_config?.environment_variables || []) as Array<{ from?: string; addonId?: string }>;
-                  for (const e of envs) {
-                    if (e.from === "addon" && e.addonId) ids.add(e.addonId);
-                  }
+          <StackResourcesForm
+            resources={formData.spec?.stack_resources || []}
+            onResourcesChange={handleResourcesChange}
+            errors={resourcesErrors}
+            emptyError={formErrors["spec.stack_resources"]}
+            volumes={formData.spec?.volumes || []}
+            availableAddonIds={(() => {
+              const ids = new Set(linkedAddonIds);
+              for (const r of formData.spec?.stack_resources || []) {
+                const envs = (r?.execution_config?.environment_variables || []) as Array<{ from?: string; addonId?: string }>;
+                for (const e of envs) {
+                  if (e.from === "addon" && e.addonId) ids.add(e.addonId);
                 }
-                return ids;
-              })()}
-            />
+              }
+              return ids;
+            })()}
+          />
         </Panel>
 
         <Panel
@@ -582,11 +582,11 @@ export default function StackCreatePage() {
           count={formData.spec?.volumes?.length ?? 0}
           bodyClassName="p-0"
         >
-            <StackVolumesForm
-              volumes={formData.spec?.volumes || []}
-              onVolumesChange={handleVolumesChange}
-              errors={volumesErrors}
-            />
+          <StackVolumesForm
+            volumes={formData.spec?.volumes || []}
+            onVolumesChange={handleVolumesChange}
+            errors={volumesErrors}
+          />
         </Panel>
 
         <AddonsInStackPanel

--- a/frontend/src/pages/stacks/components/detail/stack-resource-detail.tsx
+++ b/frontend/src/pages/stacks/components/detail/stack-resource-detail.tsx
@@ -46,9 +46,9 @@ export default function StackResourceDetail({
   const statusVariant = variantFromState(statusObj.state);
   const statusDotColor =
     statusVariant === "ready" ? "bg-success"
-    : statusVariant === "error" ? "bg-danger"
-    : statusVariant === "pending" ? "bg-warn"
-    : "bg-muted-foreground";
+      : statusVariant === "error" ? "bg-danger"
+        : statusVariant === "pending" ? "bg-warn"
+          : "bg-muted-foreground";
 
   const ensureAbsoluteUrl = (url: string): string => {
     if (!url) return url;

--- a/frontend/src/pages/stacks/components/shared/env-row.tsx
+++ b/frontend/src/pages/stacks/components/shared/env-row.tsx
@@ -87,8 +87,8 @@ export function EnvRow({
         isOrphanAddon
           ? "border-l-4 border-l-warn/60 pl-2 bg-warn/5"
           : isDirty
-          ? "border-l-4 border-l-brand bg-brand-bg"
-          : ""
+            ? "border-l-4 border-l-brand bg-brand-bg"
+            : ""
       }`}
       data-testid={`env-row-${resourceIndex}-${index}`}
       onBlur={onBlur}

--- a/frontend/src/pages/stacks/components/shared/stack-resource-deployment-tab.tsx
+++ b/frontend/src/pages/stacks/components/shared/stack-resource-deployment-tab.tsx
@@ -35,7 +35,7 @@ export interface DeploymentDraft {
 
 export function pickDeploymentDraft(resource: Resource): DeploymentDraft {
   const ec = resource.execution_config;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   const stripped = ec ? (() => { const { environment_variables, ...rest } = ec; return rest; })() : undefined;
   return {
     init_spec: resource.init_spec,

--- a/frontend/src/pages/stacks/components/shared/stack-resource-item.tsx
+++ b/frontend/src/pages/stacks/components/shared/stack-resource-item.tsx
@@ -136,9 +136,9 @@ function StackResourceItemImpl({
   const statusVariant = variantFromState(statusObj.state);
   const statusDotColor =
     statusVariant === "ready" ? "bg-success"
-    : statusVariant === "error" ? "bg-danger"
-    : statusVariant === "pending" ? "bg-warn"
-    : "bg-muted-foreground";
+      : statusVariant === "error" ? "bg-danger"
+        : statusVariant === "pending" ? "bg-warn"
+          : "bg-muted-foreground";
 
   // Per-tab projections. Done in useMemo so the projected object's identity
   // only changes when the tab's own fields change — which is what lets

--- a/frontend/src/pages/stacks/lib/stack-diff.ts
+++ b/frontend/src/pages/stacks/lib/stack-diff.ts
@@ -179,15 +179,15 @@ function diffOneResource(
   const dirty = isResourceDirty(d, b);
   const entry: ResourceDiffEntry = dirty
     ? {
-        dirty: true,
-        stats: {
-          rowsChanged: countEnvRowsChanged(d, b),
-          fieldsChanged: countChangedFields(
+      dirty: true,
+      stats: {
+        rowsChanged: countEnvRowsChanged(d, b),
+        fieldsChanged: countChangedFields(
             d as Record<string, unknown> | undefined,
             b as Record<string, unknown> | undefined,
-          ),
-        },
-      }
+        ),
+      },
+    }
     : { dirty: false };
   if (d && typeof d === "object") resourceDiffCache.set(d, entry);
   return entry;
@@ -204,14 +204,14 @@ function diffOneVolume(
   const dirty = isVolumeDirty(d, b);
   const entry: VolumeDiffEntry = dirty
     ? {
-        dirty: true,
-        stats: {
-          fieldsChanged: countChangedFields(
+      dirty: true,
+      stats: {
+        fieldsChanged: countChangedFields(
             d as Record<string, unknown> | undefined,
             b as Record<string, unknown> | undefined,
-          ),
-        },
-      }
+        ),
+      },
+    }
     : { dirty: false };
   if (d && typeof d === "object") volumeDiffCache.set(d, entry);
   return entry;

--- a/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
+++ b/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
@@ -3,7 +3,11 @@ import {
   convertApiResourceToFormResource,
   convertFormStackToApiStack,
 } from "../form-schema";
+import type { FormStackData } from "../form-schema";
 import type { StackResource } from "@/api/stacks";
+
+type ApiResourceArg = Parameters<typeof convertApiResourceToFormResource>[0];
+type Loose = Record<string, unknown>;
 
 const TOOLJET_ADDON_ID = "57fa98c8-27ca-47a8-9761-15504d60d349";
 
@@ -24,12 +28,12 @@ const baseResource = (extras: Partial<StackResource["execution_config"]> = {}) =
 describe("env round-trip", () => {
   it("loads a stack literal env var as a 'stack' row", () => {
     const r = baseResource({ environment_variables: [{ name: "PORT", value: "80" }] });
-    const form = convertApiResourceToFormResource(r as any);
+    const form = convertApiResourceToFormResource(r as unknown as ApiResourceArg);
     expect(form.execution_config?.environment_variables).toHaveLength(1);
     const row = form.execution_config!.environment_variables![0];
     expect(row.from).toBe("stack");
     expect(row.name).toBe("PORT");
-    expect((row as any).value).toBe("80");
+    expect((row as Loose).value).toBe("80");
   });
 
   it("loads a secret-backed env var as a 'secret' row", () => {
@@ -38,11 +42,11 @@ describe("env round-trip", () => {
         { name: "STRIPE", secret_ref: { secret_id: "sec-1" }, key: "live" },
       ],
     });
-    const form = convertApiResourceToFormResource(r as any);
+    const form = convertApiResourceToFormResource(r as unknown as ApiResourceArg);
     const row = form.execution_config!.environment_variables![0];
     expect(row.from).toBe("secret");
-    expect((row as any).secretId).toBe("sec-1");
-    expect((row as any).secretKey).toBe("live");
+    expect((row as Loose).secretId).toBe("sec-1");
+    expect((row as Loose).secretKey).toBe("live");
   });
 
   it("fans out one env_from_addons entry into one row per credField", () => {
@@ -62,7 +66,7 @@ describe("env round-trip", () => {
         },
       ],
     });
-    const form = convertApiResourceToFormResource(r as any);
+    const form = convertApiResourceToFormResource(r as unknown as ApiResourceArg);
     const addonRows = form.execution_config!.environment_variables!.filter(
       (r) => r.from === "addon",
     );
@@ -71,10 +75,10 @@ describe("env round-trip", () => {
       ["PG_HOST", "PG_PORT", "PG_USER"].sort(),
     );
     addonRows.forEach((r) => {
-      expect((r as any).addonId).toBe(TOOLJET_ADDON_ID);
-      expect((r as any).database).toBe("tooljet");
-      expect((r as any).superuser).toBe(false);
-      expect((r as any).addonType).toBe("postgres");
+      expect((r as Loose).addonId).toBe(TOOLJET_ADDON_ID);
+      expect((r as Loose).database).toBe("tooljet");
+      expect((r as Loose).superuser).toBe(false);
+      expect((r as Loose).addonType).toBe("postgres");
     });
   });
 
@@ -98,7 +102,7 @@ describe("env round-trip", () => {
         volumes: [],
       },
     };
-    const api = convertFormStackToApiStack(formStack as any);
+    const api = convertFormStackToApiStack(formStack as unknown as FormStackData);
     const ec = api.spec.stack_resources[0].execution_config!;
     expect(ec.env_from_addons).toHaveLength(1);
     expect(ec.env_from_addons![0].postgres!.addon_id).toBe(TOOLJET_ADDON_ID);
@@ -130,7 +134,7 @@ describe("env round-trip", () => {
         volumes: [],
       },
     };
-    const api = convertFormStackToApiStack(formStack as any);
+    const api = convertFormStackToApiStack(formStack as unknown as FormStackData);
     const entries = api.spec.stack_resources[0].execution_config!.env_from_addons!;
     expect(entries).toHaveLength(2);
     const dbs = entries.map((e) => e.postgres!.database).sort();
@@ -156,7 +160,7 @@ describe("env round-trip", () => {
         volumes: [],
       },
     };
-    const api = convertFormStackToApiStack(formStack as any);
+    const api = convertFormStackToApiStack(formStack as unknown as FormStackData);
     const pg = api.spec.stack_resources[0].execution_config!.env_from_addons![0].postgres!;
     expect(pg.superuser).toBe(true);
     expect(pg.database).toBeUndefined();
@@ -179,7 +183,7 @@ describe("env round-trip", () => {
         },
       ],
     });
-    const form = convertApiResourceToFormResource(r as any);
+    const form = convertApiResourceToFormResource(r as unknown as ApiResourceArg);
     const rows = form.execution_config!.environment_variables!;
     expect(rows.map((r) => r.from).sort()).toEqual(["addon", "secret", "stack"]);
   });
@@ -214,7 +218,7 @@ describe("env round-trip", () => {
         volumes: [],
       },
     };
-    const api = convertFormStackToApiStack(formStack as any);
+    const api = convertFormStackToApiStack(formStack as unknown as FormStackData);
     const entries = api.spec.stack_resources[0].execution_config!.env_from_addons!;
     expect(entries).toHaveLength(1);
     expect(entries[0].postgres!.addon_id).toBe("deleted-addon-id");
@@ -240,7 +244,7 @@ describe("env round-trip", () => {
         volumes: [],
       },
     };
-    const api = convertFormStackToApiStack(formStack as any);
+    const api = convertFormStackToApiStack(formStack as unknown as FormStackData);
     const ec = api.spec.stack_resources[0].execution_config!;
     expect(ec.env_from_addons ?? []).toHaveLength(0);
   });


### PR DESCRIPTION
## 📝 What this does
Clears every eslint error in the frontend (134 → 0) so lint stops blocking CI and PRs. No behavior change — formatting and type-safety only.

## 🔀 Changes
- Ran `eslint --fix` for indentation and style violations across the stacks pages
- Replaced explicit `any` in the form-schema test with typed casts
- Tightened `yaml-parser` from `Record<string, any>` to `Record<string, unknown>`
- Only pre-existing `react-refresh` warnings remain (non-blocking)