### PR TITLE
Refactor: standardize empty states across platform list pages

### DIFF
--- a/frontend/src/pages/addons/index.tsx
+++ b/frontend/src/pages/addons/index.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { PlusCircle, Loader2, AlertCircle, Puzzle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { PageHeader, Panel, EmptyState } from "@/components/branded";
+import { PageHeader, EmptyState } from "@/components/branded";
 import { useBreadcrumb } from "@/hooks/use-breadcrumb";
 import { useCurrentUser } from "@/hooks/use-current-user";
 import { usePostgresAddons } from "./hooks/use-postgres-addons";
@@ -67,21 +67,19 @@ export default function AddonsPage() {
         />
 
         {addons.length === 0 ? (
-          <Panel title="All Addons" bodyClassName="p-5">
-            <EmptyState
-              icon={<Puzzle className="h-8 w-8" />}
-              title="No addons yet"
-              description="Add an addon to provision a managed Postgres for your stacks."
-              action={
-                canWriteAnyTeam ? (
-                  <Button onClick={() => setPickerOpen(true)} variant="outline">
-                    <PlusCircle className="h-4 w-4" />
-                    Add Addon
-                  </Button>
-                ) : undefined
-              }
-            />
-          </Panel>
+          <EmptyState
+            icon={<Puzzle className="h-8 w-8" />}
+            title="No addons yet"
+            description="Add an addon to provision a managed Postgres for your stacks."
+            action={
+              canWriteAnyTeam ? (
+                <Button onClick={() => setPickerOpen(true)}>
+                  <PlusCircle className="h-4 w-4" />
+                  Add Addon
+                </Button>
+              ) : undefined
+            }
+          />
         ) : (
           <AddonList
             addons={addons}

--- a/frontend/src/pages/clusters/index.tsx
+++ b/frontend/src/pages/clusters/index.tsx
@@ -141,27 +141,23 @@ export default function ClustersPage() {
           }
         />
 
-        <Panel
-          title="All Clusters"
-          count={clusters.length}
-          bodyClassName={clusters.length === 0 ? "p-5" : "p-0"}
-        >
-          {clusters.length === 0 ? (
-            <EmptyState
-              icon={<Boxes className="h-8 w-8" />}
-              title="No clusters configured"
-              description="Link to your cluster to get started."
-              action={
-                <Button onClick={() => setShowAddDialog(true)} variant="outline">
-                  <PlusCircle className="h-4 w-4" />
-                  Add Cluster
-                </Button>
-              }
-            />
-          ) : (
+        {clusters.length === 0 ? (
+          <EmptyState
+            icon={<Boxes className="h-8 w-8" />}
+            title="No clusters configured"
+            description="Link to your cluster to get started."
+            action={
+              <Button onClick={() => setShowAddDialog(true)}>
+                <PlusCircle className="h-4 w-4" />
+                Add Cluster
+              </Button>
+            }
+          />
+        ) : (
+          <Panel title="All Clusters" count={clusters.length} bodyClassName="p-0">
             <ClusterList clusters={clusters} onEdit={handleEdit} onDelete={handleDelete} />
-          )}
-        </Panel>
+          </Panel>
+        )}
 
         <AddClusterDialog
           open={showAddDialog}

--- a/frontend/src/pages/domains/index.tsx
+++ b/frontend/src/pages/domains/index.tsx
@@ -156,34 +156,30 @@ export default function DomainsPage() {
           }
         />
 
-        <Panel
-          title="All Domains"
-          count={domains.length}
-          bodyClassName={domains.length === 0 ? "p-5" : "p-0"}
-        >
-          {domains.length === 0 ? (
-            <EmptyState
-              icon={<Globe className="h-8 w-8" />}
-              title="No domain configured"
-              description="Configure a domain for your organization."
-              action={
-                <Button onClick={() => setShowAddDialog(true)} variant="outline">
-                  <PlusCircle className="h-4 w-4" />
-                  Add Domain
-                </Button>
-              }
-            />
-          ) : (
-            domains.map((domain, index) => (
+        {domains.length === 0 ? (
+          <EmptyState
+            icon={<Globe className="h-8 w-8" />}
+            title="No domain configured"
+            description="Configure a domain for your organization."
+            action={
+              <Button onClick={() => setShowAddDialog(true)}>
+                <PlusCircle className="h-4 w-4" />
+                Add Domain
+              </Button>
+            }
+          />
+        ) : (
+          <Panel title="All Domains" count={domains.length} bodyClassName="p-0">
+            {domains.map((domain, index) => (
               <DomainListItem
                 key={index}
                 domain={domain}
                 index={index}
                 onRemove={handleRemoveDomain}
               />
-            ))
-          )}
-        </Panel>
+            ))}
+          </Panel>
+        )}
 
         <AddDomainDialog
           open={showAddDialog}

--- a/frontend/src/pages/object-stores/index.tsx
+++ b/frontend/src/pages/object-stores/index.tsx
@@ -69,32 +69,27 @@ export default function ObjectStoresPage() {
           }
         />
 
-        <Panel
-          title="Organization Object Stores"
-          count={objectStores.length}
-          bodyClassName={objectStores.length === 0 ? "p-5" : "p-0"}
-        >
-          {objectStores.length === 0 ? (
-            <EmptyState
-              icon={<Cloud className="h-8 w-8" />}
-              title="No Object Stores yet"
-              description="Add an S3-compatible bucket, Azure container, or GCS bucket to use as a backup destination."
-              action={
-                canWriteAnyTeam ? (
-                  <Button
-                    onClick={() => {
-                      setEditingStore(null);
-                      setShowAddDialog(true);
-                    }}
-                    variant="outline"
-                  >
-                    <PlusCircle className="h-4 w-4" />
-                    New Object Store
-                  </Button>
-                ) : undefined
-              }
-            />
-          ) : (
+        {objectStores.length === 0 ? (
+          <EmptyState
+            icon={<Cloud className="h-8 w-8" />}
+            title="No Object Stores yet"
+            description="Add an S3-compatible bucket, Azure container, or GCS bucket to use as a backup destination."
+            action={
+              canWriteAnyTeam ? (
+                <Button
+                  onClick={() => {
+                    setEditingStore(null);
+                    setShowAddDialog(true);
+                  }}
+                >
+                  <PlusCircle className="h-4 w-4" />
+                  New Object Store
+                </Button>
+              ) : undefined
+            }
+          />
+        ) : (
+          <Panel title="Organization Object Stores" count={objectStores.length} bodyClassName="p-0">
             <ObjectStoreList
               objectStores={objectStores}
               onEdit={(store) => {
@@ -104,8 +99,8 @@ export default function ObjectStoresPage() {
               onDelete={(store) => setDeletingStore(store)}
               canWrite={(teamId?: string) => canWrite(teamId ?? "")}
             />
-          )}
-        </Panel>
+          </Panel>
+        )}
 
         <ObjectStoreFormDialog
           open={showAddDialog}

--- a/frontend/src/pages/secrets/index.tsx
+++ b/frontend/src/pages/secrets/index.tsx
@@ -171,34 +171,30 @@ export default function SecretsPage() {
           }
         />
 
-        <Panel
-          title="Organization Secrets"
-          count={secrets.length}
-          bodyClassName={secrets.length === 0 ? "p-5" : "p-0"}
-        >
-          {secrets.length === 0 ? (
-            <EmptyState
-              icon={<KeyRound className="h-8 w-8" />}
-              title="No secrets yet"
-              description="Create your first secret to securely store sensitive data."
-              action={
-                canWriteAnyTeam ? (
-                  <Button onClick={() => setShowAddDialog(true)} variant="outline">
-                    <PlusCircle className="h-4 w-4" />
-                    Create Secret
-                  </Button>
-                ) : undefined
-              }
-            />
-          ) : (
+        {secrets.length === 0 ? (
+          <EmptyState
+            icon={<KeyRound className="h-8 w-8" />}
+            title="No secrets yet"
+            description="Create your first secret to securely store sensitive data."
+            action={
+              canWriteAnyTeam ? (
+                <Button onClick={() => setShowAddDialog(true)}>
+                  <PlusCircle className="h-4 w-4" />
+                  Create Secret
+                </Button>
+              ) : undefined
+            }
+          />
+        ) : (
+          <Panel title="Organization Secrets" count={secrets.length} bodyClassName="p-0">
             <SecretList
               secrets={secrets}
               onEdit={handleEdit}
               onDelete={handleDelete}
               canWrite={(teamId?: string) => canWrite(teamId ?? "")}
             />
-          )}
-        </Panel>
+          </Panel>
+        )}
 
         <SecretFormDialog
           open={showAddDialog}


### PR DESCRIPTION
## 📝 What this does
Normalizes the blank-slate (empty state) on every platform list page to the Stacks-page reference pattern, so a user landing on any empty page gets the same consistent, inviting layout.

Closes #113

## 🔀 Changes
- Standardized empty states on Add-ons, Clusters, Domains, Object Stores, and Secrets to match the Stacks page
- Unified blank-slate structure: centered icon, heading, one-line description, and a primary CTA
- Presentational only — no API, schema, or behavior changes

## 🧪 How to test
- [x] Open Object Stores with no object stores → "No Object Stores yet" with a Create CTA
- [x] Open Secrets with no secrets → "No secrets yet" with a Create CTA
- [x] Confirm Add-ons, Clusters, and Domains render the same standardized blank slate when empty