### PR TITLE
Fix: Team delete fails — add created_at/updated_at to volumes (#84)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cloudnative-pg/plugin-barman-cloud v0.11.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/getkin/kin-openapi v0.126.0
+	github.com/glebarez/sqlite v1.7.0
 	github.com/go-git/go-git/v5 v5.16.0
 	github.com/go-gormigrate/gormigrate/v2 v2.1.2
 	github.com/go-logr/logr v1.4.3
@@ -84,7 +85,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/glebarez/go-sqlite v1.20.3 // indirect
-	github.com/glebarez/sqlite v1.7.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect

--- a/pkg/db/migrations/202605270002_add_timestamps_to_volumes.go
+++ b/pkg/db/migrations/202605270002_add_timestamps_to_volumes.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addTimestampsToVolumesTable() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202605270002",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.Exec(`ALTER TABLE volumes ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`).Error; err != nil {
+				return fmt.Errorf("error adding created_at column to volumes table: %w", err)
+			}
+			if err := tx.Exec(`ALTER TABLE volumes ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`).Error; err != nil {
+				return fmt.Errorf("error adding updated_at column to volumes table: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -56,4 +56,5 @@ var MigrationList = []*gormigrate.Migration{
 	dropLegacyUsageTables(),
 	dropVolumeMountsTable(),
 	addStackConnectionDiscriminator(),
+	addTimestampsToVolumesTable(),
 }

--- a/pkg/models/volume.go
+++ b/pkg/models/volume.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"time"
 )
 
 type GitRepoRevisionType string
@@ -38,6 +39,8 @@ type Volume struct {
 	VolumeSource   *VolumeSource    `gorm:"type:jsonb" json:"volume_source,omitempty"`
 	SyncBeforeUse  bool             `json:"sync_before_use"`
 	Status         *VolumeStatus    `gorm:"type:jsonb" json:"volume_status,omitempty"`
+	CreatedAt      time.Time        `json:"created_at"`
+	UpdatedAt      time.Time        `json:"updated_at"`
 }
 
 func (v *Volume) VolumeSourceType() SourceVolumeType {

--- a/pkg/stores/pgstore/volume_store_test.go
+++ b/pkg/stores/pgstore/volume_store_test.go
@@ -1,0 +1,144 @@
+package pgstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ashishmax31/stackdome-api-server/pkg/models"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func newVolumesTestSessionFactory(t *testing.T) *testSessionFactory {
+	t.Helper()
+
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+	if err := gdb.Exec(`
+		CREATE TABLE volumes (
+			id text PRIMARY KEY,
+			organisation_id text NOT NULL,
+			team_id text,
+			user_id text NOT NULL,
+			name text NOT NULL,
+			namespace_id text NOT NULL,
+			namespace text NOT NULL,
+			labels jsonb,
+			annotations jsonb,
+			size text,
+			storage_class text,
+			access_mode text NOT NULL,
+			volume_source jsonb,
+			sync_before_use boolean,
+			status jsonb,
+			created_at datetime,
+			updated_at datetime
+		)
+	`).Error; err != nil {
+		t.Fatalf("failed to create volumes table: %v", err)
+	}
+	return &testSessionFactory{db: gdb}
+}
+
+func TestVolumeStoreListByTeamIDOrdersByCreatedAtDesc(t *testing.T) {
+	ctx := context.Background()
+	sf := newVolumesTestSessionFactory(t)
+	store := NewVolumeStore(VolumeStoreSpec{SessionFactory: sf})
+
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
+
+	if err := sf.db.Create(&models.Volume{
+		ID:             "vol-old",
+		OrganisationID: "org-1",
+		TeamID:         "team-1",
+		UserID:         "u-1",
+		Name:           "older",
+		NamespaceID:    "ns-1",
+		Namespace:      "ns-1",
+		Size:           "1Gi",
+		AccessMode:     models.READ_WRITE_ONCE,
+		CreatedAt:      older,
+		UpdatedAt:      older,
+	}).Error; err != nil {
+		t.Fatalf("seed older: %v", err)
+	}
+	if err := sf.db.Create(&models.Volume{
+		ID:             "vol-new",
+		OrganisationID: "org-1",
+		TeamID:         "team-1",
+		UserID:         "u-1",
+		Name:           "newer",
+		NamespaceID:    "ns-1",
+		Namespace:      "ns-1",
+		Size:           "1Gi",
+		AccessMode:     models.READ_WRITE_ONCE,
+		CreatedAt:      newer,
+		UpdatedAt:      newer,
+	}).Error; err != nil {
+		t.Fatalf("seed newer: %v", err)
+	}
+
+	res, lerr := store.ListByTeamID(ctx, "team-1")
+	if lerr != nil {
+		t.Fatalf("unexpected error: %v", lerr)
+	}
+	if len(res) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(res))
+	}
+	if res[0].ID != "vol-new" {
+		t.Fatalf("expected vol-new first (created_at DESC), got %s", res[0].ID)
+	}
+	if res[1].ID != "vol-old" {
+		t.Fatalf("expected vol-old second, got %s", res[1].ID)
+	}
+}
+
+func TestVolumeStoreListByTeamIDFiltersByTeam(t *testing.T) {
+	ctx := context.Background()
+	sf := newVolumesTestSessionFactory(t)
+	store := NewVolumeStore(VolumeStoreSpec{SessionFactory: sf})
+
+	now := time.Now()
+	if err := sf.db.Create(&models.Volume{
+		ID:             "vol-a",
+		OrganisationID: "org-1",
+		TeamID:         "team-1",
+		UserID:         "u-1",
+		Name:           "a",
+		NamespaceID:    "ns-1",
+		Namespace:      "ns-1",
+		Size:           "1Gi",
+		AccessMode:     models.READ_WRITE_ONCE,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}).Error; err != nil {
+		t.Fatalf("seed a: %v", err)
+	}
+	if err := sf.db.Create(&models.Volume{
+		ID:             "vol-b",
+		OrganisationID: "org-1",
+		TeamID:         "team-2",
+		UserID:         "u-1",
+		Name:           "b",
+		NamespaceID:    "ns-1",
+		Namespace:      "ns-1",
+		Size:           "1Gi",
+		AccessMode:     models.READ_WRITE_ONCE,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}).Error; err != nil {
+		t.Fatalf("seed b: %v", err)
+	}
+
+	res, lerr := store.ListByTeamID(ctx, "team-1")
+	if lerr != nil {
+		t.Fatalf("unexpected error: %v", lerr)
+	}
+	if len(res) != 1 || res[0].ID != "vol-a" {
+		t.Fatalf("expected only vol-a, got %+v", res)
+	}
+}


### PR DESCRIPTION
## 📝 What this does

`volumeStore.ListByTeamID` ordered by `created_at DESC` against a `volumes` table that never had the column — every team-delete dependency check raised `pq: column "created_at" does not exist`, blocking team deletion. This brings `Volume` into parity with sibling models (`Stack`, `Secret`, `ObjectStore`, `PostgresAddon`, `WorkspaceUser`) by adding timestamps to the model and a migration that backfills existing rows.

Closes #84.

## 🔀 Changes

- Added `CreatedAt` / `UpdatedAt time.Time` to `models.Volume`
- New migration `202605270002_add_timestamps_to_volumes` adds both columns as `TIMESTAMPTZ NOT NULL DEFAULT NOW()` so existing rows backfill on `ALTER TABLE`
- Registered the migration in `MigrationList`
- Added unit tests covering `ListByTeamID` ordering by `created_at DESC` and team-scoped filtering
- Promoted `glebarez/sqlite` from indirect to direct in `go.mod` (already used by sibling test factory)

## 🧪 How to test

- [ ] Run `mage test:unit` — passes
- [ ] Migrate a DB containing existing volumes, confirm `created_at` / `updated_at` columns are populated for old rows
- [ ] Delete a team via `/settings/teams` against the migrated DB — no `column "created_at" does not exist` toast