### PR TITLE
Fix config_id filter and add secret name filter

### DIFF
--- a/config/openapi/stackdome_api.yaml
+++ b/config/openapi/stackdome_api.yaml
@@ -442,6 +442,11 @@ paths:
         - Bearer: []
       parameters:
         - $ref: '#/components/parameters/org_id'
+        - in: query
+          name: name
+          schema:
+            type: string
+          description: Filter by secret name
       responses:
         '200':
           description: Successful operation
@@ -1832,6 +1837,11 @@ paths:
       parameters:
         - $ref: '#/components/parameters/org_id'
         - $ref: '#/components/parameters/team_name'
+        - in: query
+          name: name
+          schema:
+            type: string
+          description: Filter by secret name
       responses:
         '200':
           description: Successful operation

--- a/pkg/api/openapi/api/openapi.yaml
+++ b/pkg/api/openapi/api/openapi.yaml
@@ -499,6 +499,14 @@ paths:
         schema:
           type: string
         style: simple
+      - description: Filter by secret name
+        explode: true
+        in: query
+        name: name
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:
@@ -2717,6 +2725,14 @@ paths:
         schema:
           type: string
         style: simple
+      - description: Filter by secret name
+        explode: true
+        in: query
+        name: name
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:

--- a/pkg/api/openapi/api_default.go
+++ b/pkg/api/openapi/api_default.go
@@ -3369,6 +3369,13 @@ type ApiApiV1OrganizationsOrgIdSecretsGetRequest struct {
 	ctx        context.Context
 	ApiService *DefaultApiService
 	orgId      string
+	name       *string
+}
+
+// Filter by secret name
+func (r ApiApiV1OrganizationsOrgIdSecretsGetRequest) Name(name string) ApiApiV1OrganizationsOrgIdSecretsGetRequest {
+	r.name = &name
+	return r
 }
 
 func (r ApiApiV1OrganizationsOrgIdSecretsGetRequest) Execute() (*SecretList, *http.Response, error) {
@@ -3415,6 +3422,9 @@ func (a *DefaultApiService) ApiV1OrganizationsOrgIdSecretsGetExecute(r ApiApiV1O
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.name != nil {
+		localVarQueryParams.Add("name", parameterToString(*r.name, ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -6678,6 +6688,13 @@ type ApiApiV1OrganizationsOrgIdTeamsTeamNameSecretsGetRequest struct {
 	ApiService *DefaultApiService
 	orgId      string
 	teamName   string
+	name       *string
+}
+
+// Filter by secret name
+func (r ApiApiV1OrganizationsOrgIdTeamsTeamNameSecretsGetRequest) Name(name string) ApiApiV1OrganizationsOrgIdTeamsTeamNameSecretsGetRequest {
+	r.name = &name
+	return r
 }
 
 func (r ApiApiV1OrganizationsOrgIdTeamsTeamNameSecretsGetRequest) Execute() (*SecretList, *http.Response, error) {
@@ -6725,6 +6742,9 @@ func (a *DefaultApiService) ApiV1OrganizationsOrgIdTeamsTeamNameSecretsGetExecut
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.name != nil {
+		localVarQueryParams.Add("name", parameterToString(*r.name, ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/pkg/api/openapi/docs/DefaultApi.md
+++ b/pkg/api/openapi/docs/DefaultApi.md
@@ -2144,7 +2144,7 @@ Name | Type | Description  | Notes
 
 ## ApiV1OrganizationsOrgIdSecretsGet
 
-> SecretList ApiV1OrganizationsOrgIdSecretsGet(ctx, orgId).Execute()
+> SecretList ApiV1OrganizationsOrgIdSecretsGet(ctx, orgId).Name(name).Execute()
 
 List all secrets the user has access to across all teams
 
@@ -2164,10 +2164,11 @@ import (
 
 func main() {
     orgId := "orgId_example" // string | The ID of the organization
+    name := "name_example" // string | Filter by secret name (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.DefaultApi.ApiV1OrganizationsOrgIdSecretsGet(context.Background(), orgId).Execute()
+    resp, r, err := apiClient.DefaultApi.ApiV1OrganizationsOrgIdSecretsGet(context.Background(), orgId).Name(name).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ApiV1OrganizationsOrgIdSecretsGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -2193,6 +2194,7 @@ Other parameters are passed through a pointer to a apiApiV1OrganizationsOrgIdSec
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
+ **name** | **string** | Filter by secret name | 
 
 ### Return type
 
@@ -4050,7 +4052,7 @@ Name | Type | Description  | Notes
 
 ## ApiV1OrganizationsOrgIdTeamsTeamNameSecretsGet
 
-> SecretList ApiV1OrganizationsOrgIdTeamsTeamNameSecretsGet(ctx, orgId, teamName).Execute()
+> SecretList ApiV1OrganizationsOrgIdTeamsTeamNameSecretsGet(ctx, orgId, teamName).Name(name).Execute()
 
 List all secrets for a team
 
@@ -4069,10 +4071,11 @@ import (
 func main() {
     orgId := "orgId_example" // string | The ID of the organization
     teamName := "teamName_example" // string | The name of the team
+    name := "name_example" // string | Filter by secret name (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.DefaultApi.ApiV1OrganizationsOrgIdTeamsTeamNameSecretsGet(context.Background(), orgId, teamName).Execute()
+    resp, r, err := apiClient.DefaultApi.ApiV1OrganizationsOrgIdTeamsTeamNameSecretsGet(context.Background(), orgId, teamName).Name(name).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ApiV1OrganizationsOrgIdTeamsTeamNameSecretsGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -4100,6 +4103,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
 
+ **name** | **string** | Filter by secret name | 
 
 ### Return type
 

--- a/pkg/handlers/preview_stack_handler.go
+++ b/pkg/handlers/preview_stack_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ashishmax31/stackdome-api-server/pkg/errors"
 	"github.com/ashishmax31/stackdome-api-server/pkg/presenters"
 	"github.com/ashishmax31/stackdome-api-server/pkg/services"
+	"github.com/ashishmax31/stackdome-api-server/pkg/stores"
 	"github.com/gorilla/mux"
 )
 
@@ -73,7 +74,10 @@ func (h *previewStackHandler) List(w http.ResponseWriter, r *http.Request) {
 			if serr != nil {
 				return nil, serr
 			}
-			params := parseListParams(r, []string{"config_id"})
+			params := parseListParams(r, nil)
+			if configID := r.URL.Query().Get("config_id"); configID != "" {
+				params.Filters = append(params.Filters, stores.Filter{Field: "stack_preview_config_id", Value: configID})
+			}
 			result, serr := h.service.List(r.Context(), teamID, params)
 			if serr != nil {
 				return nil, serr

--- a/pkg/handlers/secret_handler.go
+++ b/pkg/handlers/secret_handler.go
@@ -52,7 +52,8 @@ func (h *secretHandler) ListByOrgID(w http.ResponseWriter, r *http.Request) {
 	cfg := &handlerConfig{
 		Action: func() (interface{}, *errors.ServiceError) {
 			orgID := mux.Vars(r)["org_id"]
-			objs, serr := h.secretService.ListSecretsForCurrentUser(r.Context(), orgID)
+			params := parseListParams(r, []string{"name"})
+			objs, serr := h.secretService.ListSecretsForCurrentUser(r.Context(), orgID, params)
 			if serr != nil {
 				return nil, serr
 			}
@@ -73,7 +74,8 @@ func (h *secretHandler) ListByTeamID(w http.ResponseWriter, r *http.Request) {
 			if serr != nil {
 				return nil, serr
 			}
-			objs, serr := h.secretService.ListByTeamID(ctx, teamID)
+			params := parseListParams(r, []string{"name"})
+			objs, serr := h.secretService.ListByTeamID(ctx, teamID, params)
 			if serr != nil {
 				return nil, serr
 			}

--- a/pkg/mocks/mock_preview_stack_store.go
+++ b/pkg/mocks/mock_preview_stack_store.go
@@ -117,21 +117,6 @@ func (mr *MockPreviewStackStoreMockRecorder) GetByID(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByID", reflect.TypeOf((*MockPreviewStackStore)(nil).GetByID), ctx, id)
 }
 
-// ListNeedingReconciliation mocks base method.
-func (m *MockPreviewStackStore) ListNeedingReconciliation(ctx context.Context, page, pageSize int) ([]*models.PreviewStack, *errors.ServiceError) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNeedingReconciliation", ctx, page, pageSize)
-	ret0, _ := ret[0].([]*models.PreviewStack)
-	ret1, _ := ret[1].(*errors.ServiceError)
-	return ret0, ret1
-}
-
-// ListNeedingReconciliation indicates an expected call of ListNeedingReconciliation.
-func (mr *MockPreviewStackStoreMockRecorder) ListNeedingReconciliation(ctx, page, pageSize any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNeedingReconciliation", reflect.TypeOf((*MockPreviewStackStore)(nil).ListNeedingReconciliation), ctx, page, pageSize)
-}
-
 // ListByConfigID mocks base method.
 func (m *MockPreviewStackStore) ListByConfigID(ctx context.Context, configID string, params stores.ListParams) (*stores.PaginatedResult[*models.PreviewStack], *errors.ServiceError) {
 	m.ctrl.T.Helper()
@@ -160,6 +145,21 @@ func (m *MockPreviewStackStore) ListByTeamID(ctx context.Context, teamID string,
 func (mr *MockPreviewStackStoreMockRecorder) ListByTeamID(ctx, teamID, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByTeamID", reflect.TypeOf((*MockPreviewStackStore)(nil).ListByTeamID), ctx, teamID, params)
+}
+
+// ListNeedingReconciliation mocks base method.
+func (m *MockPreviewStackStore) ListNeedingReconciliation(ctx context.Context, page, pageSize int) ([]*models.PreviewStack, *errors.ServiceError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNeedingReconciliation", ctx, page, pageSize)
+	ret0, _ := ret[0].([]*models.PreviewStack)
+	ret1, _ := ret[1].(*errors.ServiceError)
+	return ret0, ret1
+}
+
+// ListNeedingReconciliation indicates an expected call of ListNeedingReconciliation.
+func (mr *MockPreviewStackStoreMockRecorder) ListNeedingReconciliation(ctx, page, pageSize any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNeedingReconciliation", reflect.TypeOf((*MockPreviewStackStore)(nil).ListNeedingReconciliation), ctx, page, pageSize)
 }
 
 // Update mocks base method.

--- a/pkg/mocks/mock_secret_store.go
+++ b/pkg/mocks/mock_secret_store.go
@@ -15,6 +15,7 @@ import (
 
 	errors "github.com/ashishmax31/stackdome-api-server/pkg/errors"
 	models "github.com/ashishmax31/stackdome-api-server/pkg/models"
+	stores "github.com/ashishmax31/stackdome-api-server/pkg/stores"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -117,48 +118,48 @@ func (mr *MockSecretStoreMockRecorder) GetSecretKeys(ctx, secretID any) *gomock.
 }
 
 // ListByOrganisation mocks base method.
-func (m *MockSecretStore) ListByOrganisation(ctx context.Context, organisationID string) ([]*models.Secret, *errors.ServiceError) {
+func (m *MockSecretStore) ListByOrganisation(ctx context.Context, organisationID string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByOrganisation", ctx, organisationID)
+	ret := m.ctrl.Call(m, "ListByOrganisation", ctx, organisationID, params)
 	ret0, _ := ret[0].([]*models.Secret)
 	ret1, _ := ret[1].(*errors.ServiceError)
 	return ret0, ret1
 }
 
 // ListByOrganisation indicates an expected call of ListByOrganisation.
-func (mr *MockSecretStoreMockRecorder) ListByOrganisation(ctx, organisationID any) *gomock.Call {
+func (mr *MockSecretStoreMockRecorder) ListByOrganisation(ctx, organisationID, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByOrganisation", reflect.TypeOf((*MockSecretStore)(nil).ListByOrganisation), ctx, organisationID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByOrganisation", reflect.TypeOf((*MockSecretStore)(nil).ListByOrganisation), ctx, organisationID, params)
 }
 
 // ListByTeamID mocks base method.
-func (m *MockSecretStore) ListByTeamID(ctx context.Context, teamID string) ([]*models.Secret, *errors.ServiceError) {
+func (m *MockSecretStore) ListByTeamID(ctx context.Context, teamID string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByTeamID", ctx, teamID)
+	ret := m.ctrl.Call(m, "ListByTeamID", ctx, teamID, params)
 	ret0, _ := ret[0].([]*models.Secret)
 	ret1, _ := ret[1].(*errors.ServiceError)
 	return ret0, ret1
 }
 
 // ListByTeamID indicates an expected call of ListByTeamID.
-func (mr *MockSecretStoreMockRecorder) ListByTeamID(ctx, teamID any) *gomock.Call {
+func (mr *MockSecretStoreMockRecorder) ListByTeamID(ctx, teamID, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByTeamID", reflect.TypeOf((*MockSecretStore)(nil).ListByTeamID), ctx, teamID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByTeamID", reflect.TypeOf((*MockSecretStore)(nil).ListByTeamID), ctx, teamID, params)
 }
 
 // ListByTeamIDs mocks base method.
-func (m *MockSecretStore) ListByTeamIDs(ctx context.Context, teamIDs []string) ([]*models.Secret, *errors.ServiceError) {
+func (m *MockSecretStore) ListByTeamIDs(ctx context.Context, teamIDs []string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByTeamIDs", ctx, teamIDs)
+	ret := m.ctrl.Call(m, "ListByTeamIDs", ctx, teamIDs, params)
 	ret0, _ := ret[0].([]*models.Secret)
 	ret1, _ := ret[1].(*errors.ServiceError)
 	return ret0, ret1
 }
 
 // ListByTeamIDs indicates an expected call of ListByTeamIDs.
-func (mr *MockSecretStoreMockRecorder) ListByTeamIDs(ctx, teamIDs any) *gomock.Call {
+func (mr *MockSecretStoreMockRecorder) ListByTeamIDs(ctx, teamIDs, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByTeamIDs", reflect.TypeOf((*MockSecretStore)(nil).ListByTeamIDs), ctx, teamIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByTeamIDs", reflect.TypeOf((*MockSecretStore)(nil).ListByTeamIDs), ctx, teamIDs, params)
 }
 
 // ListByType mocks base method.

--- a/pkg/models/preview_stack.go
+++ b/pkg/models/preview_stack.go
@@ -49,11 +49,14 @@ func (s *PreviewReconcilerStatus) Scan(value any) error {
 		*s = PreviewReconcilerStatus{}
 		return nil
 	}
-	b, ok := value.([]byte)
-	if !ok {
-		return errors.New("type assertion to []byte failed for PreviewReconcilerStatus")
+	switch v := value.(type) {
+	case []byte:
+		return json.Unmarshal(v, s)
+	case string:
+		return json.Unmarshal([]byte(v), s)
+	default:
+		return errors.New("unsupported type for PreviewReconcilerStatus")
 	}
-	return json.Unmarshal(b, s)
 }
 
 // PreviewStackStatus holds the current status of a preview stack.
@@ -73,11 +76,14 @@ func (s *PreviewStackStatus) Scan(value any) error {
 		*s = PreviewStackStatus{}
 		return nil
 	}
-	b, ok := value.([]byte)
-	if !ok {
-		return errors.New("type assertion to []byte failed for PreviewStackStatus")
+	switch v := value.(type) {
+	case []byte:
+		return json.Unmarshal(v, s)
+	case string:
+		return json.Unmarshal([]byte(v), s)
+	default:
+		return errors.New("unsupported type for PreviewStackStatus")
 	}
-	return json.Unmarshal(b, s)
 }
 
 // PreviewStackOutputs holds deployment outputs for a preview stack.
@@ -104,11 +110,14 @@ func (o *ImageOverrides) Scan(value any) error {
 		*o = ImageOverrides{}
 		return nil
 	}
-	b, ok := value.([]byte)
-	if !ok {
-		return errors.New("type assertion to []byte failed for ImageOverrides")
+	switch v := value.(type) {
+	case []byte:
+		return json.Unmarshal(v, o)
+	case string:
+		return json.Unmarshal([]byte(v), o)
+	default:
+		return errors.New("unsupported type for ImageOverrides")
 	}
-	return json.Unmarshal(b, o)
 }
 
 // PreviewStack represents a preview environment spawned from a StackPreviewConfig.

--- a/pkg/services/secret_service.go
+++ b/pkg/services/secret_service.go
@@ -27,9 +27,9 @@ type SecretService interface {
 	GetByName(ctx context.Context, organisationID, name string) (*models.Secret, *errors.ServiceError)
 	Update(ctx context.Context, id string, secret *models.Secret) (*models.Secret, *errors.ServiceError)
 	Delete(ctx context.Context, ID string) *errors.ServiceError
-	ListByOrganisation(ctx context.Context, organisationID string) ([]*models.Secret, *errors.ServiceError)
-	ListByTeamID(ctx context.Context, teamID string) ([]*models.Secret, *errors.ServiceError)
-	ListSecretsForCurrentUser(ctx context.Context, orgID string) ([]*models.Secret, *errors.ServiceError)
+	ListByOrganisation(ctx context.Context, organisationID string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError)
+	ListByTeamID(ctx context.Context, teamID string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError)
+	ListSecretsForCurrentUser(ctx context.Context, orgID string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError)
 	ListByUser(ctx context.Context, organisationID, userID string) ([]*models.Secret, *errors.ServiceError)
 	ListByType(ctx context.Context, organisationID, secretType models.SecretType) ([]*models.Secret, *errors.ServiceError)
 	ValidateSecretExists(ctx context.Context, secretID string) (bool, *errors.ServiceError)
@@ -211,11 +211,11 @@ func (s *secretService) Delete(ctx context.Context, ID string) *errors.ServiceEr
 	return nil
 }
 
-func (s *secretService) ListByOrganisation(ctx context.Context, organisationID string) ([]*models.Secret, *errors.ServiceError) {
+func (s *secretService) ListByOrganisation(ctx context.Context, organisationID string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError) {
 	if permErr := s.permissions.Check(ctx, organisationID, auth.ResourceSecrets, "", auth.ActionList); permErr != nil {
 		return nil, permErr
 	}
-	secrets, err := s.secretStore.ListByOrganisation(ctx, organisationID)
+	secrets, err := s.secretStore.ListByOrganisation(ctx, organisationID, params)
 	if err != nil {
 		return nil, err
 	}
@@ -223,21 +223,21 @@ func (s *secretService) ListByOrganisation(ctx context.Context, organisationID s
 	return secrets, nil
 }
 
-func (s *secretService) ListByTeamID(ctx context.Context, teamID string) ([]*models.Secret, *errors.ServiceError) {
+func (s *secretService) ListByTeamID(ctx context.Context, teamID string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError) {
 	if permErr := s.permissions.Check(ctx, teamID, auth.ResourceSecrets, "", auth.ActionList); permErr != nil {
 		return nil, permErr
 	}
-	return s.secretStore.ListByTeamID(ctx, teamID)
+	return s.secretStore.ListByTeamID(ctx, teamID, params)
 }
 
-func (s *secretService) ListSecretsForCurrentUser(ctx context.Context, orgID string) ([]*models.Secret, *errors.ServiceError) {
+func (s *secretService) ListSecretsForCurrentUser(ctx context.Context, orgID string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError) {
 	identity := auth.GetIdentityFromCtx(ctx)
 	if identity == nil {
 		return nil, errors.Unauthorized("not authenticated")
 	}
 
 	if identity.IsOrgAdmin() {
-		return s.secretStore.ListByOrganisation(ctx, orgID)
+		return s.secretStore.ListByOrganisation(ctx, orgID, params)
 	}
 
 	memberships, serr := s.teamService.InternalListUserTeams(ctx, identity.UserID, orgID)
@@ -252,7 +252,7 @@ func (s *secretService) ListSecretsForCurrentUser(ctx context.Context, orgID str
 		}
 	}
 
-	return s.secretStore.ListByTeamIDs(ctx, allowedTeamIDs)
+	return s.secretStore.ListByTeamIDs(ctx, allowedTeamIDs, params)
 }
 
 func (s *secretService) ListByUser(ctx context.Context, organisationID, userID string) ([]*models.Secret, *errors.ServiceError) {

--- a/pkg/services/team_service.go
+++ b/pkg/services/team_service.go
@@ -227,7 +227,7 @@ func (s *teamService) checkTeamDependencies(ctx context.Context, teamID string) 
 		blocking = append(blocking, fmt.Sprintf("stacks (%d)", len(stacks)))
 	}
 
-	secrets, err := s.secretStore.ListByTeamID(ctx, teamID)
+	secrets, err := s.secretStore.ListByTeamID(ctx, teamID, stores.ListParams{})
 	if err != nil {
 		return errors.InternalServerError("failed to check team dependencies: %s", err.Reason)
 	}

--- a/pkg/stores/pgstore/pgstore_suite_test.go
+++ b/pkg/stores/pgstore/pgstore_suite_test.go
@@ -1,0 +1,13 @@
+package pgstore_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPgstore(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PgStore Suite")
+}

--- a/pkg/stores/pgstore/preview_stack_store_test.go
+++ b/pkg/stores/pgstore/preview_stack_store_test.go
@@ -1,0 +1,240 @@
+package pgstore_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/ashishmax31/stackdome-api-server/pkg/models"
+	"github.com/ashishmax31/stackdome-api-server/pkg/stores"
+	"github.com/ashishmax31/stackdome-api-server/pkg/stores/pgstore"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PreviewStackStore", func() {
+	var (
+		store stores.PreviewStackStore
+		sf    *sqliteSessionFactory
+		ctx   context.Context
+	)
+
+	const (
+		orgID   = "org-1"
+		teamID  = "team-1"
+		teamID2 = "team-2"
+		userID  = "user-1"
+		configA = "config-a"
+		configB = "config-b"
+	)
+
+	BeforeEach(func() {
+		sf = newSQLiteSessionFactory(`
+			CREATE TABLE IF NOT EXISTS preview_stacks (
+				id TEXT PRIMARY KEY,
+				organisation_id TEXT NOT NULL,
+				team_id TEXT NOT NULL,
+				user_id TEXT NOT NULL,
+				stack_preview_config_id TEXT NOT NULL,
+				stack_id TEXT,
+				active_release_id TEXT,
+				name TEXT NOT NULL,
+				pr_number TEXT NOT NULL,
+				branch TEXT NOT NULL,
+				commit_sha TEXT NOT NULL,
+				source TEXT NOT NULL,
+				image_overrides TEXT,
+				labels TEXT,
+				annotations TEXT,
+				status TEXT NOT NULL,
+				reconciler_status TEXT NOT NULL DEFAULT '{}',
+				force_sync_requested_at DATETIME,
+				stackfile_content TEXT,
+				deletion_timestamp DATETIME,
+				created_at DATETIME,
+				updated_at DATETIME
+			)
+		`)
+		store = pgstore.NewPreviewStackStore(pgstore.PreviewStackStoreSpec{SessionFactory: sf})
+		ctx = context.Background()
+
+		now := time.Now()
+		previews := []models.PreviewStack{
+			{
+				ID:                   "ps-1",
+				OrganisationID:       orgID,
+				TeamID:               teamID,
+				UserID:               userID,
+				StackPreviewConfigID: configA,
+				Name:                 "preview-pr-10",
+				PRNumber:             "10",
+				Branch:               "feature/auth",
+				CommitSHA:            "aaa1111",
+				Source:               models.PreviewStackSourceWebhook,
+				CreatedAt:            now.Add(-2 * time.Hour),
+				UpdatedAt:            now.Add(-2 * time.Hour),
+			},
+			{
+				ID:                   "ps-2",
+				OrganisationID:       orgID,
+				TeamID:               teamID,
+				UserID:               userID,
+				StackPreviewConfigID: configB,
+				Name:                 "preview-pr-20",
+				PRNumber:             "20",
+				Branch:               "feature/dashboard",
+				CommitSHA:            "bbb2222",
+				Source:               models.PreviewStackSourceManual,
+				CreatedAt:            now.Add(-1 * time.Hour),
+				UpdatedAt:            now.Add(-1 * time.Hour),
+			},
+			{
+				ID:                   "ps-3",
+				OrganisationID:       orgID,
+				TeamID:               teamID,
+				UserID:               userID,
+				StackPreviewConfigID: configA,
+				Name:                 "preview-pr-30",
+				PRNumber:             "30",
+				Branch:               "fix/login",
+				CommitSHA:            "ccc3333",
+				Source:               models.PreviewStackSourceWebhook,
+				CreatedAt:            now,
+				UpdatedAt:            now,
+			},
+			{
+				ID:                   "ps-4",
+				OrganisationID:       orgID,
+				TeamID:               teamID2,
+				UserID:               userID,
+				StackPreviewConfigID: configA,
+				Name:                 "preview-pr-40",
+				PRNumber:             "40",
+				Branch:               "feature/api",
+				CommitSHA:            "ddd4444",
+				Source:               models.PreviewStackSourceWebhook,
+				CreatedAt:            now,
+				UpdatedAt:            now,
+			},
+		}
+		for i := range previews {
+			Expect(sf.db.Create(&previews[i]).Error).NotTo(HaveOccurred())
+		}
+	})
+
+	Describe("ListByTeamID", func() {
+		Context("with stack_preview_config_id filter", func() {
+			It("returns only previews matching the config", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "stack_preview_config_id", Value: configA}},
+				}
+				result, err := store.ListByTeamID(ctx, teamID, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Items).To(HaveLen(2))
+				for _, item := range result.Items {
+					Expect(item.StackPreviewConfigID).To(Equal(configA))
+					Expect(item.TeamID).To(Equal(teamID))
+				}
+			})
+
+			It("returns single result when only one matches", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "stack_preview_config_id", Value: configB}},
+				}
+				result, err := store.ListByTeamID(ctx, teamID, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Items).To(HaveLen(1))
+				Expect(result.Items[0].StackPreviewConfigID).To(Equal(configB))
+				Expect(result.Items[0].Name).To(Equal("preview-pr-20"))
+			})
+		})
+
+		Context("without filter", func() {
+			It("returns all previews for the team", func() {
+				result, err := store.ListByTeamID(ctx, teamID, stores.ListParams{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Items).To(HaveLen(3))
+				Expect(result.Total).To(Equal(int64(3)))
+			})
+
+			It("does not return previews from other teams", func() {
+				result, err := store.ListByTeamID(ctx, teamID2, stores.ListParams{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Items).To(HaveLen(1))
+				Expect(result.Items[0].ID).To(Equal("ps-4"))
+			})
+		})
+
+		Context("with non-existent config_id", func() {
+			It("returns empty result", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "stack_preview_config_id", Value: "config-nonexistent"}},
+				}
+				result, err := store.ListByTeamID(ctx, teamID, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Items).To(BeEmpty())
+				Expect(result.Total).To(Equal(int64(0)))
+			})
+		})
+
+		Context("with name filter", func() {
+			It("returns only the preview with the matching name", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "name", Value: "preview-pr-10"}},
+				}
+				result, err := store.ListByTeamID(ctx, teamID, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Items).To(HaveLen(1))
+				Expect(result.Items[0].ID).To(Equal("ps-1"))
+			})
+		})
+
+		Context("with multiple filters", func() {
+			It("returns only previews matching all filters", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{
+						{Field: "stack_preview_config_id", Value: configA},
+						{Field: "name", Value: "preview-pr-10"},
+					},
+				}
+				result, err := store.ListByTeamID(ctx, teamID, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Items).To(HaveLen(1))
+				Expect(result.Items[0].ID).To(Equal("ps-1"))
+			})
+		})
+
+		Context("pagination metadata", func() {
+			It("populates total and page info", func() {
+				result, err := store.ListByTeamID(ctx, teamID, stores.ListParams{Page: 1, PageSize: 2})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Items).To(HaveLen(2))
+				Expect(result.Total).To(Equal(int64(3)))
+				Expect(result.Page).To(Equal(1))
+				Expect(result.PageSize).To(Equal(2))
+				Expect(result.TotalPages).To(Equal(2))
+			})
+		})
+	})
+
+	Describe("ListByConfigID", func() {
+		Context("without filter", func() {
+			It("returns all previews for the config across teams", func() {
+				result, err := store.ListByConfigID(ctx, configA, stores.ListParams{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Items).To(HaveLen(3))
+			})
+		})
+
+		Context("with name filter", func() {
+			It("returns only matching preview", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "name", Value: "preview-pr-30"}},
+				}
+				result, err := store.ListByConfigID(ctx, configA, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Items).To(HaveLen(1))
+				Expect(result.Items[0].PRNumber).To(Equal("30"))
+			})
+		})
+	})
+})

--- a/pkg/stores/pgstore/secret.go
+++ b/pkg/stores/pgstore/secret.go
@@ -162,41 +162,44 @@ func (s *secretStore) Delete(ctx context.Context, ID string) *errors.ServiceErro
 	return nil
 }
 
-func (s *secretStore) ListByOrganisation(ctx context.Context, organisationID string) ([]*models.Secret, *errors.ServiceError) {
+func (s *secretStore) ListByOrganisation(ctx context.Context, organisationID string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError) {
 	var secrets []*models.Secret
 
-	if err := s.sessionFactory.New(ctx).
+	query := s.sessionFactory.New(ctx).
 		Where("organisation_id = ?", organisationID).
-		Order("created_at DESC").
-		Find(&secrets).Error; err != nil {
+		Order("created_at DESC")
+	query = params.ApplyFiltersOnly(query)
+	if err := query.Find(&secrets).Error; err != nil {
 		return nil, errors.GeneralError("failed to list secrets: %s", err.Error())
 	}
 
 	return secrets, nil
 }
 
-func (s *secretStore) ListByTeamID(ctx context.Context, teamID string) ([]*models.Secret, *errors.ServiceError) {
+func (s *secretStore) ListByTeamID(ctx context.Context, teamID string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError) {
 	var secrets []*models.Secret
 
-	if err := s.sessionFactory.New(ctx).
+	query := s.sessionFactory.New(ctx).
 		Where("team_id = ?", teamID).
-		Order("created_at DESC").
-		Find(&secrets).Error; err != nil {
+		Order("created_at DESC")
+	query = params.ApplyFiltersOnly(query)
+	if err := query.Find(&secrets).Error; err != nil {
 		return nil, errors.GeneralError("failed to list secrets by team: %s", err.Error())
 	}
 
 	return secrets, nil
 }
 
-func (s *secretStore) ListByTeamIDs(ctx context.Context, teamIDs []string) ([]*models.Secret, *errors.ServiceError) {
+func (s *secretStore) ListByTeamIDs(ctx context.Context, teamIDs []string, params stores.ListParams) ([]*models.Secret, *errors.ServiceError) {
 	if len(teamIDs) == 0 {
 		return []*models.Secret{}, nil
 	}
 	var secrets []*models.Secret
-	if err := s.sessionFactory.New(ctx).
+	query := s.sessionFactory.New(ctx).
 		Where("team_id IN ?", teamIDs).
-		Order("created_at DESC").
-		Find(&secrets).Error; err != nil {
+		Order("created_at DESC")
+	query = params.ApplyFiltersOnly(query)
+	if err := query.Find(&secrets).Error; err != nil {
 		return nil, errors.GeneralError("failed to list secrets by teams: %s", err.Error())
 	}
 	return secrets, nil

--- a/pkg/stores/pgstore/secret_store_test.go
+++ b/pkg/stores/pgstore/secret_store_test.go
@@ -1,0 +1,261 @@
+package pgstore_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/ashishmax31/stackdome-api-server/pkg/models"
+	"github.com/ashishmax31/stackdome-api-server/pkg/stores"
+	"github.com/ashishmax31/stackdome-api-server/pkg/stores/pgstore"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SecretStore", func() {
+	var (
+		store stores.SecretStore
+		sf    *sqliteSessionFactory
+		ctx   context.Context
+	)
+
+	const (
+		orgID  = "org-1"
+		orgID2 = "org-2"
+		teamA  = "team-a"
+		teamB  = "team-b"
+		userID = "user-1"
+	)
+
+	BeforeEach(func() {
+		sf = newSQLiteSessionFactory(`
+			CREATE TABLE IF NOT EXISTS secrets (
+				id TEXT PRIMARY KEY,
+				organisation_id TEXT NOT NULL,
+				team_id TEXT,
+				user_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT,
+				type TEXT NOT NULL,
+				encrypted_data TEXT NOT NULL,
+				keys TEXT,
+				data_hash TEXT NOT NULL,
+				created_at DATETIME,
+				updated_at DATETIME
+			)
+		`)
+		store = pgstore.NewSecretStore(pgstore.SecretStoreSpec{SessionFactory: sf})
+		ctx = context.Background()
+
+		now := time.Now()
+		secrets := []models.Secret{
+			{
+				ID:             "sec-1",
+				OrganisationID: orgID,
+				TeamID:         teamA,
+				UserID:         userID,
+				Name:           "github-pat",
+				Type:           models.SecretTypeToken,
+				EncryptedData:  "enc-data-1",
+				DataHash:       "hash-1",
+				CreatedAt:      now.Add(-2 * time.Hour),
+				UpdatedAt:      now.Add(-2 * time.Hour),
+			},
+			{
+				ID:             "sec-2",
+				OrganisationID: orgID,
+				TeamID:         teamA,
+				UserID:         userID,
+				Name:           "docker-creds",
+				Type:           models.SecretTypeDockerRegistry,
+				EncryptedData:  "enc-data-2",
+				DataHash:       "hash-2",
+				CreatedAt:      now.Add(-1 * time.Hour),
+				UpdatedAt:      now.Add(-1 * time.Hour),
+			},
+			{
+				ID:             "sec-3",
+				OrganisationID: orgID,
+				TeamID:         teamB,
+				UserID:         userID,
+				Name:           "ssh-deploy-key",
+				Type:           models.SecretTypeSSHKey,
+				EncryptedData:  "enc-data-3",
+				DataHash:       "hash-3",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			},
+			{
+				ID:             "sec-4",
+				OrganisationID: orgID2,
+				TeamID:         teamA,
+				UserID:         userID,
+				Name:           "other-org-secret",
+				Type:           models.SecretTypeGeneric,
+				EncryptedData:  "enc-data-4",
+				DataHash:       "hash-4",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			},
+		}
+		for i := range secrets {
+			Expect(sf.db.Create(&secrets[i]).Error).NotTo(HaveOccurred())
+		}
+	})
+
+	Describe("ListByOrganisation", func() {
+		Context("with name filter", func() {
+			It("returns only the matching secret", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "name", Value: "github-pat"}},
+				}
+				results, err := store.ListByOrganisation(ctx, orgID, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(1))
+				Expect(results[0].Name).To(Equal("github-pat"))
+				Expect(results[0].ID).To(Equal("sec-1"))
+			})
+
+			It("returns empty when no match", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "name", Value: "nonexistent"}},
+				}
+				results, err := store.ListByOrganisation(ctx, orgID, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(BeEmpty())
+			})
+		})
+
+		Context("without filter", func() {
+			It("returns all secrets for the org", func() {
+				results, err := store.ListByOrganisation(ctx, orgID, stores.ListParams{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(3))
+			})
+
+			It("does not return secrets from other orgs", func() {
+				results, err := store.ListByOrganisation(ctx, orgID2, stores.ListParams{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(1))
+				Expect(results[0].Name).To(Equal("other-org-secret"))
+			})
+		})
+
+		Context("with type filter", func() {
+			It("returns only secrets matching the type", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "type", Value: models.SecretTypeToken}},
+				}
+				results, err := store.ListByOrganisation(ctx, orgID, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(1))
+				Expect(results[0].Name).To(Equal("github-pat"))
+			})
+		})
+
+		Context("with multiple filters", func() {
+			It("returns only secrets matching all filters", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{
+						{Field: "name", Value: "github-pat"},
+						{Field: "type", Value: models.SecretTypeToken},
+					},
+				}
+				results, err := store.ListByOrganisation(ctx, orgID, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(1))
+				Expect(results[0].ID).To(Equal("sec-1"))
+			})
+
+			It("returns empty when filters contradict", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{
+						{Field: "name", Value: "github-pat"},
+						{Field: "type", Value: models.SecretTypeSSHKey},
+					},
+				}
+				results, err := store.ListByOrganisation(ctx, orgID, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("ListByTeamID", func() {
+		Context("with name filter", func() {
+			It("returns only the matching secret within the team", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "name", Value: "docker-creds"}},
+				}
+				results, err := store.ListByTeamID(ctx, teamA, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(1))
+				Expect(results[0].Name).To(Equal("docker-creds"))
+			})
+		})
+
+		Context("without filter", func() {
+			It("returns all secrets for the team", func() {
+				results, err := store.ListByTeamID(ctx, teamA, stores.ListParams{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(3))
+			})
+
+			It("returns only secrets for the specified team", func() {
+				results, err := store.ListByTeamID(ctx, teamB, stores.ListParams{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(1))
+				Expect(results[0].Name).To(Equal("ssh-deploy-key"))
+			})
+		})
+
+		Context("with non-matching filter", func() {
+			It("returns empty", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "name", Value: "nonexistent"}},
+				}
+				results, err := store.ListByTeamID(ctx, teamA, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("ListByTeamIDs", func() {
+		Context("with name filter", func() {
+			It("returns only matching secrets across teams", func() {
+				params := stores.ListParams{
+					Filters: []stores.Filter{{Field: "name", Value: "github-pat"}},
+				}
+				results, err := store.ListByTeamIDs(ctx, []string{teamA, teamB}, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(1))
+				Expect(results[0].Name).To(Equal("github-pat"))
+			})
+		})
+
+		Context("without filter", func() {
+			It("returns all secrets across the specified teams", func() {
+				results, err := store.ListByTeamIDs(ctx, []string{teamA, teamB}, stores.ListParams{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(4))
+			})
+		})
+
+		Context("with empty team IDs", func() {
+			It("returns empty result", func() {
+				results, err := store.ListByTeamIDs(ctx, []string{}, stores.ListParams{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(BeEmpty())
+			})
+		})
+
+		Context("with single team ID", func() {
+			It("returns only secrets for that team", func() {
+				results, err := store.ListByTeamIDs(ctx, []string{teamB}, stores.ListParams{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).To(HaveLen(1))
+				Expect(results[0].ID).To(Equal("sec-3"))
+			})
+		})
+	})
+})

--- a/pkg/stores/pgstore/testhelpers_test.go
+++ b/pkg/stores/pgstore/testhelpers_test.go
@@ -1,0 +1,34 @@
+package pgstore_test
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/ashishmax31/stackdome-api-server/config"
+	"github.com/glebarez/sqlite"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+)
+
+type sqliteSessionFactory struct {
+	db *gorm.DB
+}
+
+func newSQLiteSessionFactory(ddlStatements ...string) *sqliteSessionFactory {
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	Expect(err).NotTo(HaveOccurred(), "failed to open sqlite db")
+
+	for _, ddl := range ddlStatements {
+		Expect(gdb.Exec(ddl).Error).NotTo(HaveOccurred(), "failed to execute DDL")
+	}
+
+	return &sqliteSessionFactory{db: gdb}
+}
+
+func (f *sqliteSessionFactory) Init(*config.DatabaseConfig) {}
+func (f *sqliteSessionFactory) DirectDB() *sql.DB           { d, _ := f.db.DB(); return d }
+func (f *sqliteSessionFactory) New(context.Context) *gorm.DB {
+	return f.db.Session(&gorm.Session{})
+}
+func (f *sqliteSessionFactory) CheckConnection() error { return nil }
+func (f *sqliteSessionFactory) Close() error           { d, _ := f.db.DB(); return d.Close() }

--- a/pkg/stores/secret.go
+++ b/pkg/stores/secret.go
@@ -15,9 +15,9 @@ type SecretStore interface {
 	Update(ctx context.Context, secret *models.Secret) (*models.Secret, *errors.ServiceError)
 	UpdateEncryptedData(ctx context.Context, secretID string, encryptedData string, keys []string, dataHash string) *errors.ServiceError
 	Delete(ctx context.Context, ID string) *errors.ServiceError
-	ListByOrganisation(ctx context.Context, organisationID string) ([]*models.Secret, *errors.ServiceError)
-	ListByTeamID(ctx context.Context, teamID string) ([]*models.Secret, *errors.ServiceError)
-	ListByTeamIDs(ctx context.Context, teamIDs []string) ([]*models.Secret, *errors.ServiceError)
+	ListByOrganisation(ctx context.Context, organisationID string, params ListParams) ([]*models.Secret, *errors.ServiceError)
+	ListByTeamID(ctx context.Context, teamID string, params ListParams) ([]*models.Secret, *errors.ServiceError)
+	ListByTeamIDs(ctx context.Context, teamIDs []string, params ListParams) ([]*models.Secret, *errors.ServiceError)
 	ListByUser(ctx context.Context, organisationID, userID string) ([]*models.Secret, *errors.ServiceError)
 	ListByType(ctx context.Context, organisationID, secretType models.SecretType) ([]*models.Secret, *errors.ServiceError)
 	ValidateSecretExists(ctx context.Context, secretID string) (bool, *errors.ServiceError)


### PR DESCRIPTION
## Summary

- **Fix config_id filter on preview stacks list**: The `config_id` query param was parsed but never applied — the DB column is `stack_preview_config_id`, causing a silent mismatch. Now maps correctly.
- **Add name filter to secrets list**: Thread `ListParams` through handler → service → store for secrets. `GET /secrets?name=github-pat` now returns only matching secrets.
- **Model Scan portability**: Preview stack custom types now handle both `[]byte` and `string` in `Scan()` methods for DB driver compatibility.

## Test plan

- [x] 22 Ginkgo BDD store-level specs (SQLite in-memory)
  - Secret: name filter on ListByOrganisation, ListByTeamID, ListByTeamIDs
  - PreviewStack: config_id filter on ListByTeamID, ListByConfigID
- [x] `make test` passes
- [ ] Manual curl verification against staging