### PR TITLE
Add KEEP_RESOURCES_ON_FAILURE for e2e test debugging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+See [CLAUDE.md](CLAUDE.md) for all project instructions, architecture, commands, and conventions. That file is the single source of truth — this file exists so non-Claude agents (Codex, Copilot, etc.) discover the same guidance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ Build system is **Mage** (`magefile.go`, namespaced targets); `Makefile` wraps s
 | Tear down local env | `mage dev:teardown` |
 | Backend unit tests | `mage test:unit` (or `make test`) |
 | Single Go test | `go test ./pkg/<pkg>/ -run TestName` |
-| Integration tests (needs Docker/Kind) | `mage test:integration` |
+| Integration tests (needs Docker/Kind) | `make test-integration` |
+| Focused integration test | `KEEP_CLUSTER=true KEEP_RESOURCES_ON_FAILURE=true FOCUS="Test Name" make test-integration` |
 | Lint Go | `golangci-lint run ./...` (or `mage lint`) |
 | Format Go | `mage fmt` |
 | Regenerate mocks | `make mocks` (mockgen via `go:generate`) |
@@ -43,9 +44,75 @@ Build system is **Mage** (`magefile.go`, namespaced targets); `Makefile` wraps s
 Notes:
 - `mage dev:setup` is idempotent; reads/writes `.env` (creates from `.env_template`), writes cluster creds to `dev_env.yaml`.
 - `mage build` skips `tsc -b` so unrelated frontend type errors don't block the binary; frontend's own `pnpm build` does run `tsc -b`.
-- Integration tests need `TEST_KUBECONFIG` pointing at a Mage-created Kind cluster (`mage cluster:create` / `cluster:delete`); state cached in `~/.cache/stackdome-api-server/clusters/`.
+- **Running integration tests for new features or new tests:** Always use focused runs (`FOCUS="Test Name"`) for faster feedback instead of running the full suite. Use `KEEP_CLUSTER=true` to preserve the Kind cluster between runs (avoids 3-8min bootstrap). Use `KEEP_RESOURCES_ON_FAILURE=true` to skip resource cleanup on failure so you can inspect cluster state (`kubectl`) and DB to diagnose what went wrong. Recommended command:
+  ```
+  KEEP_CLUSTER=true KEEP_RESOURCES_ON_FAILURE=true FOCUS="My New Test" make test-integration
+  ```
+  `FOCUS` accepts a Ginkgo regex — use the `It()` description text or a `Context()` name to scope the run. Output is saved to `test/int/last-run.log`.
 - New DB migration: scaffold with `hack/create_migration.sh`; ordered files live in `pkg/db/migrations/`.
 - Full end-to-end demo env: `hack/run_local.sh [stack.json]`.
+
+## Integration Test Patterns
+
+When writing new integration tests, follow these conventions:
+
+**File organization:**
+- E2E tests that need a real cluster go in `test/int/*_e2e_test.go`
+- API-only tests (no cluster interaction) go in `test/int/*_test.go`
+- Fixtures (factory functions for OpenAPI objects) go in `test/int/shared/fixtures.go`
+- CRUD helpers (create/get/update/delete via API client) go in `test/int/shared/helpers.go`
+- Cluster inspection helpers (get deployments, services, CRs) go in `test/int/shared/cluster_helpers.go`
+
+**Test structure:**
+```go
+var _ = Describe("Feature E2E", Ordered, func() {
+    var client *openapi.APIClient
+    var orgID string
+    teamName := models.DefaultTeamName
+
+    BeforeAll(func() {
+        testEnv := GetEnvironment()
+        client = testEnv.Client
+        orgID = testEnv.OrgID
+    })
+
+    Context("Scenario", func() {
+        It("should do something", func() {
+            By("Creating a resource")
+            // Use factory functions from shared/fixtures.go
+            resource := shared.CreateSimpleStack("test-name")
+            created := shared.CreateStack(client, orgID, teamName, resource)
+
+            // Always register cleanup
+            shared.DeferResourceCleanup(func() {
+                shared.DeleteStack(client, orgID, teamName, created.GetId())
+            })
+
+            By("Verifying the result")
+            // Assertions with gomega
+        })
+    })
+})
+```
+
+**Key conventions:**
+- Use `shared.DeferResourceCleanup()` (not raw `DeferCleanup`) for all resource cleanup — it respects `KEEP_RESOURCES_ON_FAILURE`
+- Use `shared.ShouldSkipCleanup()` in custom `DeferCleanup` blocks that mix cleanup with debug logging
+- Use `By("description")` to document each step — these appear in test output
+- Use factory functions from `shared/fixtures.go` to create test objects — don't construct OpenAPI objects inline
+- Add new CRUD helpers to `shared/helpers.go` following the existing pattern (call API, `Expect` no error, return result)
+- Add new cluster inspection helpers to `shared/cluster_helpers.go`
+- Use `GetEnvironment()` to access the shared test environment (client, cluster, org ID)
+- Prefix test resource names with `test-` to make them identifiable in cluster output
+
+**API-only tests (no cluster needed):**
+For tests that only exercise the API layer (validation, CRUD, connections, topology) without needing real cluster reconciliation, use the `CreateSkipProvisioningStack()` fixtures. These add the `stack.stackdome.io/skip-cluster-provisioning` annotation which tells the stack worker to mark the stack as Ready immediately without creating CRs in the cluster. This makes tests much faster and avoids cluster dependencies.
+
+**Running tests during development:**
+```
+KEEP_CLUSTER=true KEEP_RESOURCES_ON_FAILURE=true FOCUS="My New Test" make test-integration
+```
+Always use focused runs when developing. See `test/int/README.md` for full details.
 
 ## Agent skills
 

--- a/test/int/AGENTS.md
+++ b/test/int/AGENTS.md
@@ -1,0 +1,1 @@
+See [README.md](README.md) for integration test instructions.

--- a/test/int/CLAUDE.md
+++ b/test/int/CLAUDE.md
@@ -1,0 +1,1 @@
+See [README.md](README.md) for integration test instructions.

--- a/test/int/README.md
+++ b/test/int/README.md
@@ -18,14 +18,21 @@ The integration tests follow a **shared infrastructure** pattern where:
 # Run all integration tests
 make test-integration
 
-# Keep cluster for debugging
-KEEP_CLUSTER=true make test-integration
+# Run a focused test (ALWAYS use this when developing new tests or features)
+FOCUS="My Test Name" make test-integration
+
+# Recommended workflow for developing/debugging tests:
+# - FOCUS: run only the test you're working on (accepts Ginkgo regex)
+# - KEEP_CLUSTER: preserve the Kind cluster between runs (skip 3-8min bootstrap)
+# - KEEP_RESOURCES_ON_FAILURE: skip resource cleanup on failure so you can
+#   inspect the cluster (kubectl) and DB to figure out what went wrong
+KEEP_CLUSTER=true KEEP_RESOURCES_ON_FAILURE=true FOCUS="My Test Name" make test-integration
 
 # With debug logging
 TEST_LOG_LEVEL=debug make test-integration
 ```
 
-Output is logged to `test/int/last-run.log`.
+`FOCUS` accepts a Ginkgo regex — use the `It()` description text or a `Context()` name to scope the run. Output is logged to `test/int/last-run.log`.
 
 ### Using go test directly
 ```bash
@@ -48,6 +55,8 @@ go test ./test/int/... -v -ginkgo.v -timeout 30m -count=1 -ginkgo.focus="Postgre
 | `DB_USERNAME` | Database username | `postgres` |
 | `DB_PASSWORD` | Database password | `foobar-bizz-buzz` |
 | `KEEP_CLUSTER` | Keep infrastructure after tests for debugging | `false` |
+| `KEEP_RESOURCES_ON_FAILURE` | Skip resource cleanup on failure (use with `KEEP_CLUSTER`) | `false` |
+| `FOCUS` | Ginkgo regex to run specific tests (e.g. `FOCUS="Full Lifecycle"`) | (all) |
 | `CLUSTER_AGENT_IMAGE_TAG` | Cluster agent container image tag | `v0.4.6-alpha` |
 
 ## Test Structure
@@ -200,8 +209,14 @@ After bootstrap, all test specs share:
 
 For detailed troubleshooting:
 ```bash
-# Maximum debug output
-TEST_LOG_LEVEL=debug KEEP_CLUSTER=true make test-integration
+# Maximum debug output with resource preservation on failure
+TEST_LOG_LEVEL=debug KEEP_CLUSTER=true KEEP_RESOURCES_ON_FAILURE=true FOCUS="Failing Test" make test-integration
+
+# After a failure with KEEP_RESOURCES_ON_FAILURE, inspect:
+# - Cluster: kubectl get all -A
+# - CRs: kubectl get stacks,postgresclusters -A
+# - Pods/logs: kubectl logs -n <namespace> <pod>
+# - DB: psql to the test database (see last-run.log for DB name)
 
 # Keep infrastructure for manual inspection
 KEEP_CLUSTER=true make test-integration

--- a/test/int/integration_test.go
+++ b/test/int/integration_test.go
@@ -2,6 +2,7 @@ package int
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -13,12 +14,25 @@ import (
 
 var env = &bootstrap.Environment{}
 
+// specFailed tracks whether any spec has failed, used with KEEP_RESOURCES_ON_FAILURE
+// to skip data clearing and abort remaining specs so cluster state is preserved.
+var specFailed bool
+
+var _ = ReportAfterEach(func(report SpecReport) {
+	if report.Failed() && os.Getenv("KEEP_RESOURCES_ON_FAILURE") == "true" {
+		specFailed = true
+	}
+})
+
 func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration Test Suite")
 }
 
 var _ = BeforeEach(func() {
+	if specFailed {
+		Skip("Previous spec failed with KEEP_RESOURCES_ON_FAILURE=true — skipping remaining specs to preserve cluster state")
+	}
 	By("Clearing test data")
 	Expect(env.Database.ClearData(context.Background())).To(Succeed())
 })

--- a/test/int/postgres_addon_e2e_test.go
+++ b/test/int/postgres_addon_e2e_test.go
@@ -52,7 +52,7 @@ var _ = Describe("PostgresAddon E2E", Ordered, func() {
 			By("Verifying CR has the addon ID label")
 			shared.VerifyCRLabel(cr, addonID)
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeletePostgresAddon(client, orgID, teamName, addonID)
 			})
 		})
@@ -74,7 +74,7 @@ var _ = Describe("PostgresAddon E2E", Ordered, func() {
 			Expect(addonID).NotTo(BeEmpty())
 			Expect(namespace).NotTo(BeEmpty())
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeletePostgresAddon(client, orgID, teamName, addonID)
 			})
 
@@ -141,7 +141,7 @@ var _ = Describe("PostgresAddon E2E", Ordered, func() {
 			addonName := createdAddon.GetName()
 			namespace := createdAddon.GetNamespace()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeletePostgresAddon(client, orgID, teamName, addonID)
 			})
 
@@ -205,7 +205,7 @@ var _ = Describe("PostgresAddon E2E", Ordered, func() {
 			createdAddon := shared.CreatePostgresAddon(client, orgID, teamName, addon)
 			addonID := createdAddon.GetId()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeletePostgresAddon(client, orgID, teamName, addonID)
 			})
 
@@ -256,7 +256,7 @@ var _ = Describe("PostgresAddon E2E", Ordered, func() {
 			createdAddon := shared.CreatePostgresAddon(client, orgID, teamName, addon)
 			addonID := createdAddon.GetId()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeletePostgresAddon(client, orgID, teamName, addonID)
 			})
 

--- a/test/int/shared/helpers.go
+++ b/test/int/shared/helpers.go
@@ -2,12 +2,34 @@ package shared
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
 
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/ashishmax31/stackdome-api-server/pkg/api/openapi"
 )
+
+// ShouldSkipCleanup returns true when KEEP_RESOURCES_ON_FAILURE is set and the current spec failed.
+// Use inside DeferCleanup callbacks to preserve cluster resources for debugging.
+func ShouldSkipCleanup() bool {
+	return os.Getenv("KEEP_RESOURCES_ON_FAILURE") == "true" && ginkgo.CurrentSpecReport().Failed()
+}
+
+// DeferResourceCleanup wraps ginkgo.DeferCleanup to skip resource deletion when
+// KEEP_RESOURCES_ON_FAILURE is set and the current spec failed.
+func DeferResourceCleanup(fn func()) {
+	ginkgo.DeferCleanup(func() {
+		if ShouldSkipCleanup() {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "KEEP_RESOURCES_ON_FAILURE: skipping cleanup for failed spec %q\n",
+				ginkgo.CurrentSpecReport().FullText())
+			return
+		}
+		fn()
+	})
+}
 
 // PostgreSQL addon CRUD operations for Ginkgo tests
 func CreatePostgresAddon(client *openapi.APIClient, orgID, teamName string, addon *openapi.PostgresAddon) *openapi.PostgresAddon {

--- a/test/int/shared/invite_helpers.go
+++ b/test/int/shared/invite_helpers.go
@@ -150,6 +150,13 @@ func CreateTeam(client *openapi.APIClient, orgID, teamName string) *openapi.Team
 	return resp
 }
 
+func DeleteTeam(client *openapi.APIClient, orgID, teamName string) {
+	ctx := context.Background()
+	httpResp, err := client.DefaultApi.ApiV1OrganizationsOrgIdTeamsTeamNameDelete(ctx, orgID, teamName).Execute()
+	Expect(err).NotTo(HaveOccurred(), "failed to delete team")
+	Expect(httpResp.StatusCode).To(Equal(http.StatusNoContent))
+}
+
 func ListTeamMembers(client *openapi.APIClient, orgID, teamName string) *openapi.TeamMembershipList {
 	ctx := context.Background()
 	resp, httpResp, err := client.DefaultApi.ApiV1OrganizationsOrgIdTeamsTeamNameMembersGet(ctx, orgID, teamName).Execute()

--- a/test/int/stack_e2e_test.go
+++ b/test/int/stack_e2e_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			Expect(stackID).NotTo(BeEmpty())
 			Expect(namespace).NotTo(BeEmpty())
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 1*time.Minute)
 			})
@@ -119,7 +119,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			stackID := created.GetId()
 			namespace := created.GetNamespace()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 1*time.Minute)
 			})
@@ -159,7 +159,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			stackID := created.GetId()
 			namespace := created.GetNamespace()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 1*time.Minute)
 			})
@@ -191,7 +191,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			stackID := created.GetId()
 			namespace := created.GetNamespace()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 1*time.Minute)
 			})
@@ -242,7 +242,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			stackID := created.GetId()
 			namespace := created.GetNamespace()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 1*time.Minute)
 			})
@@ -272,7 +272,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			stackName := created.GetName()
 			namespace := created.GetNamespace()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 1*time.Minute)
 			})
@@ -322,7 +322,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			createdAddon := shared.CreatePostgresAddon(client, orgID, teamName, addon)
 			addonID := createdAddon.GetId()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeletePostgresAddon(client, orgID, teamName, addonID)
 			})
 
@@ -335,7 +335,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			stackID := created.GetId()
 			namespace := created.GetNamespace()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 1*time.Minute)
 			})
@@ -382,7 +382,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			addonName := createdAddon.GetName()
 			addonNamespace := createdAddon.GetNamespace()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeletePostgresAddon(client, orgID, teamName, addonID)
 			})
 
@@ -398,7 +398,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			stackID := created.GetId()
 			namespace := created.GetNamespace()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 1*time.Minute)
 			})
@@ -493,7 +493,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			createdAddon := shared.CreatePostgresAddon(client, orgID, teamName, addon)
 			addonID := createdAddon.GetId()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeletePostgresAddon(client, orgID, teamName, addonID)
 			})
 
@@ -508,7 +508,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			createdSecret := shared.CreateSecret(client, orgID, teamName, secret)
 			secretID := createdSecret.GetId()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteSecret(client, orgID, teamName, secretID)
 			})
 
@@ -518,7 +518,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			stackID := created.GetId()
 			namespace := created.GetNamespace()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 1*time.Minute)
 			})
@@ -587,7 +587,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			created := shared.CreateStack(client, orgID, teamName, stack)
 			stackID := created.GetId()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 1*time.Minute)
 			})
@@ -639,7 +639,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			createdSecret := shared.CreateSecret(client, orgID, teamName, gitSecret)
 			secretID := createdSecret.GetId()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteSecret(client, orgID, teamName, secretID)
 			})
 
@@ -656,6 +656,9 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			DeferCleanup(func() {
 				if CurrentSpecReport().Failed() {
 					shared.DumpBuildSourceDebugInfo(ctx, client, clusterClient, clientset, orgID, teamName, stackID, namespace)
+				}
+				if shared.ShouldSkipCleanup() {
+					return
 				}
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 2*time.Minute)
@@ -733,7 +736,7 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			createdSecret := shared.CreateSecret(client, orgID, teamName, gitSecret)
 			secretID := createdSecret.GetId()
 
-			DeferCleanup(func() {
+			shared.DeferResourceCleanup(func() {
 				shared.DeleteSecret(client, orgID, teamName, secretID)
 			})
 
@@ -748,6 +751,9 @@ var _ = Describe("Stack E2E", Ordered, func() {
 				if CurrentSpecReport().Failed() {
 					kubeClient, _ := testEnv.Cluster.GetKubeClient()
 					shared.DumpBuildSourceDebugInfo(ctx, client, clusterClient, kubeClient, orgID, teamName, stackID, namespace)
+				}
+				if shared.ShouldSkipCleanup() {
+					return
 				}
 				shared.DeleteStack(client, orgID, teamName, stackID)
 				shared.WaitForStackDeleted(client, orgID, teamName, stackID, 2*time.Minute)

--- a/test/int/volume_test.go
+++ b/test/int/volume_test.go
@@ -1,0 +1,32 @@
+package int
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/ashishmax31/stackdome-api-server/pkg/api/openapi"
+	"github.com/ashishmax31/stackdome-api-server/test/int/shared"
+)
+
+var _ = Describe("Volume", func() {
+	var client *openapi.APIClient
+	var orgID string
+
+	BeforeEach(func() {
+		testEnv := GetEnvironment()
+		Expect(testEnv).NotTo(BeNil(), "Test environment should be initialized")
+
+		client = testEnv.Client
+		orgID = testEnv.OrgID
+	})
+
+	Context("Team dependency check", func() {
+		It("should allow deleting a team with no volumes (ListByTeamID ORDER BY created_at)", func() {
+			By("Creating a non-default team")
+			team := shared.CreateTeam(client, orgID, "vol-test-team")
+
+			By("Deleting the team — exercises volumeStore.ListByTeamID which orders by created_at")
+			shared.DeleteTeam(client, orgID, team.GetName())
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Add `KEEP_RESOURCES_ON_FAILURE` env var that preserves cluster resources (CRs, pods, services) when an e2e test fails, for post-mortem inspection with `kubectl`
- Remaining specs are skipped after a failure to prevent state corruption
- Add missing `DeleteTeam` shared helper and `volume_test.go` for team delete dependency check

## Usage
```bash
KEEP_CLUSTER=true KEEP_RESOURCES_ON_FAILURE=true make test-integration
```

## Test plan
- [ ] Run integration tests normally — cleanup behavior unchanged
- [ ] Run with `KEEP_RESOURCES_ON_FAILURE=true` and a deliberately failing test — verify resources remain in cluster and subsequent specs are skipped
- [ ] Verify `go build ./test/int/...` and `go vet ./test/int/...` pass