### PR TITLE
Fix stack connections unique constraint for multi-database addon wiring

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -37,8 +37,16 @@ jobs:
       - name: Configure private module access
         run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
 
+      - name: Install Mage
+        run: go install github.com/magefile/mage@latest
+
       - name: Download dependencies
         run: go mod download
+        env:
+          GOPRIVATE: github.com/ashishmax31/*,stackdome.io/*,github.com/Stackdome/*
+
+      - name: Run unit tests
+        run: mage test:unit
         env:
           GOPRIVATE: github.com/ashishmax31/*,stackdome.io/*,github.com/Stackdome/*
 

--- a/Makefile
+++ b/Makefile
@@ -61,27 +61,31 @@ PG_PORT := 5432
 .PHONY: ensure-postgres
 ensure-postgres: SHELL := /usr/bin/env bash
 ensure-postgres: ## Start the dev PostgreSQL container if it isn't already running.
-	@if $(DOCKER) ps --format '{{.Names}}' | grep -q '^$(PG_CONTAINER)$$'; then \
-		echo "PostgreSQL container '$(PG_CONTAINER)' already running."; \
-	elif $(DOCKER) ps -a --format '{{.Names}}' | grep -q '^$(PG_CONTAINER)$$'; then \
-		echo "Starting existing PostgreSQL container '$(PG_CONTAINER)'..."; \
-		$(DOCKER) start $(PG_CONTAINER); \
+	@if pg_isready -h localhost -p $(PG_PORT) -q 2>/dev/null; then \
+		echo "PostgreSQL already listening on port $(PG_PORT), skipping container setup."; \
 	else \
-		echo "Creating PostgreSQL container '$(PG_CONTAINER)'..."; \
-		$(DOCKER) run --name $(PG_CONTAINER) \
-			-e POSTGRES_USER=$(PG_USER) \
-			-e POSTGRES_PASSWORD=$(PG_PASSWORD) \
-			-e POSTGRES_DB=$(PG_DB) \
-			-p $(PG_PORT):5432 \
-			-d postgres; \
+		if $(DOCKER) ps --format '{{.Names}}' | grep -q '^$(PG_CONTAINER)$$'; then \
+			echo "PostgreSQL container '$(PG_CONTAINER)' already running."; \
+		elif $(DOCKER) ps -a --format '{{.Names}}' | grep -q '^$(PG_CONTAINER)$$'; then \
+			echo "Starting existing PostgreSQL container '$(PG_CONTAINER)'..."; \
+			$(DOCKER) start $(PG_CONTAINER); \
+		else \
+			echo "Creating PostgreSQL container '$(PG_CONTAINER)'..."; \
+			$(DOCKER) run --name $(PG_CONTAINER) \
+				-e POSTGRES_USER=$(PG_USER) \
+				-e POSTGRES_PASSWORD=$(PG_PASSWORD) \
+				-e POSTGRES_DB=$(PG_DB) \
+				-p $(PG_PORT):5432 \
+				-d postgres; \
+		fi; \
+		echo "Waiting for PostgreSQL to be ready..."; \
+		for i in $$(seq 1 30); do \
+			$(DOCKER) exec $(PG_CONTAINER) pg_isready -U $(PG_USER) >/dev/null 2>&1 && \
+				echo "PostgreSQL ready (port: $(PG_PORT))" && exit 0; \
+			sleep 1; \
+		done; \
+		echo "PostgreSQL failed to start within 30 seconds" && exit 1; \
 	fi
-	@echo "Waiting for PostgreSQL to be ready..."
-	@for i in $$(seq 1 30); do \
-		$(DOCKER) exec $(PG_CONTAINER) pg_isready -U $(PG_USER) >/dev/null 2>&1 && \
-			echo "PostgreSQL ready (port: $(PG_PORT))" && exit 0; \
-		sleep 1; \
-	done; \
-	echo "PostgreSQL failed to start within 30 seconds" && exit 1
 
 .PHONY: test-integration
 test-integration: SHELL := /usr/bin/env bash

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,40 @@ test:
 	mage test:unit
 .PHONY: test
 
+PG_CONTAINER := psql-stackdome-dev
+PG_USER := postgres
+PG_PASSWORD := foobar-bizz-buzz
+PG_DB := stackdome_dev
+PG_PORT := 5432
+
+.PHONY: ensure-postgres
+ensure-postgres: SHELL := /usr/bin/env bash
+ensure-postgres: ## Start the dev PostgreSQL container if it isn't already running.
+	@if $(DOCKER) ps --format '{{.Names}}' | grep -q '^$(PG_CONTAINER)$$'; then \
+		echo "PostgreSQL container '$(PG_CONTAINER)' already running."; \
+	elif $(DOCKER) ps -a --format '{{.Names}}' | grep -q '^$(PG_CONTAINER)$$'; then \
+		echo "Starting existing PostgreSQL container '$(PG_CONTAINER)'..."; \
+		$(DOCKER) start $(PG_CONTAINER); \
+	else \
+		echo "Creating PostgreSQL container '$(PG_CONTAINER)'..."; \
+		$(DOCKER) run --name $(PG_CONTAINER) \
+			-e POSTGRES_USER=$(PG_USER) \
+			-e POSTGRES_PASSWORD=$(PG_PASSWORD) \
+			-e POSTGRES_DB=$(PG_DB) \
+			-p $(PG_PORT):5432 \
+			-d postgres; \
+	fi
+	@echo "Waiting for PostgreSQL to be ready..."
+	@for i in $$(seq 1 30); do \
+		$(DOCKER) exec $(PG_CONTAINER) pg_isready -U $(PG_USER) >/dev/null 2>&1 && \
+			echo "PostgreSQL ready (port: $(PG_PORT))" && exit 0; \
+		sleep 1; \
+	done; \
+	echo "PostgreSQL failed to start within 30 seconds" && exit 1
+
 .PHONY: test-integration
 test-integration: SHELL := /usr/bin/env bash
-test-integration: ## Run integration tests. Optional: FOCUS="My Test Name" to run a specific spec.
+test-integration: ensure-postgres ## Run integration tests. Optional: FOCUS="My Test Name" to run a specific spec.
 	@go test -c -o test/int/integration.test ./test/int
 	@cd test/int && set -o pipefail && ./integration.test -test.v -ginkgo.v -test.timeout 30m -test.count 1 \
 		$(if $(FOCUS),-ginkgo.focus="$(FOCUS)") \

--- a/pkg/db/migrations/202605270001_add_stack_connection_discriminator.go
+++ b/pkg/db/migrations/202605270001_add_stack_connection_discriminator.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addStackConnectionDiscriminator() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202605270001_add_stack_connection_discriminator",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.Exec(
+				"ALTER TABLE stack_connections ADD COLUMN discriminator TEXT NOT NULL DEFAULT ''",
+			).Error; err != nil {
+				return fmt.Errorf("error adding discriminator column: %w", err)
+			}
+			if err := tx.Exec(
+				"DROP INDEX IF EXISTS idx_stack_connections_unique_edge",
+			).Error; err != nil {
+				return fmt.Errorf("error dropping old unique index: %w", err)
+			}
+			if err := tx.Exec(
+				"CREATE UNIQUE INDEX idx_stack_connections_unique_edge ON stack_connections(stack_id, kind, from_ref, to_ref, discriminator)",
+			).Error; err != nil {
+				return fmt.Errorf("error creating unique index with discriminator: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -55,4 +55,5 @@ var MigrationList = []*gormigrate.Migration{
 	createStackConnectionsTable(),
 	dropLegacyUsageTables(),
 	dropVolumeMountsTable(),
+	addStackConnectionDiscriminator(),
 }

--- a/pkg/models/stack_connection.go
+++ b/pkg/models/stack_connection.go
@@ -26,6 +26,24 @@ const (
 	TopologyNodeTypeObjectStore   TopologyNodeType = "object_store"
 )
 
+type ConnectionConfigKey string
+
+const (
+	// Postgres addon config keys
+	ConnectionConfigKeyDatabase        ConnectionConfigKey = "database"
+	ConnectionConfigKeyCredentialScope ConnectionConfigKey = "credential_scope"
+	ConnectionConfigKeySuperuser       ConnectionConfigKey = "superuser"
+
+	// Volume mount config keys
+	ConnectionConfigKeyMountPath ConnectionConfigKey = "mount_path"
+	ConnectionConfigKeySubPath   ConnectionConfigKey = "sub_path"
+	ConnectionConfigKeyReadOnly  ConnectionConfigKey = "read_only"
+
+	// Build artifact source config keys
+	ConnectionConfigKeySourcePath      ConnectionConfigKey = "source_path"
+	ConnectionConfigKeyDestinationPath ConnectionConfigKey = "destination_path"
+)
+
 type ConnectionTargetType string
 
 const (
@@ -37,16 +55,29 @@ type StackConnections []StackConnection
 type ConnectionMappings []ConnectionMapping
 type ConnectionConfig map[string]interface{}
 
+// StackConnection represents a directed edge between two topology nodes in a stack.
+//
+// The unique constraint on (stack_id, kind, from_ref, to_ref, discriminator) prevents
+// duplicate edges. The Discriminator field is a config-derived scoping key that allows
+// multiple connections between the same (from, to) pair when they target different
+// logical sub-resources — e.g., two env connections from the same PostgresAddon to the
+// same stack resource, each targeting a different database. For connection types that
+// don't need sub-resource scoping, the discriminator is an empty string and the
+// constraint behaves like a simple (stack_id, kind, from_ref, to_ref) unique index.
+//
+// To extend discriminator support for new connection types, add a case to
+// ComputeDiscriminator(). The store layer calls it automatically before persistence.
 type StackConnection struct {
-	ID        string             `json:"id" gorm:"column:id;primary_key;default:gen_random_uuid()"`
-	StackID   string             `json:"-" gorm:"not null;index"`
-	Kind      ConnectionKind     `json:"kind" gorm:"not null"`
-	From      TopologyNodeRef    `json:"from" gorm:"column:from_ref;type:jsonb;not null"`
-	To        TopologyNodeRef    `json:"to" gorm:"column:to_ref;type:jsonb;not null"`
-	Mappings  ConnectionMappings `json:"mappings,omitempty" gorm:"type:jsonb"`
-	Config    ConnectionConfig   `json:"config,omitempty" gorm:"type:jsonb"`
-	CreatedAt time.Time          `json:"-"`
-	UpdatedAt time.Time          `json:"-"`
+	ID            string             `json:"id" gorm:"column:id;primary_key;default:gen_random_uuid()"`
+	StackID       string             `json:"-" gorm:"not null;index"`
+	Kind          ConnectionKind     `json:"kind" gorm:"not null"`
+	From          TopologyNodeRef    `json:"from" gorm:"column:from_ref;type:jsonb;not null"`
+	To            TopologyNodeRef    `json:"to" gorm:"column:to_ref;type:jsonb;not null"`
+	Mappings      ConnectionMappings `json:"mappings,omitempty" gorm:"type:jsonb"`
+	Config        ConnectionConfig   `json:"config,omitempty" gorm:"type:jsonb"`
+	Discriminator string             `json:"-" gorm:"not null;default:''"`
+	CreatedAt     time.Time          `json:"-"`
+	UpdatedAt     time.Time          `json:"-"`
 }
 
 type TopologyNodeRef struct {
@@ -131,6 +162,23 @@ func (c StackConnection) ConfigBool(key string) (bool, bool, error) {
 		return false, false, fmt.Errorf("config.%s must be a boolean", key)
 	}
 	return asBool, true, nil
+}
+
+// ComputeDiscriminator derives a scoping key from the connection's config based on
+// the source type and kind. This allows the unique index to permit multiple connections
+// between the same (from, to) pair when they address different sub-resources.
+//
+// Currently supported:
+//   - addon/postgres + env → config.database (allows wiring multiple databases from one addon)
+//
+// Returns "" for all other connection types, preserving standard edge uniqueness.
+func (c *StackConnection) ComputeDiscriminator() string {
+	if c.Kind == ConnectionKindEnv && c.From.Type == TopologyNodeTypePostgresAddon {
+		if db, ok := c.Config[string(ConnectionConfigKeyDatabase)].(string); ok && db != "" {
+			return db
+		}
+	}
+	return ""
 }
 
 func (connections StackConnections) HasAnyKind(kinds ...ConnectionKind) bool {

--- a/pkg/services/stack_service.go
+++ b/pkg/services/stack_service.go
@@ -384,10 +384,12 @@ func (s *stackService) ListStackConnections(ctx context.Context, stackID string)
 func (s *stackService) CreateStackConnection(ctx context.Context, stackID string, connection *models.StackConnection) (*models.StackConnection, *errors.ServiceError) {
 	stack, _, err := s.prepareDesiredStackWithConnectionMutation(ctx, stackID, func(connections models.StackConnections) (models.StackConnections, *models.StackConnection, *errors.ServiceError) {
 		newConnection := *connection
+		newDiscriminator := newConnection.ComputeDiscriminator()
 		for _, existing := range connections {
 			if existing.Kind == newConnection.Kind &&
 				existing.From == newConnection.From &&
-				existing.To == newConnection.To {
+				existing.To == newConnection.To &&
+				existing.ComputeDiscriminator() == newDiscriminator {
 				return nil, nil, errors.Conflict("a '%s' connection from %s to %s already exists",
 					newConnection.Kind,
 					connectionNodeLabel(newConnection.From),
@@ -409,6 +411,7 @@ func (s *stackService) UpdateStackConnection(ctx context.Context, stackID, conne
 	stack, _, err := s.prepareDesiredStackWithConnectionMutation(ctx, stackID, func(connections models.StackConnections) (models.StackConnections, *models.StackConnection, *errors.ServiceError) {
 		updated := *connection
 		updated.ID = connectionID
+		updatedDiscriminator := updated.ComputeDiscriminator()
 		found := false
 		for i := range connections {
 			if connections[i].ID == connectionID {
@@ -418,7 +421,8 @@ func (s *stackService) UpdateStackConnection(ctx context.Context, stackID, conne
 			}
 			if connections[i].Kind == updated.Kind &&
 				connections[i].From == updated.From &&
-				connections[i].To == updated.To {
+				connections[i].To == updated.To &&
+				connections[i].ComputeDiscriminator() == updatedDiscriminator {
 				return nil, nil, errors.Conflict("a '%s' connection from %s to %s already exists",
 					updated.Kind,
 					connectionNodeLabel(updated.From),

--- a/pkg/stores/pgstore/stack_connection.go
+++ b/pkg/stores/pgstore/stack_connection.go
@@ -40,6 +40,7 @@ func (s *stackConnectionStore) CreateWithTx(ctx context.Context, stackID string,
 	}
 
 	connection.StackID = stackID
+	connection.Discriminator = connection.ComputeDiscriminator()
 	if err := tx.Create(connection).Error; err != nil {
 		return nil, errors.GeneralError("failed to create stack connection: %s", err.Error())
 	}
@@ -54,14 +55,16 @@ func (s *stackConnectionStore) UpdateWithTx(ctx context.Context, stackID, connec
 
 	connection.StackID = stackID
 	connection.ID = connectionID
+	connection.Discriminator = connection.ComputeDiscriminator()
 	result := tx.Model(&models.StackConnection{}).
 		Where("stack_id = ? AND id = ?", stackID, connectionID).
 		Updates(map[string]interface{}{
-			"kind":     connection.Kind,
-			"from_ref": connection.From,
-			"to_ref":   connection.To,
-			"mappings": connection.Mappings,
-			"config":   connection.Config,
+			"kind":          connection.Kind,
+			"from_ref":      connection.From,
+			"to_ref":        connection.To,
+			"mappings":      connection.Mappings,
+			"config":        connection.Config,
+			"discriminator": connection.Discriminator,
 		})
 	if result.Error != nil {
 		return nil, errors.GeneralError("failed to update stack connection: %s", result.Error.Error())
@@ -119,16 +122,18 @@ func (s *stackConnectionStore) ReplaceByStackIDWithTx(ctx context.Context, stack
 
 	for i := range connections {
 		c := &connections[i]
+		c.Discriminator = c.ComputeDiscriminator()
 		if c.ID != "" {
 			if _, exists := existingByID[c.ID]; exists {
 				if updErr := tx.Model(&models.StackConnection{}).
 					Where("stack_id = ? AND id = ?", stackID, c.ID).
 					Updates(map[string]interface{}{
-						"kind":     c.Kind,
-						"from_ref": c.From,
-						"to_ref":   c.To,
-						"mappings": c.Mappings,
-						"config":   c.Config,
+						"kind":          c.Kind,
+						"from_ref":      c.From,
+						"to_ref":        c.To,
+						"mappings":      c.Mappings,
+						"config":        c.Config,
+						"discriminator": c.Discriminator,
 					}).Error; updErr != nil {
 					return errors.GeneralError("failed to update stack connection '%s': %s", c.ID, updErr.Error())
 				}

--- a/pkg/stores/pgstore/stack_connection_test.go
+++ b/pkg/stores/pgstore/stack_connection_test.go
@@ -31,6 +31,7 @@ func newTestSessionFactory(t *testing.T) *testSessionFactory {
 			to_ref jsonb NOT NULL,
 			mappings jsonb,
 			config jsonb,
+			discriminator text NOT NULL DEFAULT '',
 			created_at datetime,
 			updated_at datetime
 		)
@@ -173,6 +174,75 @@ func TestStackConnectionStoreReferencesTargetByStackScopedName(t *testing.T) {
 	}
 	if !referenced {
 		t.Fatalf("expected stack-local volume target to be referenced")
+	}
+}
+
+func TestStackConnectionStoreAllowsMultipleConnectionsToSameAddonWithDifferentDatabases(t *testing.T) {
+	sf := newTestSessionFactory(t)
+
+	pgFrom := models.TopologyNodeRef{Type: models.TopologyNodeTypePostgresAddon, Id: "pg-1"}
+	webTo := models.TopologyNodeRef{Type: models.TopologyNodeTypeStackResource, Name: "web"}
+
+	conn1 := models.StackConnection{
+		ID:      "conn-1",
+		StackID: "stack-1",
+		Kind:    models.ConnectionKindEnv,
+		From:    pgFrom,
+		To:      webTo,
+		Config:  models.ConnectionConfig{"database": "app_db"},
+	}
+	conn1.Discriminator = conn1.ComputeDiscriminator()
+
+	conn2 := models.StackConnection{
+		ID:      "conn-2",
+		StackID: "stack-1",
+		Kind:    models.ConnectionKindEnv,
+		From:    pgFrom,
+		To:      webTo,
+		Config:  models.ConnectionConfig{"database": "tooljet_db"},
+	}
+	conn2.Discriminator = conn2.ComputeDiscriminator()
+
+	createConnectionRecord(t, sf, conn1)
+	createConnectionRecord(t, sf, conn2)
+
+	var count int64
+	if err := sf.db.Model(&models.StackConnection{}).Where("stack_id = ?", "stack-1").Count(&count).Error; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 connections, got %d", count)
+	}
+}
+
+func TestComputeDiscriminatorReturnsDatabase(t *testing.T) {
+	conn := models.StackConnection{
+		Kind:   models.ConnectionKindEnv,
+		From:   models.TopologyNodeRef{Type: models.TopologyNodeTypePostgresAddon, Id: "pg-1"},
+		Config: models.ConnectionConfig{"database": "app_db"},
+	}
+	if got := conn.ComputeDiscriminator(); got != "app_db" {
+		t.Fatalf("expected discriminator 'app_db', got '%s'", got)
+	}
+}
+
+func TestComputeDiscriminatorReturnsEmptyForNonPostgres(t *testing.T) {
+	conn := models.StackConnection{
+		Kind: models.ConnectionKindEnv,
+		From: models.TopologyNodeRef{Type: models.TopologyNodeTypeSecret, Id: "sec-1"},
+	}
+	if got := conn.ComputeDiscriminator(); got != "" {
+		t.Fatalf("expected empty discriminator for secret connection, got '%s'", got)
+	}
+}
+
+func TestComputeDiscriminatorReturnsEmptyForVolumeMount(t *testing.T) {
+	conn := models.StackConnection{
+		Kind: models.ConnectionKindVolumeMount,
+		From: models.TopologyNodeRef{Type: models.TopologyNodeTypeVolume, Name: "data"},
+	}
+	if got := conn.ComputeDiscriminator(); got != "" {
+		t.Fatalf("expected empty discriminator for volume mount, got '%s'", got)
 	}
 }
 

--- a/pkg/stores/pgstore/stack_connection_test.go
+++ b/pkg/stores/pgstore/stack_connection_test.go
@@ -236,6 +236,16 @@ func TestComputeDiscriminatorReturnsEmptyForNonPostgres(t *testing.T) {
 	}
 }
 
+func TestComputeDiscriminatorReturnsEmptyForPostgresWithNilConfig(t *testing.T) {
+	conn := models.StackConnection{
+		Kind: models.ConnectionKindEnv,
+		From: models.TopologyNodeRef{Type: models.TopologyNodeTypePostgresAddon, Id: "pg-1"},
+	}
+	if got := conn.ComputeDiscriminator(); got != "" {
+		t.Fatalf("expected empty discriminator for postgres addon with nil config, got '%s'", got)
+	}
+}
+
 func TestComputeDiscriminatorReturnsEmptyForVolumeMount(t *testing.T) {
 	conn := models.StackConnection{
 		Kind: models.ConnectionKindVolumeMount,

--- a/pkg/validator/stack/stack_validator.go
+++ b/pkg/validator/stack/stack_validator.go
@@ -538,19 +538,19 @@ func validateBuildArtifactSourceConfig(volumeMap map[string]*models.Volume, labe
 		return errors.BadRequest("connection '%s' references unknown volume '%s'", label, connection.To.Name)
 	}
 	if err := validateConfigKeys(connection.Config, map[string]struct{}{
-		"source_path":      {},
-		"destination_path": {},
+		string(models.ConnectionConfigKeySourcePath):      {},
+		string(models.ConnectionConfigKeyDestinationPath): {},
 	}, label, "build_artifact_source"); err != nil {
 		return err
 	}
-	sourcePath, _, err := getOptionalStringConfig(connection.Config, "source_path", label)
+	sourcePath, _, err := getOptionalStringConfig(connection.Config, string(models.ConnectionConfigKeySourcePath), label)
 	if err != nil {
 		return err
 	}
 	if sourcePath == "" {
 		return errors.BadRequest("connection '%s' requires config.source_path for build artifact sources", label)
 	}
-	if _, _, err := getOptionalStringConfig(connection.Config, "destination_path", label); err != nil {
+	if _, _, err := getOptionalStringConfig(connection.Config, string(models.ConnectionConfigKeyDestinationPath), label); err != nil {
 		return err
 	}
 	return nil
@@ -565,23 +565,23 @@ func (v *stackValidator) validatePostgresConnectionConfig(ctx context.Context, l
 	}
 
 	if err := validateConfigKeys(connection.Config, map[string]struct{}{
-		"database":         {},
-		"credential_scope": {},
-		"superuser":        {},
+		string(models.ConnectionConfigKeyDatabase):        {},
+		string(models.ConnectionConfigKeyCredentialScope): {},
+		string(models.ConnectionConfigKeySuperuser):       {},
 	}, label, "postgres"); err != nil {
 		return nil, err
 	}
 
-	database, _, err := getOptionalStringConfig(connection.Config, "database", label)
+	database, _, err := getOptionalStringConfig(connection.Config, string(models.ConnectionConfigKeyDatabase), label)
 	if err != nil {
 		return nil, err
 	}
 
-	credentialScope, hasCredentialScope, err := getOptionalStringConfig(connection.Config, "credential_scope", label)
+	credentialScope, hasCredentialScope, err := getOptionalStringConfig(connection.Config, string(models.ConnectionConfigKeyCredentialScope), label)
 	if err != nil {
 		return nil, err
 	}
-	superuser, hasSuperuser, err := getOptionalBoolConfig(connection.Config, "superuser", label)
+	superuser, hasSuperuser, err := getOptionalBoolConfig(connection.Config, string(models.ConnectionConfigKeySuperuser), label)
 	if err != nil {
 		return nil, err
 	}
@@ -635,14 +635,14 @@ func validateVolumeConnectionConfig(volumeMap map[string]*models.Volume, label s
 	}
 
 	if err := validateConfigKeys(connection.Config, map[string]struct{}{
-		"mount_path": {},
-		"sub_path":   {},
-		"read_only":  {},
+		string(models.ConnectionConfigKeyMountPath): {},
+		string(models.ConnectionConfigKeySubPath):   {},
+		string(models.ConnectionConfigKeyReadOnly):  {},
 	}, label, "volume"); err != nil {
 		return err
 	}
 
-	mountPath, _, err := getOptionalStringConfig(connection.Config, "mount_path", label)
+	mountPath, _, err := getOptionalStringConfig(connection.Config, string(models.ConnectionConfigKeyMountPath), label)
 	if err != nil {
 		return err
 	}
@@ -650,10 +650,10 @@ func validateVolumeConnectionConfig(volumeMap map[string]*models.Volume, label s
 		return errors.BadRequest("connection '%s' requires config.mount_path for volume mounts", label)
 	}
 
-	if _, _, err := getOptionalStringConfig(connection.Config, "sub_path", label); err != nil {
+	if _, _, err := getOptionalStringConfig(connection.Config, string(models.ConnectionConfigKeySubPath), label); err != nil {
 		return err
 	}
-	if _, _, err := getOptionalBoolConfig(connection.Config, "read_only", label); err != nil {
+	if _, _, err := getOptionalBoolConfig(connection.Config, string(models.ConnectionConfigKeyReadOnly), label); err != nil {
 		return err
 	}
 

--- a/pkg/worker/stack/connection_reconciler.go
+++ b/pkg/worker/stack/connection_reconciler.go
@@ -117,11 +117,11 @@ func (r *connectionReconciler) resolveVolumeMountConnections(
 			return fmt.Errorf("volume_mount connection '%s' references unknown stack resource '%s'", connection.ID, connection.To.Name)
 		}
 
-		mountPath, err := connection.RequiredConfigString("mount_path")
+		mountPath, err := connection.RequiredConfigString(string(models.ConnectionConfigKeyMountPath))
 		if err != nil {
 			return fmt.Errorf("volume_mount connection '%s' has invalid config: %w", connection.ID, err)
 		}
-		subPath, _, err := connection.ConfigString("sub_path")
+		subPath, _, err := connection.ConfigString(string(models.ConnectionConfigKeySubPath))
 		if err != nil {
 			return fmt.Errorf("volume_mount connection '%s' has invalid config: %w", connection.ID, err)
 		}
@@ -158,11 +158,11 @@ func (r *connectionReconciler) resolveBuildArtifactSourceConnections(
 			return fmt.Errorf("build_artifact_source connection '%s' references unknown volume '%s'", connection.ID, connection.To.Name)
 		}
 
-		sourcePath, err := connection.RequiredConfigString("source_path")
+		sourcePath, err := connection.RequiredConfigString(string(models.ConnectionConfigKeySourcePath))
 		if err != nil {
 			return fmt.Errorf("build_artifact_source connection '%s' has invalid config: %w", connection.ID, err)
 		}
-		destinationPath, _, err := connection.ConfigString("destination_path")
+		destinationPath, _, err := connection.ConfigString(string(models.ConnectionConfigKeyDestinationPath))
 		if err != nil {
 			return fmt.Errorf("build_artifact_source connection '%s' has invalid config: %w", connection.ID, err)
 		}
@@ -341,18 +341,18 @@ func resolveSelfOutputEnvVars(resource *models.StackResource) error {
 }
 
 func postgresConnectionConfig(connection models.StackConnection) (database string, superuser bool, err error) {
-	if value, ok, err := connection.ConfigString("database"); err != nil {
+	if value, ok, err := connection.ConfigString(string(models.ConnectionConfigKeyDatabase)); err != nil {
 		return "", false, fmt.Errorf("connection '%s' has invalid config: %w", connection.ID, err)
 	} else if ok {
 		database = value
 	}
 
-	if scope, ok, err := connection.ConfigString("credential_scope"); err != nil {
+	if scope, ok, err := connection.ConfigString(string(models.ConnectionConfigKeyCredentialScope)); err != nil {
 		return "", false, fmt.Errorf("connection '%s' has invalid config: %w", connection.ID, err)
 	} else if ok {
 		superuser = scope == "superuser"
 	}
-	if value, ok, err := connection.ConfigBool("superuser"); err != nil {
+	if value, ok, err := connection.ConfigBool(string(models.ConnectionConfigKeySuperuser)); err != nil {
 		return "", false, fmt.Errorf("connection '%s' has invalid config: %w", connection.ID, err)
 	} else if ok {
 		superuser = value

--- a/test/int/shared/fixtures.go
+++ b/test/int/shared/fixtures.go
@@ -755,6 +755,14 @@ func VolumeMountConn(volumeName, targetResource, mountPath, subPath string) open
 	return *conn
 }
 
+func PostgresMapping(output, envName string) openapi.ConnectionMapping {
+	target := openapi.NewConnectionTarget("env")
+	target.SetName(envName)
+	value := openapi.NewValueRef()
+	value.SetOutput(output)
+	return *openapi.NewConnectionMapping(*target, *value)
+}
+
 func HostMapping() openapi.ConnectionMapping {
 	target := openapi.NewConnectionTarget("env")
 	target.SetName("API_HOST")

--- a/test/int/stack_connection_topology_test.go
+++ b/test/int/stack_connection_topology_test.go
@@ -389,6 +389,38 @@ var _ = Describe("Stack Connections & Topology", func() {
 			Expect(databases).To(HaveKey("appdb"))
 			Expect(databases).To(HaveKey("tooljetdb"))
 		})
+
+		It("should reject a second env connection targeting the same database with 409", func() {
+			By("Creating a postgres addon")
+			addon := shared.CreateMinimalPostgresAddon("test-dup-db")
+			db1 := openapi.NewPostgresDatabase("appdb")
+			db1.SetExtensions([]string{})
+			addon.Spec.SetDatabases([]openapi.PostgresDatabase{*db1})
+			createdAddon := shared.CreatePostgresAddon(client, orgID, teamName, addon)
+			addonID := createdAddon.GetId()
+
+			By("Creating a stack with a resource")
+			web := shared.ResourceWithPort("web", 8080)
+			stack := shared.CreateSkipProvisioningStack("test-dup-db-conn", []openapi.StackResource{web})
+			createdStack := shared.CreateStack(client, orgID, teamName, stack)
+			stackID := createdStack.GetId()
+			shared.WaitForStackReady(client, orgID, teamName, stackID, 1*time.Minute)
+
+			By("Creating first connection targeting appdb")
+			conn1 := shared.EnvConnectionWithID("addon/postgres", addonID, "stack_resource", "web", []openapi.ConnectionMapping{
+				shared.PostgresMapping("host", "PG_HOST"),
+			})
+			conn1.SetConfig(map[string]interface{}{"database": "appdb"})
+			created := shared.CreateStackConnection(client, orgID, teamName, stackID, &conn1)
+			Expect(created.GetId()).NotTo(BeEmpty())
+
+			By("Attempting duplicate connection targeting same database")
+			conn2 := shared.EnvConnectionWithID("addon/postgres", addonID, "stack_resource", "web", []openapi.ConnectionMapping{
+				shared.PostgresMapping("host", "PG_HOST_2"),
+			})
+			conn2.SetConfig(map[string]interface{}{"database": "appdb"})
+			shared.CreateStackConnectionExpectError(client, orgID, teamName, stackID, &conn2, http.StatusConflict)
+		})
 	})
 
 	// -----------------------------------------------------------------

--- a/test/int/stack_connection_topology_test.go
+++ b/test/int/stack_connection_topology_test.go
@@ -339,6 +339,59 @@ var _ = Describe("Stack Connections & Topology", func() {
 	})
 
 	// -----------------------------------------------------------------
+	// Multi-database discriminator
+	// -----------------------------------------------------------------
+	Context("Multi-database addon connections", func() {
+		It("should allow two env connections from the same postgres addon to the same resource with different databases", func() {
+			By("Creating a postgres addon with two databases")
+			addon := shared.CreateMinimalPostgresAddon("test-multi-db")
+			db1 := openapi.NewPostgresDatabase("appdb")
+			db1.SetExtensions([]string{})
+			db2 := openapi.NewPostgresDatabase("tooljetdb")
+			db2.SetExtensions([]string{})
+			addon.Spec.SetDatabases([]openapi.PostgresDatabase{*db1, *db2})
+			createdAddon := shared.CreatePostgresAddon(client, orgID, teamName, addon)
+			addonID := createdAddon.GetId()
+
+			By("Creating a stack with a resource")
+			web := shared.ResourceWithPort("web", 8080)
+			stack := shared.CreateSkipProvisioningStack("test-multi-db-conn", []openapi.StackResource{web})
+			createdStack := shared.CreateStack(client, orgID, teamName, stack)
+			stackID := createdStack.GetId()
+			shared.WaitForStackReady(client, orgID, teamName, stackID, 1*time.Minute)
+
+			By("Creating first connection targeting appdb")
+			conn1 := shared.EnvConnectionWithID("addon/postgres", addonID, "stack_resource", "web", []openapi.ConnectionMapping{
+				shared.PostgresMapping("host", "PG_HOST"),
+				shared.PostgresMapping("database", "PG_DB"),
+			})
+			conn1.SetConfig(map[string]interface{}{"database": "appdb"})
+			created1 := shared.CreateStackConnection(client, orgID, teamName, stackID, &conn1)
+			Expect(created1.GetId()).NotTo(BeEmpty())
+
+			By("Creating second connection targeting tooljetdb (same addon, same resource, different database)")
+			conn2 := shared.EnvConnectionWithID("addon/postgres", addonID, "stack_resource", "web", []openapi.ConnectionMapping{
+				shared.PostgresMapping("host", "TOOLJET_DB_HOST"),
+				shared.PostgresMapping("database", "TOOLJET_DB"),
+			})
+			conn2.SetConfig(map[string]interface{}{"database": "tooljetdb"})
+			created2 := shared.CreateStackConnection(client, orgID, teamName, stackID, &conn2)
+			Expect(created2.GetId()).NotTo(BeEmpty())
+
+			By("Verifying both connections exist")
+			connections := shared.ListStackConnections(client, orgID, teamName, stackID)
+			Expect(connections).To(HaveLen(2))
+
+			databases := map[string]bool{}
+			for _, c := range connections {
+				databases[c.GetConfig()["database"].(string)] = true
+			}
+			Expect(databases).To(HaveKey("appdb"))
+			Expect(databases).To(HaveKey("tooljetdb"))
+		})
+	})
+
+	// -----------------------------------------------------------------
 	// Connection Create — Negative Paths
 	// -----------------------------------------------------------------
 	Context("Connection Create Negative Paths", func() {


### PR DESCRIPTION
## Summary

Fixes #80 — the unique index on `stack_connections(stack_id, kind, from_ref, to_ref)` blocked creating two env connections from the same PostgresAddon to the same stack resource when targeting different databases (e.g. `appdb` and `tooljetdb`).

- Add `discriminator` column derived from `config.database` for addon/postgres env connections (empty string for all other types, preserving existing uniqueness)
- Update unique index to include discriminator: `(stack_id, kind, from_ref, to_ref, discriminator)`
- Fix application-level duplicate detection in service layer to also consider discriminator
- Add `ConnectionConfigKey` typed constants, replace raw string literals across validator and reconciler
- Add `ensure-postgres` Makefile target so `make test-integration` auto-starts the dev postgres container
- Add `mage test:unit` step to CI workflow

## Test plan

- [x] Unit tests: `ComputeDiscriminator()` returns correct value for postgres/secret/volume connections
- [x] Unit tests: two connections with same (from, to) but different databases coexist in store
- [x] Unit tests: all existing validator and connection reconciler tests pass with typed constants
- [x] Integration test: creates postgres addon with two databases, wires both to same resource, verifies both connections persist
- [x] Full unit suite: `mage test:unit` passes
- [x] Focused integration test: `FOCUS="Multi-database addon connections" make test-integration` passes