### PR TITLE
CI: add frontend lint and test workflow

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: frontend/package.json
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -1,0 +1,41 @@
+name: Frontend
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - frontend/**
+      - .github/workflows/frontend.yaml
+
+concurrency:
+  group: frontend-${{ github.head_ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: frontend
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test:run

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -17,6 +17,7 @@ defaults:
 
 jobs:
   frontend:
+    name: lint & test
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## 📝 What this does
Adds a CI gate for the frontend. Until now only the Go integration suite ran in CI — frontend lint and unit tests could regress unnoticed. This workflow runs ESLint and Vitest on every PR to `main` that touches frontend code.

The workflow is path-filtered to `frontend/**` (and the workflow file itself), so backend-only PRs skip it. Verified locally against current `main`: lint passes (0 errors), all 231 tests pass.