### PR TITLE
Feature: Thin stack API with declarative PUT /apply

### DIFF
--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -258,6 +258,7 @@ func (s apiServer) routes() *mux.Router {
 	teamResourceRouter.HandleFunc("/stacks/{id}/connections/{connection_id}", stackHandler.UpdateConnection).Methods(http.MethodPut)
 	teamResourceRouter.HandleFunc("/stacks/{id}/connections/{connection_id}", stackHandler.DeleteConnection).Methods(http.MethodDelete)
 	teamResourceRouter.HandleFunc("/stacks/{id}", stackHandler.Update).Methods(http.MethodPut)
+	teamResourceRouter.HandleFunc("/stacks/{id}/apply", stackHandler.Apply).Methods(http.MethodPut)
 	teamResourceRouter.HandleFunc("/stacks/{id}", stackHandler.Delete).Methods(http.MethodDelete)
 	teamResourceRouter.HandleFunc("/stacks/{id}/logs", stackHandler.StreamLogs).Methods(http.MethodGet)
 	teamResourceRouter.HandleFunc("/stacks/{id}/metrics", stackHandler.GetMetrics).Methods(http.MethodGet)

--- a/config/openapi/stackdome_api.yaml
+++ b/config/openapi/stackdome_api.yaml
@@ -1582,6 +1582,10 @@ paths:
   /api/v1/organizations/{org_id}/teams/{team_name}/stacks:
     post:
       summary: Create a new stack
+      description: |
+        Creates a thin stack shell (name, labels, annotations, settings). Any inline
+        `stack_resources`, `volumes`, or `connections` in the body are ignored — add
+        children via `PUT /stacks/{id}/apply` or the individual sub-resource endpoints.
       security:
         - Bearer: []
       parameters:
@@ -1678,6 +1682,10 @@ paths:
                 $ref: '#/components/schemas/Error'
     put:
       summary: Update a stack
+      description: |
+        Updates only shell fields (name, labels, annotations, settings). `namespace` is
+        immutable. Child collections (`stack_resources`, `volumes`, `connections`) in the
+        body are ignored — use `PUT /stacks/{id}/apply` for a full reconcile.
       security:
         - Bearer: []
       parameters:
@@ -1728,6 +1736,48 @@ paths:
                 $ref: '#/components/schemas/Stack'
         '401':
           description: Unauthorized
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/apply:
+    put:
+      summary: Apply a full stack document (declarative reconcile)
+      description: |
+        Declarative whole-document apply. Reconciles the stack against the supplied
+        document: resources and connections not present in the body are deleted, while
+        volumes are add-only and are never deleted. This is the only endpoint that
+        accepts a full stack document.
+      operationId: applyStack
+      security:
+        - Bearer: []
+      parameters:
+        - $ref: '#/components/parameters/org_id'
+        - $ref: '#/components/parameters/team_name'
+        - $ref: '#/components/parameters/id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Stack'
+      responses:
+        '200':
+          description: Stack updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Stack'
+        '401':
+          description: Unauthorized
+        '400':
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: Internal server error
           content:
@@ -1838,6 +1888,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    post:
+      summary: Create a stack resource
+      operationId: createStackResource
+      security:
+        - Bearer: []
+      parameters:
+        - $ref: '#/components/parameters/org_id'
+        - $ref: '#/components/parameters/team_name'
+        - $ref: '#/components/parameters/id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StackResource'
+      responses:
+        '201':
+          description: Stack resource created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StackResource'
+        '400':
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Stack not found
+        '409':
+          description: Stack resource already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources/{resource_name}:
     get:
       summary: Get a specific stack resource by name
@@ -1857,6 +1951,68 @@ paths:
                 $ref: '#/components/schemas/StackResource'
         '401':
           description: Unauthorized
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      summary: Update a stack resource
+      operationId: updateStackResource
+      security:
+        - Bearer: []
+      parameters:
+        - $ref: '#/components/parameters/org_id'
+        - $ref: '#/components/parameters/team_name'
+        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_name'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StackResource'
+      responses:
+        '200':
+          description: Stack resource updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StackResource'
+        '400':
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Stack or resource not found
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      summary: Delete a stack resource
+      operationId: deleteStackResource
+      security:
+        - Bearer: []
+      parameters:
+        - $ref: '#/components/parameters/org_id'
+        - $ref: '#/components/parameters/team_name'
+        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/resource_name'
+      responses:
+        '204':
+          description: Stack resource deleted successfully
+        '401':
+          description: Unauthorized
+        '404':
+          description: Stack or resource not found
         '500':
           description: Internal server error
           content:
@@ -4512,8 +4668,6 @@ components:
 
     StackSpec:
       type: object
-      required:
-        - stack_resources
       properties:
         stack_resources:
           type: array

--- a/frontend/src/api/stacks.ts
+++ b/frontend/src/api/stacks.ts
@@ -58,6 +58,13 @@ export async function updateStack(orgId: string, teamName: string, stackId: stri
   return response.data;
 }
 
+// Declarative reconcile: the only endpoint that accepts a full stack document
+// (resources/volumes/connections inline). POST/PUT stacks ignore inline children.
+export async function applyStack(orgId: string, teamName: string, stackId: string, input: StackUpdateRequest): Promise<Stack> {
+  const response = await api.put<Stack>(`/organizations/${orgId}/teams/${teamName}/stacks/${stackId}/apply`, input);
+  return response.data;
+}
+
 export async function deleteStack(orgId: string, teamName: string, stackId: string): Promise<void> {
   await api.delete(`/organizations/${orgId}/teams/${teamName}/stacks/${stackId}`);
 }

--- a/frontend/src/api/types/openapi.d.ts
+++ b/frontend/src/api/types/openapi.d.ts
@@ -3646,7 +3646,13 @@ export interface paths {
             };
         };
         put?: never;
-        /** Create a new stack */
+        /**
+         * Create a new stack
+         * @description Creates a thin stack shell (name, labels, annotations, settings). Any inline
+         *     `stack_resources`, `volumes`, or `connections` in the body are ignored — add
+         *     children via `PUT /stacks/{id}/apply` or the individual sub-resource endpoints.
+         *
+         */
         post: {
             parameters: {
                 query?: never;
@@ -3767,7 +3773,13 @@ export interface paths {
                 };
             };
         };
-        /** Update a stack */
+        /**
+         * Update a stack
+         * @description Updates only shell fields (name, labels, annotations, settings). `namespace` is
+         *     immutable. Child collections (`stack_resources`, `volumes`, `connections`) in the
+         *     body are ignored — use `PUT /stacks/{id}/apply` for a full reconcile.
+         *
+         */
         put: {
             parameters: {
                 query?: never;
@@ -3869,6 +3881,30 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/apply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Apply a full stack document (declarative reconcile)
+         * @description Declarative whole-document apply. Reconciles the stack against the supplied
+         *     document: resources and connections not present in the body are deleted, while
+         *     volumes are add-only and are never deleted. This is the only endpoint that
+         *     accepts a full stack document.
+         *
+         */
+        put: operations["applyStack"];
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -4057,7 +4093,8 @@ export interface paths {
             };
         };
         put?: never;
-        post?: never;
+        /** Create a stack resource */
+        post: operations["createStackResource"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4117,9 +4154,11 @@ export interface paths {
                 };
             };
         };
-        put?: never;
+        /** Update a stack resource */
+        put: operations["updateStackResource"];
         post?: never;
-        delete?: never;
+        /** Delete a stack resource */
+        delete: operations["deleteStackResource"];
         options?: never;
         head?: never;
         patch?: never;
@@ -7665,7 +7704,7 @@ export interface components {
             total?: number;
         };
         StackSpec: {
-            stack_resources: components["schemas"]["StackResource"][];
+            stack_resources?: components["schemas"]["StackResource"][];
             volumes?: components["schemas"]["Volume"][];
             connections?: components["schemas"]["StackConnection"][];
         };
@@ -8951,6 +8990,249 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    applyStack: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the organization */
+                org_id: components["parameters"]["org_id"];
+                /** @description The name of the team */
+                team_name: components["parameters"]["team_name"];
+                /** @description The id of record */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Stack"];
+            };
+        };
+        responses: {
+            /** @description Stack updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Stack"];
+                };
+            };
+            /** @description Invalid request data */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    createStackResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the organization */
+                org_id: components["parameters"]["org_id"];
+                /** @description The name of the team */
+                team_name: components["parameters"]["team_name"];
+                /** @description The id of record */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StackResource"];
+            };
+        };
+        responses: {
+            /** @description Stack resource created successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StackResource"];
+                };
+            };
+            /** @description Invalid request data */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Stack not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Stack resource already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    updateStackResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the organization */
+                org_id: components["parameters"]["org_id"];
+                /** @description The name of the team */
+                team_name: components["parameters"]["team_name"];
+                /** @description The id of record */
+                id: components["parameters"]["id"];
+                /** @description The name of the stack resource */
+                resource_name: components["parameters"]["resource_name"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StackResource"];
+            };
+        };
+        responses: {
+            /** @description Stack resource updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StackResource"];
+                };
+            };
+            /** @description Invalid request data */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Stack or resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteStackResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the organization */
+                org_id: components["parameters"]["org_id"];
+                /** @description The name of the team */
+                team_name: components["parameters"]["team_name"];
+                /** @description The id of record */
+                id: components["parameters"]["id"];
+                /** @description The name of the stack resource */
+                resource_name: components["parameters"]["resource_name"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Stack resource deleted successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Stack or resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     listReleases: {
         parameters: {
             query?: {

--- a/frontend/src/api/zod-schemas.ts
+++ b/frontend/src/api/zod-schemas.ts
@@ -660,9 +660,10 @@ const StackConnection = z
 const StackSpec = z
   .object({
     stack_resources: z.array(StackResource),
-    volumes: z.array(Volume).optional(),
-    connections: z.array(StackConnection).optional(),
+    volumes: z.array(Volume),
+    connections: z.array(StackConnection),
   })
+  .partial()
   .passthrough();
 const StackSettings = z
   .object({
@@ -5335,6 +5336,10 @@ const endpoints = makeApi([
     method: "post",
     path: "/api/v1/organizations/:org_id/teams/:team_name/stacks",
     alias: "postApiv1organizationsOrg_idteamsTeam_namestacks",
+    description: `Creates a thin stack shell (name, labels, annotations, settings). Any inline
+&#x60;stack_resources&#x60;, &#x60;volumes&#x60;, or &#x60;connections&#x60; in the body are ignored — add
+children via &#x60;PUT /stacks/{id}/apply&#x60; or the individual sub-resource endpoints.
+`,
     requestFormat: "json",
     parameters: [
       {
@@ -5458,6 +5463,10 @@ const endpoints = makeApi([
     method: "put",
     path: "/api/v1/organizations/:org_id/teams/:team_name/stacks/:id",
     alias: "putApiv1organizationsOrg_idteamsTeam_namestacksId",
+    description: `Updates only shell fields (name, labels, annotations, settings). &#x60;namespace&#x60; is
+immutable. Child collections (&#x60;stack_resources&#x60;, &#x60;volumes&#x60;, &#x60;connections&#x60;) in the
+body are ignored — use &#x60;PUT /stacks/{id}/apply&#x60; for a full reconcile.
+`,
     requestFormat: "json",
     parameters: [
       {
@@ -5524,6 +5533,57 @@ const endpoints = makeApi([
     ],
     response: Stack,
     errors: [
+      {
+        status: 401,
+        description: `Unauthorized`,
+        schema: z.void(),
+      },
+      {
+        status: 500,
+        description: `Internal server error`,
+        schema: Error,
+      },
+    ],
+  },
+  {
+    method: "put",
+    path: "/api/v1/organizations/:org_id/teams/:team_name/stacks/:id/apply",
+    alias: "applyStack",
+    description: `Declarative whole-document apply. Reconciles the stack against the supplied
+document: resources and connections not present in the body are deleted, while
+volumes are add-only and are never deleted. This is the only endpoint that
+accepts a full stack document.
+`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: Stack,
+      },
+      {
+        name: "org_id",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "team_name",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "id",
+        type: "Path",
+        schema: z.string(),
+      },
+    ],
+    response: Stack,
+    errors: [
+      {
+        status: 400,
+        description: `Invalid request data`,
+        schema: Error,
+      },
       {
         status: 401,
         description: `Unauthorized`,
@@ -6088,6 +6148,62 @@ const endpoints = makeApi([
     ],
   },
   {
+    method: "post",
+    path: "/api/v1/organizations/:org_id/teams/:team_name/stacks/:id/resources",
+    alias: "createStackResource",
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: StackResource,
+      },
+      {
+        name: "org_id",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "team_name",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "id",
+        type: "Path",
+        schema: z.string(),
+      },
+    ],
+    response: StackResource,
+    errors: [
+      {
+        status: 400,
+        description: `Invalid request data`,
+        schema: Error,
+      },
+      {
+        status: 401,
+        description: `Unauthorized`,
+        schema: z.void(),
+      },
+      {
+        status: 404,
+        description: `Stack not found`,
+        schema: z.void(),
+      },
+      {
+        status: 409,
+        description: `Stack resource already exists`,
+        schema: Error,
+      },
+      {
+        status: 500,
+        description: `Internal server error`,
+        schema: Error,
+      },
+    ],
+  },
+  {
     method: "get",
     path: "/api/v1/organizations/:org_id/teams/:team_name/stacks/:id/resources/:resource_name",
     alias:
@@ -6120,6 +6236,108 @@ const endpoints = makeApi([
       {
         status: 401,
         description: `Unauthorized`,
+        schema: z.void(),
+      },
+      {
+        status: 500,
+        description: `Internal server error`,
+        schema: Error,
+      },
+    ],
+  },
+  {
+    method: "put",
+    path: "/api/v1/organizations/:org_id/teams/:team_name/stacks/:id/resources/:resource_name",
+    alias: "updateStackResource",
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: StackResource,
+      },
+      {
+        name: "org_id",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "team_name",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "id",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "resource_name",
+        type: "Path",
+        schema: z.string(),
+      },
+    ],
+    response: StackResource,
+    errors: [
+      {
+        status: 400,
+        description: `Invalid request data`,
+        schema: Error,
+      },
+      {
+        status: 401,
+        description: `Unauthorized`,
+        schema: z.void(),
+      },
+      {
+        status: 404,
+        description: `Stack or resource not found`,
+        schema: z.void(),
+      },
+      {
+        status: 500,
+        description: `Internal server error`,
+        schema: Error,
+      },
+    ],
+  },
+  {
+    method: "delete",
+    path: "/api/v1/organizations/:org_id/teams/:team_name/stacks/:id/resources/:resource_name",
+    alias: "deleteStackResource",
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "org_id",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "team_name",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "id",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "resource_name",
+        type: "Path",
+        schema: z.string(),
+      },
+    ],
+    response: z.void(),
+    errors: [
+      {
+        status: 401,
+        description: `Unauthorized`,
+        schema: z.void(),
+      },
+      {
+        status: 404,
+        description: `Stack or resource not found`,
         schema: z.void(),
       },
       {

--- a/frontend/src/pages/stacks/components/detail/index.tsx
+++ b/frontend/src/pages/stacks/components/detail/index.tsx
@@ -17,7 +17,7 @@ import type { FormStackResourceData, FormVolumeExtendedData as VolumeFormData, F
 import type { StackResource, Volume, Stack } from "@/pages/stacks/types";
 import type { StackConnection } from "@/api/connections";
 import { alignBaselineToDraft } from "@/pages/stacks/lib/stack-diff";
-import { createStack, getStackById, deleteStack } from "@/api/stacks";
+import { createStack, applyStack, getStackById, deleteStack } from "@/api/stacks";
 import { emptyDraftSeed, buildDraftFormData, type DraftSeed } from "@/pages/stacks/lib/canvas/draft-seed";
 import { createRelease, cancelRelease, rollbackRelease } from "@/api/releases";
 import { useReleases } from "@/pages/stacks/components/detail/deployments/use-releases";
@@ -592,7 +592,13 @@ export default function StackDetailPage() {
       }
 
       const apiData = convertFormStackToApiStack(formStackData);
+      // POST creates the shell only (inline children are ignored by the thin API);
+      // the declarative apply populates resources/volumes/connections.
       const created = await createStack(orgId, teamName, apiData);
+      if (!created.id) {
+        throw new Error("Created stack is missing an id");
+      }
+      await applyStack(orgId, teamName, created.id, apiData);
       session.discard();
       navigate(`/stacks/${created.id}`, { replace: true, state: null });
     } catch (err) {

--- a/frontend/src/pages/stacks/hooks/use-stack-revert.ts
+++ b/frontend/src/pages/stacks/hooks/use-stack-revert.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import type { Stack } from "@/api/stacks";
-import { getStackById, updateStack } from "@/api/stacks";
+import { getStackById, applyStack } from "@/api/stacks";
 import { deleteVolume } from "@/api/volumes";
 import type { StackReleaseSnapshot } from "@/api/releases";
 import { snapshotToUpdateRequest, volumesToDelete } from "@/pages/stacks/lib/draft-sync/snapshot-to-update";
@@ -22,7 +22,7 @@ export function useStackRevert({ ids, stack, liveSnapshot, onReverted }: UseStac
     setReverting(true);
     try {
       const req = snapshotToUpdateRequest(liveSnapshot, { name: stack.name, labels: stack.labels });
-      await updateStack(ids.orgId, ids.teamName, ids.stackId, req);
+      await applyStack(ids.orgId, ids.teamName, ids.stackId, req);
       // Draft-only volumes are unmounted after the PUT; remove them (destroys
       // the cluster volume — the confirm dialog carries that warning).
       for (const v of volumesToDelete(stack, liveSnapshot)) {

--- a/pkg/api/openapi/README.md
+++ b/pkg/api/openapi/README.md
@@ -193,6 +193,10 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**ApiV1UsersCurrentTeamsGet**](docs/DefaultApi.md#apiv1userscurrentteamsget) | **Get** /api/v1/users/current/teams | List teams for the current authenticated user
 *DefaultApi* | [**ApiV1UsersIdGet**](docs/DefaultApi.md#apiv1usersidget) | **Get** /api/v1/users/{id} | Get a user
 *DefaultApi* | [**ApiV1WebhooksGithubPost**](docs/DefaultApi.md#apiv1webhooksgithubpost) | **Post** /api/v1/webhooks/github | GitHub webhook receiver (unauthenticated, HMAC-verified)
+*DefaultApi* | [**ApplyStack**](docs/DefaultApi.md#applystack) | **Put** /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/apply | Apply a full stack document (declarative reconcile)
+*DefaultApi* | [**CreateStackResource**](docs/DefaultApi.md#createstackresource) | **Post** /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources | Create a stack resource
+*DefaultApi* | [**DeleteStackResource**](docs/DefaultApi.md#deletestackresource) | **Delete** /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources/{resource_name} | Delete a stack resource
+*DefaultApi* | [**UpdateStackResource**](docs/DefaultApi.md#updatestackresource) | **Put** /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources/{resource_name} | Update a stack resource
 *PreviewConfigsApi* | [**CreatePreviewConfig**](docs/PreviewConfigsApi.md#createpreviewconfig) | **Post** /api/v1/organizations/{org_id}/teams/{team_name}/stack-preview-configs | Create a new preview config
 *PreviewConfigsApi* | [**DeletePreviewConfig**](docs/PreviewConfigsApi.md#deletepreviewconfig) | **Delete** /api/v1/organizations/{org_id}/teams/{team_name}/stack-preview-configs/{id} | Delete a preview config
 *PreviewConfigsApi* | [**GetPreviewConfig**](docs/PreviewConfigsApi.md#getpreviewconfig) | **Get** /api/v1/organizations/{org_id}/teams/{team_name}/stack-preview-configs/{id} | Get a specific preview config

--- a/pkg/api/openapi/api/openapi.yaml
+++ b/pkg/api/openapi/api/openapi.yaml
@@ -2184,6 +2184,10 @@ paths:
       - Bearer: []
       summary: List all stacks for a team
     post:
+      description: "Creates a thin stack shell (name, labels, annotations, settings).\
+        \ Any inline\n`stack_resources`, `volumes`, or `connections` in the body are\
+        \ ignored — add\nchildren via `PUT /stacks/{id}/apply` or the individual sub-resource\
+        \ endpoints.\n"
       parameters:
       - description: The ID of the organization
         explode: false
@@ -2327,6 +2331,10 @@ paths:
       - Bearer: []
       summary: Get a specific stack
     put:
+      description: "Updates only shell fields (name, labels, annotations, settings).\
+        \ `namespace` is\nimmutable. Child collections (`stack_resources`, `volumes`,\
+        \ `connections`) in the\nbody are ignored — use `PUT /stacks/{id}/apply` for\
+        \ a full reconcile.\n"
       parameters:
       - description: The ID of the organization
         explode: false
@@ -2382,6 +2390,68 @@ paths:
       security:
       - Bearer: []
       summary: Update a stack
+  /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/apply:
+    put:
+      description: "Declarative whole-document apply. Reconciles the stack against\
+        \ the supplied\ndocument: resources and connections not present in the body\
+        \ are deleted, while\nvolumes are add-only and are never deleted. This is\
+        \ the only endpoint that\naccepts a full stack document.\n"
+      operationId: applyStack
+      parameters:
+      - description: The ID of the organization
+        explode: false
+        in: path
+        name: org_id
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The name of the team
+        explode: false
+        in: path
+        name: team_name
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The id of record
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+        style: simple
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Stack'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Stack'
+          description: Stack updated successfully
+        "401":
+          description: Unauthorized
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid request data
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Apply a full stack document (declarative reconcile)
   /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/logs:
     get:
       parameters:
@@ -2557,7 +2627,123 @@ paths:
       security:
       - Bearer: []
       summary: List all stack resources under a stack
+    post:
+      operationId: createStackResource
+      parameters:
+      - description: The ID of the organization
+        explode: false
+        in: path
+        name: org_id
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The name of the team
+        explode: false
+        in: path
+        name: team_name
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The id of record
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+        style: simple
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StackResource'
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StackResource'
+          description: Stack resource created successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid request data
+        "401":
+          description: Unauthorized
+        "404":
+          description: Stack not found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Stack resource already exists
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Create a stack resource
   /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources/{resource_name}:
+    delete:
+      operationId: deleteStackResource
+      parameters:
+      - description: The ID of the organization
+        explode: false
+        in: path
+        name: org_id
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The name of the team
+        explode: false
+        in: path
+        name: team_name
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The id of record
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The name of the stack resource
+        explode: false
+        in: path
+        name: resource_name
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "204":
+          description: Stack resource deleted successfully
+        "401":
+          description: Unauthorized
+        "404":
+          description: Stack or resource not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Delete a stack resource
     get:
       parameters:
       - description: The ID of the organization
@@ -2610,6 +2796,73 @@ paths:
       security:
       - Bearer: []
       summary: Get a specific stack resource by name
+    put:
+      operationId: updateStackResource
+      parameters:
+      - description: The ID of the organization
+        explode: false
+        in: path
+        name: org_id
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The name of the team
+        explode: false
+        in: path
+        name: team_name
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The id of record
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The name of the stack resource
+        explode: false
+        in: path
+        name: resource_name
+        required: true
+        schema:
+          type: string
+        style: simple
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StackResource'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StackResource'
+          description: Stack resource updated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid request data
+        "401":
+          description: Unauthorized
+        "404":
+          description: Stack or resource not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Update a stack resource
   /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources/{resource_name}/logs:
     get:
       parameters:
@@ -9139,8 +9392,6 @@ components:
           items:
             $ref: '#/components/schemas/StackConnection'
           type: array
-      required:
-      - stack_resources
       type: object
     StackStatus:
       example:

--- a/pkg/api/openapi/api_default.go
+++ b/pkg/api/openapi/api_default.go
@@ -10703,6 +10703,10 @@ func (r ApiApiV1OrganizationsOrgIdTeamsTeamNameStacksIdPutRequest) Execute() (*S
 /*
 ApiV1OrganizationsOrgIdTeamsTeamNameStacksIdPut Update a stack
 
+Updates only shell fields (name, labels, annotations, settings). `namespace` is
+immutable. Child collections (`stack_resources`, `volumes`, `connections`) in the
+body are ignored — use `PUT /stacks/{id}/apply` for a full reconcile.
+
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId The ID of the organization
 	@param teamName The name of the team
@@ -11866,6 +11870,10 @@ func (r ApiApiV1OrganizationsOrgIdTeamsTeamNameStacksPostRequest) Execute() (*St
 
 /*
 ApiV1OrganizationsOrgIdTeamsTeamNameStacksPost Create a new stack
+
+Creates a thin stack shell (name, labels, annotations, settings). Any inline
+`stack_resources`, `volumes`, or `connections` in the body are ignored — add
+children via `PUT /stacks/{id}/apply` or the individual sub-resource endpoints.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgId The ID of the organization
@@ -13713,4 +13721,554 @@ func (a *DefaultApiService) ApiV1WebhooksGithubPostExecute(r ApiApiV1WebhooksGit
 	}
 
 	return localVarHTTPResponse, nil
+}
+
+type ApiApplyStackRequest struct {
+	ctx        context.Context
+	ApiService *DefaultApiService
+	orgId      string
+	teamName   string
+	id         string
+	stack      *Stack
+}
+
+func (r ApiApplyStackRequest) Stack(stack Stack) ApiApplyStackRequest {
+	r.stack = &stack
+	return r
+}
+
+func (r ApiApplyStackRequest) Execute() (*Stack, *http.Response, error) {
+	return r.ApiService.ApplyStackExecute(r)
+}
+
+/*
+ApplyStack Apply a full stack document (declarative reconcile)
+
+Declarative whole-document apply. Reconciles the stack against the supplied
+document: resources and connections not present in the body are deleted, while
+volumes are add-only and are never deleted. This is the only endpoint that
+accepts a full stack document.
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param orgId The ID of the organization
+	@param teamName The name of the team
+	@param id The id of record
+	@return ApiApplyStackRequest
+*/
+func (a *DefaultApiService) ApplyStack(ctx context.Context, orgId string, teamName string, id string) ApiApplyStackRequest {
+	return ApiApplyStackRequest{
+		ApiService: a,
+		ctx:        ctx,
+		orgId:      orgId,
+		teamName:   teamName,
+		id:         id,
+	}
+}
+
+// Execute executes the request
+//
+//	@return Stack
+func (a *DefaultApiService) ApplyStackExecute(r ApiApplyStackRequest) (*Stack, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodPut
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *Stack
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultApiService.ApplyStack")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/apply"
+	localVarPath = strings.Replace(localVarPath, "{"+"org_id"+"}", url.PathEscape(parameterToString(r.orgId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"team_name"+"}", url.PathEscape(parameterToString(r.teamName, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterToString(r.id, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+	if r.stack == nil {
+		return localVarReturnValue, nil, reportError("stack is required and must be specified")
+	}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.stack
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type ApiCreateStackResourceRequest struct {
+	ctx           context.Context
+	ApiService    *DefaultApiService
+	orgId         string
+	teamName      string
+	id            string
+	stackResource *StackResource
+}
+
+func (r ApiCreateStackResourceRequest) StackResource(stackResource StackResource) ApiCreateStackResourceRequest {
+	r.stackResource = &stackResource
+	return r
+}
+
+func (r ApiCreateStackResourceRequest) Execute() (*StackResource, *http.Response, error) {
+	return r.ApiService.CreateStackResourceExecute(r)
+}
+
+/*
+CreateStackResource Create a stack resource
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param orgId The ID of the organization
+	@param teamName The name of the team
+	@param id The id of record
+	@return ApiCreateStackResourceRequest
+*/
+func (a *DefaultApiService) CreateStackResource(ctx context.Context, orgId string, teamName string, id string) ApiCreateStackResourceRequest {
+	return ApiCreateStackResourceRequest{
+		ApiService: a,
+		ctx:        ctx,
+		orgId:      orgId,
+		teamName:   teamName,
+		id:         id,
+	}
+}
+
+// Execute executes the request
+//
+//	@return StackResource
+func (a *DefaultApiService) CreateStackResourceExecute(r ApiCreateStackResourceRequest) (*StackResource, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodPost
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *StackResource
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultApiService.CreateStackResource")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources"
+	localVarPath = strings.Replace(localVarPath, "{"+"org_id"+"}", url.PathEscape(parameterToString(r.orgId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"team_name"+"}", url.PathEscape(parameterToString(r.teamName, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterToString(r.id, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+	if r.stackResource == nil {
+		return localVarReturnValue, nil, reportError("stackResource is required and must be specified")
+	}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.stackResource
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 409 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type ApiDeleteStackResourceRequest struct {
+	ctx          context.Context
+	ApiService   *DefaultApiService
+	orgId        string
+	teamName     string
+	id           string
+	resourceName string
+}
+
+func (r ApiDeleteStackResourceRequest) Execute() (*http.Response, error) {
+	return r.ApiService.DeleteStackResourceExecute(r)
+}
+
+/*
+DeleteStackResource Delete a stack resource
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param orgId The ID of the organization
+	@param teamName The name of the team
+	@param id The id of record
+	@param resourceName The name of the stack resource
+	@return ApiDeleteStackResourceRequest
+*/
+func (a *DefaultApiService) DeleteStackResource(ctx context.Context, orgId string, teamName string, id string, resourceName string) ApiDeleteStackResourceRequest {
+	return ApiDeleteStackResourceRequest{
+		ApiService:   a,
+		ctx:          ctx,
+		orgId:        orgId,
+		teamName:     teamName,
+		id:           id,
+		resourceName: resourceName,
+	}
+}
+
+// Execute executes the request
+func (a *DefaultApiService) DeleteStackResourceExecute(r ApiDeleteStackResourceRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod = http.MethodDelete
+		localVarPostBody   interface{}
+		formFiles          []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultApiService.DeleteStackResource")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources/{resource_name}"
+	localVarPath = strings.Replace(localVarPath, "{"+"org_id"+"}", url.PathEscape(parameterToString(r.orgId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"team_name"+"}", url.PathEscape(parameterToString(r.teamName, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterToString(r.id, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"resource_name"+"}", url.PathEscape(parameterToString(r.resourceName, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
+type ApiUpdateStackResourceRequest struct {
+	ctx           context.Context
+	ApiService    *DefaultApiService
+	orgId         string
+	teamName      string
+	id            string
+	resourceName  string
+	stackResource *StackResource
+}
+
+func (r ApiUpdateStackResourceRequest) StackResource(stackResource StackResource) ApiUpdateStackResourceRequest {
+	r.stackResource = &stackResource
+	return r
+}
+
+func (r ApiUpdateStackResourceRequest) Execute() (*StackResource, *http.Response, error) {
+	return r.ApiService.UpdateStackResourceExecute(r)
+}
+
+/*
+UpdateStackResource Update a stack resource
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param orgId The ID of the organization
+	@param teamName The name of the team
+	@param id The id of record
+	@param resourceName The name of the stack resource
+	@return ApiUpdateStackResourceRequest
+*/
+func (a *DefaultApiService) UpdateStackResource(ctx context.Context, orgId string, teamName string, id string, resourceName string) ApiUpdateStackResourceRequest {
+	return ApiUpdateStackResourceRequest{
+		ApiService:   a,
+		ctx:          ctx,
+		orgId:        orgId,
+		teamName:     teamName,
+		id:           id,
+		resourceName: resourceName,
+	}
+}
+
+// Execute executes the request
+//
+//	@return StackResource
+func (a *DefaultApiService) UpdateStackResourceExecute(r ApiUpdateStackResourceRequest) (*StackResource, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodPut
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *StackResource
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultApiService.UpdateStackResource")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources/{resource_name}"
+	localVarPath = strings.Replace(localVarPath, "{"+"org_id"+"}", url.PathEscape(parameterToString(r.orgId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"team_name"+"}", url.PathEscape(parameterToString(r.teamName, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterToString(r.id, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"resource_name"+"}", url.PathEscape(parameterToString(r.resourceName, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+	if r.stackResource == nil {
+		return localVarReturnValue, nil, reportError("stackResource is required and must be specified")
+	}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.stackResource
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/pkg/api/openapi/docs/DefaultApi.md
+++ b/pkg/api/openapi/docs/DefaultApi.md
@@ -119,6 +119,10 @@ Method | HTTP request | Description
 [**ApiV1UsersCurrentTeamsGet**](DefaultApi.md#ApiV1UsersCurrentTeamsGet) | **Get** /api/v1/users/current/teams | List teams for the current authenticated user
 [**ApiV1UsersIdGet**](DefaultApi.md#ApiV1UsersIdGet) | **Get** /api/v1/users/{id} | Get a user
 [**ApiV1WebhooksGithubPost**](DefaultApi.md#ApiV1WebhooksGithubPost) | **Post** /api/v1/webhooks/github | GitHub webhook receiver (unauthenticated, HMAC-verified)
+[**ApplyStack**](DefaultApi.md#ApplyStack) | **Put** /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/apply | Apply a full stack document (declarative reconcile)
+[**CreateStackResource**](DefaultApi.md#CreateStackResource) | **Post** /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources | Create a stack resource
+[**DeleteStackResource**](DefaultApi.md#DeleteStackResource) | **Delete** /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources/{resource_name} | Delete a stack resource
+[**UpdateStackResource**](DefaultApi.md#UpdateStackResource) | **Put** /api/v1/organizations/{org_id}/teams/{team_name}/stacks/{id}/resources/{resource_name} | Update a stack resource
 
 
 
@@ -6564,6 +6568,8 @@ Name | Type | Description  | Notes
 
 Update a stack
 
+
+
 ### Example
 
 ```go
@@ -6580,7 +6586,7 @@ func main() {
     orgId := "orgId_example" // string | The ID of the organization
     teamName := "teamName_example" // string | The name of the team
     id := "id_example" // string | The id of record
-    stack := *openapiclient.NewStack("Name_example", *openapiclient.NewStackSpec([]openapiclient.StackResource{*openapiclient.NewStackResource("Name_example")})) // Stack | 
+    stack := *openapiclient.NewStack("Name_example", *openapiclient.NewStackSpec()) // Stack | 
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -7261,6 +7267,8 @@ Name | Type | Description  | Notes
 
 Create a new stack
 
+
+
 ### Example
 
 ```go
@@ -7276,7 +7284,7 @@ import (
 func main() {
     orgId := "orgId_example" // string | The ID of the organization
     teamName := "teamName_example" // string | The name of the team
-    stack := *openapiclient.NewStack("Name_example", *openapiclient.NewStackSpec([]openapiclient.StackResource{*openapiclient.NewStackResource("Name_example")})) // Stack | 
+    stack := *openapiclient.NewStack("Name_example", *openapiclient.NewStackSpec()) // Stack | 
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -8356,6 +8364,314 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## ApplyStack
+
+> Stack ApplyStack(ctx, orgId, teamName, id).Stack(stack).Execute()
+
+Apply a full stack document (declarative reconcile)
+
+
+
+### Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    openapiclient "./openapi"
+)
+
+func main() {
+    orgId := "orgId_example" // string | The ID of the organization
+    teamName := "teamName_example" // string | The name of the team
+    id := "id_example" // string | The id of record
+    stack := *openapiclient.NewStack("Name_example", *openapiclient.NewStackSpec()) // Stack | 
+
+    configuration := openapiclient.NewConfiguration()
+    apiClient := openapiclient.NewAPIClient(configuration)
+    resp, r, err := apiClient.DefaultApi.ApplyStack(context.Background(), orgId, teamName, id).Stack(stack).Execute()
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ApplyStack``: %v\n", err)
+        fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+    }
+    // response from `ApplyStack`: Stack
+    fmt.Fprintf(os.Stdout, "Response from `DefaultApi.ApplyStack`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The ID of the organization | 
+**teamName** | **string** | The name of the team | 
+**id** | **string** | The id of record | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiApplyStackRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+ **stack** | [**Stack**](Stack.md) |  | 
+
+### Return type
+
+[**Stack**](Stack.md)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## CreateStackResource
+
+> StackResource CreateStackResource(ctx, orgId, teamName, id).StackResource(stackResource).Execute()
+
+Create a stack resource
+
+### Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    openapiclient "./openapi"
+)
+
+func main() {
+    orgId := "orgId_example" // string | The ID of the organization
+    teamName := "teamName_example" // string | The name of the team
+    id := "id_example" // string | The id of record
+    stackResource := *openapiclient.NewStackResource("Name_example") // StackResource | 
+
+    configuration := openapiclient.NewConfiguration()
+    apiClient := openapiclient.NewAPIClient(configuration)
+    resp, r, err := apiClient.DefaultApi.CreateStackResource(context.Background(), orgId, teamName, id).StackResource(stackResource).Execute()
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateStackResource``: %v\n", err)
+        fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+    }
+    // response from `CreateStackResource`: StackResource
+    fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateStackResource`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The ID of the organization | 
+**teamName** | **string** | The name of the team | 
+**id** | **string** | The id of record | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCreateStackResourceRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+ **stackResource** | [**StackResource**](StackResource.md) |  | 
+
+### Return type
+
+[**StackResource**](StackResource.md)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## DeleteStackResource
+
+> DeleteStackResource(ctx, orgId, teamName, id, resourceName).Execute()
+
+Delete a stack resource
+
+### Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    openapiclient "./openapi"
+)
+
+func main() {
+    orgId := "orgId_example" // string | The ID of the organization
+    teamName := "teamName_example" // string | The name of the team
+    id := "id_example" // string | The id of record
+    resourceName := "resourceName_example" // string | The name of the stack resource
+
+    configuration := openapiclient.NewConfiguration()
+    apiClient := openapiclient.NewAPIClient(configuration)
+    resp, r, err := apiClient.DefaultApi.DeleteStackResource(context.Background(), orgId, teamName, id, resourceName).Execute()
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.DeleteStackResource``: %v\n", err)
+        fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+    }
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The ID of the organization | 
+**teamName** | **string** | The name of the team | 
+**id** | **string** | The id of record | 
+**resourceName** | **string** | The name of the stack resource | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiDeleteStackResourceRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## UpdateStackResource
+
+> StackResource UpdateStackResource(ctx, orgId, teamName, id, resourceName).StackResource(stackResource).Execute()
+
+Update a stack resource
+
+### Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    openapiclient "./openapi"
+)
+
+func main() {
+    orgId := "orgId_example" // string | The ID of the organization
+    teamName := "teamName_example" // string | The name of the team
+    id := "id_example" // string | The id of record
+    resourceName := "resourceName_example" // string | The name of the stack resource
+    stackResource := *openapiclient.NewStackResource("Name_example") // StackResource | 
+
+    configuration := openapiclient.NewConfiguration()
+    apiClient := openapiclient.NewAPIClient(configuration)
+    resp, r, err := apiClient.DefaultApi.UpdateStackResource(context.Background(), orgId, teamName, id, resourceName).StackResource(stackResource).Execute()
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.UpdateStackResource``: %v\n", err)
+        fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+    }
+    // response from `UpdateStackResource`: StackResource
+    fmt.Fprintf(os.Stdout, "Response from `DefaultApi.UpdateStackResource`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The ID of the organization | 
+**teamName** | **string** | The name of the team | 
+**id** | **string** | The id of record | 
+**resourceName** | **string** | The name of the stack resource | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiUpdateStackResourceRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+
+ **stackResource** | [**StackResource**](StackResource.md) |  | 
+
+### Return type
+
+[**StackResource**](StackResource.md)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
 [[Back to Model list]](../README.md#documentation-for-models)

--- a/pkg/api/openapi/docs/StackSpec.md
+++ b/pkg/api/openapi/docs/StackSpec.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**StackResources** | [**[]StackResource**](StackResource.md) |  | 
+**StackResources** | Pointer to [**[]StackResource**](StackResource.md) |  | [optional] 
 **Volumes** | Pointer to [**[]Volume**](Volume.md) |  | [optional] 
 **Connections** | Pointer to [**[]StackConnection**](StackConnection.md) |  | [optional] 
 
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 
 ### NewStackSpec
 
-`func NewStackSpec(stackResources []StackResource, ) *StackSpec`
+`func NewStackSpec() *StackSpec`
 
 NewStackSpec instantiates a new StackSpec object
 This constructor will assign default values to properties that have it defined,
@@ -46,6 +46,11 @@ and a boolean to check if the value has been set.
 
 SetStackResources sets StackResources field to given value.
 
+### HasStackResources
+
+`func (o *StackSpec) HasStackResources() bool`
+
+HasStackResources returns a boolean if a field has been set.
 
 ### GetVolumes
 

--- a/pkg/api/openapi/model_stack_spec.go
+++ b/pkg/api/openapi/model_stack_spec.go
@@ -16,7 +16,7 @@ import (
 
 // StackSpec struct for StackSpec
 type StackSpec struct {
-	StackResources []StackResource   `json:"stack_resources"`
+	StackResources []StackResource   `json:"stack_resources,omitempty"`
 	Volumes        []Volume          `json:"volumes,omitempty"`
 	Connections    []StackConnection `json:"connections,omitempty"`
 }
@@ -25,9 +25,8 @@ type StackSpec struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewStackSpec(stackResources []StackResource) *StackSpec {
+func NewStackSpec() *StackSpec {
 	this := StackSpec{}
-	this.StackResources = stackResources
 	return &this
 }
 
@@ -39,26 +38,34 @@ func NewStackSpecWithDefaults() *StackSpec {
 	return &this
 }
 
-// GetStackResources returns the StackResources field value
+// GetStackResources returns the StackResources field value if set, zero value otherwise.
 func (o *StackSpec) GetStackResources() []StackResource {
-	if o == nil {
+	if o == nil || o.StackResources == nil {
 		var ret []StackResource
 		return ret
 	}
-
 	return o.StackResources
 }
 
-// GetStackResourcesOk returns a tuple with the StackResources field value
+// GetStackResourcesOk returns a tuple with the StackResources field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *StackSpec) GetStackResourcesOk() ([]StackResource, bool) {
-	if o == nil {
+	if o == nil || o.StackResources == nil {
 		return nil, false
 	}
 	return o.StackResources, true
 }
 
-// SetStackResources sets field value
+// HasStackResources returns a boolean if a field has been set.
+func (o *StackSpec) HasStackResources() bool {
+	if o != nil && o.StackResources != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetStackResources gets a reference to the given []StackResource and assigns it to the StackResources field.
 func (o *StackSpec) SetStackResources(v []StackResource) {
 	o.StackResources = v
 }
@@ -129,7 +136,7 @@ func (o *StackSpec) SetConnections(v []StackConnection) {
 
 func (o StackSpec) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-	if true {
+	if o.StackResources != nil {
 		toSerialize["stack_resources"] = o.StackResources
 	}
 	if o.Volumes != nil {

--- a/pkg/handlers/stack_handler.go
+++ b/pkg/handlers/stack_handler.go
@@ -95,6 +95,9 @@ func (h *stackHandler) CreateConnection(w http.ResponseWriter, r *http.Request) 
 	var connection openapi.StackConnection
 	cfg := &handlerConfig{
 		MarshalInto: &connection,
+		Validate: func() *errors.ServiceError {
+			return validation.ValidateStackConnection(&connection)
+		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
 			obj, err := h.stackService.CreateStackConnection(r.Context(), id, presenters.ConvertStackConnection(&connection))
@@ -130,6 +133,9 @@ func (h *stackHandler) UpdateConnection(w http.ResponseWriter, r *http.Request) 
 	var connection openapi.StackConnection
 	cfg := &handlerConfig{
 		MarshalInto: &connection,
+		Validate: func() *errors.ServiceError {
+			return validation.ValidateStackConnection(&connection)
+		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			stackID := mux.Vars(r)["id"]
 			connectionID := mux.Vars(r)["connection_id"]
@@ -256,7 +262,7 @@ func (h *stackHandler) Create(w http.ResponseWriter, r *http.Request) {
 	var ws openapi.Stack
 	cfg := &handlerConfig{
 		&ws,
-		validation.ValidateStack(&ws),
+		validation.ValidateStackShell(&ws),
 		func() (interface{}, *errors.ServiceError) {
 			ctx := r.Context()
 			teamID, serr := resolveTeamID(r, h.teamService)
@@ -272,6 +278,9 @@ func (h *stackHandler) Create(w http.ResponseWriter, r *http.Request) {
 			convertedObject.OrganisationID = orgID
 			convertedObject.TeamID = teamID
 			convertedObject.UserID = identity.UserID
+			convertedObject.StackResources = nil
+			convertedObject.Volumes = nil
+			convertedObject.Connections = nil
 
 			obj, serr := h.stackService.CreateStack(ctx, convertedObject)
 			if serr != nil {
@@ -286,6 +295,44 @@ func (h *stackHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *stackHandler) Update(w http.ResponseWriter, r *http.Request) {
+	var ws openapi.Stack
+	cfg := &handlerConfig{
+		&ws,
+		validation.ValidateStackShell(&ws),
+		func() (interface{}, *errors.ServiceError) {
+			ctx := r.Context()
+			id := mux.Vars(r)["id"]
+			identity := auth.GetIdentityFromCtx(ctx)
+			if identity == nil {
+				return nil, errors.Unauthorized("failed to fetch user")
+			}
+
+			teamID, serr := resolveTeamID(r, h.teamService)
+			if serr != nil {
+				return nil, serr
+			}
+
+			convertedObject := presenters.ConvertStack(&ws)
+			orgID := mux.Vars(r)["org_id"]
+			convertedObject.OrganisationID = orgID
+			convertedObject.TeamID = teamID
+			convertedObject.UserID = identity.UserID
+			convertedObject.StackResources = nil
+			convertedObject.Volumes = nil
+			convertedObject.Connections = nil
+
+			obj, serr := h.stackService.UpdateStackShell(ctx, id, convertedObject)
+			if serr != nil {
+				return nil, serr
+			}
+			return presenters.PresentStack(obj), nil
+		},
+		handleError,
+	}
+	handle(w, r, cfg, http.StatusOK)
+}
+
+func (h *stackHandler) Apply(w http.ResponseWriter, r *http.Request) {
 	var ws openapi.Stack
 	cfg := &handlerConfig{
 		&ws,
@@ -309,6 +356,7 @@ func (h *stackHandler) Update(w http.ResponseWriter, r *http.Request) {
 			convertedObject.TeamID = teamID
 			convertedObject.UserID = identity.UserID
 
+			// Full object update including children resources.
 			obj, serr := h.stackService.UpdateStack(ctx, id, convertedObject)
 			if serr != nil {
 				return nil, serr

--- a/pkg/handlers/stack_resource_handler.go
+++ b/pkg/handlers/stack_resource_handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Stackdome/stackdome/pkg/api/openapi"
 	"github.com/Stackdome/stackdome/pkg/errors"
+	"github.com/Stackdome/stackdome/pkg/handlers/validation"
 	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/presenters"
 	"github.com/Stackdome/stackdome/pkg/services"
@@ -40,6 +41,9 @@ func (h *stackResourceHandler) Create(w http.ResponseWriter, r *http.Request) {
 	var resource openapi.StackResource
 	cfg := &handlerConfig{
 		MarshalInto: &resource,
+		Validate: func() *errors.ServiceError {
+			return validation.ValidateStackResource(&resource, nil)
+		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			stackID := mux.Vars(r)["id"]
 			modelResource := presenters.ConvertStackResource(&resource)
@@ -58,6 +62,9 @@ func (h *stackResourceHandler) Update(w http.ResponseWriter, r *http.Request) {
 	var resource openapi.StackResource
 	cfg := &handlerConfig{
 		MarshalInto: &resource,
+		Validate: func() *errors.ServiceError {
+			return validation.ValidateStackResource(&resource, nil)
+		},
 		Action: func() (interface{}, *errors.ServiceError) {
 			stackID := mux.Vars(r)["id"]
 			resourceName := mux.Vars(r)["resource_name"]

--- a/pkg/handlers/validation/stack.go
+++ b/pkg/handlers/validation/stack.go
@@ -18,13 +18,25 @@ func ValidateStack(in *openapi.Stack) Validate {
 	})
 }
 
+// ValidateStackShell validates only the stack's own (shell) fields, without
+// validating any child stack resources. Use this on thin create/update paths
+// where child resources are managed separately.
+func ValidateStackShell(in *openapi.Stack) Validate {
+	return ValidateAll([]Validate{
+		validateEmpty(in, "Id", "id"),
+		validateEmpty(in, "OrganisationId", "organisation_id"),
+		validateEmpty(in, "Status", "status"),
+		validateLabels(&in.Labels),
+		validateAnnotations(&in.Annotations),
+		validateNotEmpty(in, "Name", "name"),
+		validateEmpty(in, "Namespace", "namespace"),
+	})
+}
+
 func validateStackSpec(in *openapi.Stack) Validate {
 	return func() *errors.ServiceError {
-		if len(in.Spec.StackResources) == 0 {
-			return errors.BadRequest("spec.stack_resources: %s", "spec.resources is required")
-		}
 		for _, wr := range in.Spec.StackResources {
-			if err := validateStackResource(&wr, in); err != nil {
+			if err := ValidateStackResource(&wr, in); err != nil {
 				return err
 			}
 		}
@@ -32,7 +44,10 @@ func validateStackSpec(in *openapi.Stack) Validate {
 	}
 }
 
-func validateStackResource(in *openapi.StackResource, stack *openapi.Stack) *errors.ServiceError {
+// ValidateStackResource validates a single stack resource. When stack is nil,
+// the depends_on check is skipped since peer resources cannot be resolved
+// without the surrounding stack.
+func ValidateStackResource(in *openapi.StackResource, stack *openapi.Stack) *errors.ServiceError {
 	if err := validateEmpty(in, "Id", "id")(); err != nil {
 		return err
 	}
@@ -69,7 +84,7 @@ func validateStackResource(in *openapi.StackResource, stack *openapi.Stack) *err
 		}
 	}
 
-	if len(in.DependsOn) != 0 {
+	if stack != nil && len(in.DependsOn) != 0 {
 		if err := validateDependencies(in, stack); err != nil {
 			return err
 		}

--- a/pkg/handlers/validation/stack_connection.go
+++ b/pkg/handlers/validation/stack_connection.go
@@ -1,0 +1,25 @@
+package validation
+
+import (
+	"github.com/Stackdome/stackdome/pkg/api/openapi"
+	"github.com/Stackdome/stackdome/pkg/errors"
+)
+
+// ValidateStackConnection validates the structurally-required fields of a stack
+// connection on the thin create/update paths. It mirrors the fields the
+// model-level validator relies on (kind, from.type, to.type) without re-checking
+// the type-specific or graph-relative constraints, which need the surrounding
+// stack to resolve. Id is never required here: it is generated on create and
+// supplied via the URL path on update.
+func ValidateStackConnection(in *openapi.StackConnection) *errors.ServiceError {
+	if in.Kind == "" {
+		return errors.BadRequest("kind: %s", "kind is required")
+	}
+	if in.From.Type == "" {
+		return errors.BadRequest("from.type: %s", "from.type is required")
+	}
+	if in.To.Type == "" {
+		return errors.BadRequest("to.type: %s", "to.type is required")
+	}
+	return nil
+}

--- a/pkg/mocks/mock_stack_store.go
+++ b/pkg/mocks/mock_stack_store.go
@@ -326,6 +326,21 @@ func (mr *MockStackStoreMockRecorder) UpdateRevision(ctx, id, revision any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRevision", reflect.TypeOf((*MockStackStore)(nil).UpdateRevision), ctx, id, revision)
 }
 
+// UpdateShellWithTx mocks base method.
+func (m *MockStackStore) UpdateShellWithTx(ctx context.Context, id string, spec *models.Stack) (*models.Stack, *errors.ServiceError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateShellWithTx", ctx, id, spec)
+	ret0, _ := ret[0].(*models.Stack)
+	ret1, _ := ret[1].(*errors.ServiceError)
+	return ret0, ret1
+}
+
+// UpdateShellWithTx indicates an expected call of UpdateShellWithTx.
+func (mr *MockStackStoreMockRecorder) UpdateShellWithTx(ctx, id, spec any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShellWithTx", reflect.TypeOf((*MockStackStore)(nil).UpdateShellWithTx), ctx, id, spec)
+}
+
 // UpdateStatus mocks base method.
 func (m *MockStackStore) UpdateStatus(ctx context.Context, id string, status *models.StackStatus) *errors.ServiceError {
 	m.ctrl.T.Helper()

--- a/pkg/presenters/stack_source_test.go
+++ b/pkg/presenters/stack_source_test.go
@@ -10,7 +10,8 @@ import (
 
 func convertSingleResource(t *testing.T, source *openapi.SourceSpec) *models.StackResource {
 	t.Helper()
-	spec := openapi.NewStackSpec([]openapi.StackResource{{Name: "web", Source: source}})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{{Name: "web", Source: source}})
 	converted := presenters.ConvertStack(openapi.NewStack("demo", *spec))
 	if len(converted.StackResources) != 1 {
 		t.Fatalf("expected one resource, got %d", len(converted.StackResources))

--- a/pkg/presenters/stack_test.go
+++ b/pkg/presenters/stack_test.go
@@ -91,7 +91,7 @@ func TestConvertStackIncludesConnections(t *testing.T) {
 		},
 	})
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{})
+	spec := openapi.NewStackSpec()
 	spec.SetConnections([]openapi.StackConnection{*conn})
 	stack := openapi.NewStack("demo", *spec)
 
@@ -172,7 +172,8 @@ func TestPresentAndConvertStackPreservesEnvVarSelfOutput(t *testing.T) {
 		t.Fatalf("expected presented self_output, got %q", presentedEnv.GetSelfOutput())
 	}
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{
 		{
 			Name:   "web",
 			Source: &openapi.SourceSpec{Image: openapi.NewImageSource("nginx:latest")},

--- a/pkg/services/stack_service.go
+++ b/pkg/services/stack_service.go
@@ -20,6 +20,7 @@ import (
 type StackService interface {
 	CreateStack(ctx context.Context, spec *models.Stack) (*models.Stack, *errors.ServiceError)
 	UpdateStack(ctx context.Context, ID string, spec *models.Stack) (*models.Stack, *errors.ServiceError)
+	UpdateStackShell(ctx context.Context, ID string, spec *models.Stack) (*models.Stack, *errors.ServiceError)
 	ListStackConnections(ctx context.Context, stackID string) (models.StackConnections, *errors.ServiceError)
 	CreateStackConnection(ctx context.Context, stackID string, connection *models.StackConnection) (*models.StackConnection, *errors.ServiceError)
 	CreateStackVolume(ctx context.Context, stackID string, volume *models.Volume) (*models.Volume, *errors.ServiceError)
@@ -208,17 +209,15 @@ func (s *stackService) InternalCreateWithTx(ctx context.Context, spec *models.St
 		return nil, createErr
 	}
 
+	var createdVolumes []*models.Volume
 	for _, volume := range desiredVolumes {
-		if _, err := s.volumeService.InternalCreateWithTx(ctx, createdStack, volume); err != nil {
+		createdVolume, err := s.volumeService.InternalCreateWithTx(ctx, createdStack, volume)
+		if err != nil {
 			return nil, err
 		}
+		createdVolumes = append(createdVolumes, createdVolume)
 	}
-
-	volumesForStack, err := s.volumeService.ListVolumesUsedByStack(ctx, createdStack.ID)
-	if err != nil {
-		return nil, errors.GeneralError("failed to list volumes for stack '%s': %s", createdStack.ID, err.Error())
-	}
-	createdStack.Volumes = volumesForStack
+	createdStack.Volumes = createdVolumes
 
 	for _, resource := range desiredResources {
 		if _, err := s.stackResourceService.InternalCreateWithTx(ctx, createdStack, resource); err != nil {
@@ -226,6 +225,7 @@ func (s *stackService) InternalCreateWithTx(ctx context.Context, spec *models.St
 		}
 	}
 
+	// This is makes sure that we track all the explicit resources we use in the stack.
 	if err := s.referenceService.ReprojectSpec(ctx, createdStack.ID); err != nil {
 		return nil, err
 	}
@@ -297,6 +297,60 @@ func (s *stackService) InternalUpdateStack(ctx context.Context, ID string, spec 
 		}
 	}
 
+	return updatedStack, nil
+}
+
+func (s *stackService) UpdateStackShell(ctx context.Context, ID string, spec *models.Stack) (*models.Stack, *errors.ServiceError) {
+	existingStack, err := s.GetStack(ctx, ID)
+	if err != nil {
+		return nil, err
+	}
+	if permErr := s.permissions.Check(ctx, existingStack.TeamID, auth.ResourceStacks, ID, auth.ActionWrite); permErr != nil {
+		return nil, permErr
+	}
+	return s.InternalUpdateShellStack(ctx, ID, spec)
+}
+
+func (s *stackService) InternalUpdateShellStack(ctx context.Context, ID string, spec *models.Stack) (*models.Stack, *errors.ServiceError) {
+	existingStack, err := s.InternalGetStack(ctx, ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// set namespace
+	spec.ID = existingStack.ID
+	spec.Namespace = existingStack.Namespace
+	spec.ClusterID = existingStack.ClusterID
+	spec.OrganisationID = existingStack.OrganisationID
+	spec.TeamID = existingStack.TeamID
+	spec.UserID = existingStack.UserID
+
+	// Strip children so only the stack's own columns are updated; connections
+	// must NOT be replaced.
+	spec.StackResources = nil
+	spec.Volumes = nil
+	spec.Connections = nil
+
+	var updatedStack *models.Stack
+	err = s.stackStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
+		updatedStack, err = s.InternalUpdateShellWithTx(ctx, spec, existingStack)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return updatedStack, nil
+}
+
+func (s *stackService) InternalUpdateShellWithTx(ctx context.Context, spec *models.Stack, existingStack *models.Stack) (*models.Stack, *errors.ServiceError) {
+	updatedStack, updateErr := s.stackStore.UpdateShellWithTx(ctx, existingStack.ID, spec)
+	if updateErr != nil {
+		return nil, updateErr
+	}
 	return updatedStack, nil
 }
 

--- a/pkg/stores/pgstore/stack.go
+++ b/pkg/stores/pgstore/stack.go
@@ -329,6 +329,22 @@ func (w *stackStore) UpdateWithTx(ctx context.Context, id string, spec *models.S
 	return w.GetByID(ctx, id)
 }
 
+func (w *stackStore) UpdateShellWithTx(ctx context.Context, id string, spec *models.Stack) (*models.Stack, *errors.ServiceError) {
+	_, err := w.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	tx := db.TxFromContext(ctx)
+	if tx == nil {
+		return nil, errors.GeneralError("transaction not found in context")
+	}
+	spec.Status = nil
+	if err := tx.Model(&models.Stack{}).Omit(clause.Associations).Where("id = ?", id).Updates(spec).Error; err != nil {
+		return nil, errors.GeneralError("failed to update stack: %s", err.Error())
+	}
+	return w.GetByID(ctx, id)
+}
+
 func (w *stackStore) UpdateStatus(ctx context.Context, id string, status *models.StackStatus) *errors.ServiceError {
 	if err := w.sessionFactory.New(ctx).Model(&models.Stack{}).Where("id = ?", id).UpdateColumn("status", status).Error; err != nil {
 		return errors.GeneralError("failed to update stack status: %s", err.Error())

--- a/pkg/stores/stack_store.go
+++ b/pkg/stores/stack_store.go
@@ -26,6 +26,7 @@ type StackStore interface {
 	DeleteConnectionWithTx(ctx context.Context, id string, connectionID string) *errors.ServiceError
 	InternalList(ctx context.Context, query string, args ...any) ([]*models.Stack, *errors.ServiceError)
 	UpdateWithTx(ctx context.Context, id string, spec *models.Stack) (*models.Stack, *errors.ServiceError)
+	UpdateShellWithTx(ctx context.Context, id string, spec *models.Stack) (*models.Stack, *errors.ServiceError)
 	UpdateStatus(ctx context.Context, id string, status *models.StackStatus) *errors.ServiceError
 	UpdateForDelete(ctx context.Context, id string, spec *models.Stack) (*models.Stack, *errors.ServiceError)
 	DeleteWithTx(ctx context.Context, id string) *errors.ServiceError

--- a/test/int/resource_reference_test.go
+++ b/test/int/resource_reference_test.go
@@ -112,7 +112,8 @@ var _ = Describe("Resource Reference Delete Protection", func() {
 			updatedImageSpecSource := openapi.SourceSpec{Image: openapi.NewImageSource(shared.TestImage)}
 			updatedResource.SetSource(updatedImageSpecSource)
 			updatedResource.SetPorts([]openapi.Port{*openapi.NewPort("http", 80, false)})
-			updatedSpec := openapi.NewStackSpec([]openapi.StackResource{*updatedResource})
+			updatedSpec := openapi.NewStackSpec()
+			updatedSpec.SetStackResources([]openapi.StackResource{*updatedResource})
 			updatedStack := openapi.NewStack("test-release-ref", *updatedSpec)
 			updatedStack.SetAnnotations([]openapi.Annotation{
 				*openapi.NewAnnotation(shared.SkipProvisioningAnnotationKey, "true"),
@@ -178,7 +179,8 @@ var _ = Describe("Resource Reference Delete Protection", func() {
 			updatedImageSpecSource := openapi.SourceSpec{Image: openapi.NewImageSource(shared.TestImage)}
 			updatedResource.SetSource(updatedImageSpecSource)
 			updatedResource.SetPorts([]openapi.Port{*openapi.NewPort("http", 80, false)})
-			updatedSpec := openapi.NewStackSpec([]openapi.StackResource{*updatedResource})
+			updatedSpec := openapi.NewStackSpec()
+			updatedSpec.SetStackResources([]openapi.StackResource{*updatedResource})
 			updatedStack := openapi.NewStack("test-failed-ref", *updatedSpec)
 			updatedStack.SetAnnotations([]openapi.Annotation{
 				*openapi.NewAnnotation(shared.SkipProvisioningAnnotationKey, "true"),

--- a/test/int/shared/fixtures.go
+++ b/test/int/shared/fixtures.go
@@ -344,7 +344,8 @@ func CreateCrashingStack(name string) *openapi.Stack {
 	exec.SetCommand([]string{"sh", "-c", fmt.Sprintf("echo '%s'; exit 1", CrashMessage)})
 	resource.SetExecutionConfig(*exec)
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*resource})
 	return openapi.NewStack(name, *spec)
 }
 
@@ -356,7 +357,8 @@ func CreateSimpleStack(name string) *openapi.Stack {
 		*openapi.NewPort("http", 80, false),
 	})
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*resource})
 	return openapi.NewStack(name, *spec)
 }
 
@@ -395,7 +397,8 @@ func CreateMultiResourceStack(name string) *openapi.Stack {
 	value.SetOutput("host")
 	conn.SetMappings([]openapi.ConnectionMapping{*openapi.NewConnectionMapping(*target, *value)})
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*backend, *frontend})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*backend, *frontend})
 	spec.SetConnections([]openapi.StackConnection{*conn})
 	return openapi.NewStack(name, *spec)
 }
@@ -416,7 +419,8 @@ func CreateStackWithDependencies(name string) *openapi.Stack {
 	})
 	resourceB.SetDependsOn([]string{"database"})
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*resourceA, *resourceB})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*resourceA, *resourceB})
 	return openapi.NewStack(name, *spec)
 }
 
@@ -448,7 +452,8 @@ func CreateStackWithEnvAndPorts(name string) *openapi.Stack {
 	})
 	resource.SetExecutionConfig(*exec)
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*resource})
 	return openapi.NewStack(name, *spec)
 }
 
@@ -464,7 +469,8 @@ func CreateStackWithInitContainer(name string) *openapi.Stack {
 	initSpec.Command = []string{"sh", "-c", InitCommand}
 	resource.SetInitSpec(*initSpec)
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*resource})
 	return openapi.NewStack(name, *spec)
 }
 
@@ -476,7 +482,8 @@ func CreateStackWithPostgresAddon(name string, addonID string, database string) 
 		*openapi.NewPort("http", 8080, false),
 	})
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*resource})
 	spec.SetConnections([]openapi.StackConnection{
 		postgresEnvConnection(addonID, "app", database, false),
 	})
@@ -491,7 +498,8 @@ func CreateStackWithPostgresAddonSuperuser(name string, addonID string) *openapi
 		*openapi.NewPort("http", 8080, false),
 	})
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*resource})
 	spec.SetConnections([]openapi.StackConnection{
 		postgresEnvConnection(addonID, "app", "", true),
 	})
@@ -559,7 +567,8 @@ func CreateFullStack(name string, addonID string, database string, secretID stri
 		resourceToResourceEnvConnection(FullStackAPIName, FullStackWorkerName),
 	}
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*api, *worker})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*api, *worker})
 	spec.SetVolumes([]openapi.Volume{*volume})
 	spec.SetConnections(connections)
 	return openapi.NewStack(name, *spec)
@@ -635,7 +644,8 @@ func CreateStackWithBrokenBuildSource(name string, repoURL string) *openapi.Stac
 	// push omitted: builds go to the internal cluster registry
 	resource.SetSource(openapi.SourceSpec{Git: gitSource})
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*resource})
 	return openapi.NewStack(name, *spec)
 }
 
@@ -650,14 +660,16 @@ func skipProvisioningAnnotation() []openapi.Annotation {
 }
 
 func CreateSkipProvisioningStack(name string, resources []openapi.StackResource) *openapi.Stack {
-	spec := openapi.NewStackSpec(resources)
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources(resources)
 	stack := openapi.NewStack(name, *spec)
 	stack.SetAnnotations(skipProvisioningAnnotation())
 	return stack
 }
 
 func CreateSkipProvisioningStackWithVolumes(name string, resources []openapi.StackResource, volumes []openapi.Volume) *openapi.Stack {
-	spec := openapi.NewStackSpec(resources)
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources(resources)
 	spec.SetVolumes(volumes)
 	stack := openapi.NewStack(name, *spec)
 	stack.SetAnnotations(skipProvisioningAnnotation())
@@ -665,7 +677,8 @@ func CreateSkipProvisioningStackWithVolumes(name string, resources []openapi.Sta
 }
 
 func CreateSkipProvisioningStackWithConnections(name string, resources []openapi.StackResource, connections []openapi.StackConnection) *openapi.Stack {
-	spec := openapi.NewStackSpec(resources)
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources(resources)
 	spec.SetConnections(connections)
 	stack := openapi.NewStack(name, *spec)
 	stack.SetAnnotations(skipProvisioningAnnotation())
@@ -673,7 +686,8 @@ func CreateSkipProvisioningStackWithConnections(name string, resources []openapi
 }
 
 func CreateSkipProvisioningStackFull(name string, resources []openapi.StackResource, volumes []openapi.Volume, connections []openapi.StackConnection) *openapi.Stack {
-	spec := openapi.NewStackSpec(resources)
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources(resources)
 	spec.SetVolumes(volumes)
 	spec.SetConnections(connections)
 	stack := openapi.NewStack(name, *spec)
@@ -705,14 +719,16 @@ func SecretEnvConnection(secretID, targetResource, envName, outputKey string) op
 }
 
 func CreateSimulatedReleaseStack(name string, resources []openapi.StackResource, state string) *openapi.Stack {
-	spec := openapi.NewStackSpec(resources)
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources(resources)
 	stack := openapi.NewStack(name, *spec)
 	stack.SetAnnotations(simulateReleaseAnnotations(state))
 	return stack
 }
 
 func CreateSimulatedReleaseStackWithConnections(name string, resources []openapi.StackResource, connections []openapi.StackConnection, state string) *openapi.Stack {
-	spec := openapi.NewStackSpec(resources)
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources(resources)
 	spec.SetConnections(connections)
 	stack := openapi.NewStack(name, *spec)
 	stack.SetAnnotations(simulateReleaseAnnotations(state))
@@ -808,6 +824,7 @@ func CreateStackWithBuildSource(name string, repoURL string) *openapi.Stack {
 		*openapi.NewPort("http", int32(BuildSourcePort), true),
 	})
 
-	spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources([]openapi.StackResource{*resource})
 	return openapi.NewStack(name, *spec)
 }

--- a/test/int/shared/helpers.go
+++ b/test/int/shared/helpers.go
@@ -309,8 +309,26 @@ func ExpectPostgresAddonEqual(expected, actual *openapi.PostgresAddon) {
 
 func CreateStack(client *openapi.APIClient, orgID, teamName string, stack *openapi.Stack) *openapi.Stack {
 	ctx := context.Background()
-	resp, httpResp, err := client.DefaultApi.ApiV1OrganizationsOrgIdTeamsTeamNameStacksPost(ctx, orgID, teamName).Stack(*stack).Execute()
+
+	// Thin create: server creates a shell, ignoring inline children.
+	postResp, httpResp, err := client.DefaultApi.ApiV1OrganizationsOrgIdTeamsTeamNameStacksPost(ctx, orgID, teamName).Stack(*stack).Execute()
 	Expect(err).NotTo(HaveOccurred(), "failed to create stack")
+	Expect(httpResp.StatusCode).To(Equal(http.StatusCreated), "unexpected status code")
+	Expect(postResp).NotTo(BeNil(), "expected stack response")
+
+	// Fat apply: submit the same full stack so children are declared.
+	applied, httpResp, err := client.DefaultApi.ApplyStack(ctx, orgID, teamName, postResp.GetId()).Stack(*stack).Execute()
+	Expect(err).NotTo(HaveOccurred(), "failed to apply stack")
+	Expect(httpResp.StatusCode).To(Equal(http.StatusOK), "unexpected status code")
+	Expect(applied).NotTo(BeNil(), "expected applied stack response")
+
+	return applied
+}
+
+func CreateShellStack(client *openapi.APIClient, orgID, teamName string, stack *openapi.Stack) *openapi.Stack {
+	ctx := context.Background()
+	resp, httpResp, err := client.DefaultApi.ApiV1OrganizationsOrgIdTeamsTeamNameStacksPost(ctx, orgID, teamName).Stack(*stack).Execute()
+	Expect(err).NotTo(HaveOccurred(), "failed to create shell stack")
 	Expect(httpResp.StatusCode).To(Equal(http.StatusCreated), "unexpected status code")
 	Expect(resp).NotTo(BeNil(), "expected stack response")
 
@@ -394,8 +412,21 @@ func ListStacks(client *openapi.APIClient, orgID, teamName string) *openapi.Stac
 
 func UpdateStack(client *openapi.APIClient, orgID, teamName, stackID string, stack *openapi.Stack) *openapi.Stack {
 	ctx := context.Background()
+	resp, httpResp, err := client.DefaultApi.ApplyStack(ctx, orgID, teamName, stackID).Stack(*stack).Execute()
+	Expect(err).NotTo(HaveOccurred(), "failed to apply stack")
+	Expect(httpResp.StatusCode).To(Equal(http.StatusOK), "unexpected status code")
+	Expect(resp).NotTo(BeNil(), "expected stack response")
+
+	return resp
+}
+
+// UpdateStackShellH updates a stack via the shell-only PUT endpoint. The server
+// updates shell fields (name, labels, etc.) and ignores any inline children, so
+// existing resources/connections are preserved.
+func UpdateStackShellH(client *openapi.APIClient, orgID, teamName, stackID string, stack *openapi.Stack) *openapi.Stack {
+	ctx := context.Background()
 	resp, httpResp, err := client.DefaultApi.ApiV1OrganizationsOrgIdTeamsTeamNameStacksIdPut(ctx, orgID, teamName, stackID).Stack(*stack).Execute()
-	Expect(err).NotTo(HaveOccurred(), "failed to update stack")
+	Expect(err).NotTo(HaveOccurred(), "failed to update stack shell")
 	Expect(httpResp.StatusCode).To(Equal(http.StatusOK), "unexpected status code")
 	Expect(resp).NotTo(BeNil(), "expected stack response")
 
@@ -430,6 +461,59 @@ func CreateStackExpectError(client *openapi.APIClient, orgID, teamName string, s
 func UpdateStackExpectError(client *openapi.APIClient, orgID, teamName, stackID string, stack *openapi.Stack, expectedStatus int) *openapi.GenericOpenAPIError {
 	ctx := context.Background()
 	_, httpResp, err := client.DefaultApi.ApiV1OrganizationsOrgIdTeamsTeamNameStacksIdPut(ctx, orgID, teamName, stackID).Stack(*stack).Execute()
+	Expect(err).To(HaveOccurred(), "expected error")
+	Expect(httpResp.StatusCode).To(Equal(expectedStatus), "unexpected status code")
+
+	apiErr, ok := err.(*openapi.GenericOpenAPIError)
+	Expect(ok).To(BeTrue(), "expected GenericOpenAPIError")
+
+	return apiErr
+}
+
+func ApplyStackExpectError(client *openapi.APIClient, orgID, teamName, stackID string, stack *openapi.Stack, expectedStatus int) *openapi.GenericOpenAPIError {
+	ctx := context.Background()
+	_, httpResp, err := client.DefaultApi.ApplyStack(ctx, orgID, teamName, stackID).Stack(*stack).Execute()
+	Expect(err).To(HaveOccurred(), "expected error")
+	Expect(httpResp.StatusCode).To(Equal(expectedStatus), "unexpected status code")
+
+	apiErr, ok := err.(*openapi.GenericOpenAPIError)
+	Expect(ok).To(BeTrue(), "expected GenericOpenAPIError")
+
+	return apiErr
+}
+
+// Thin stack sub-resource operations for Ginkgo tests
+
+func AddStackResource(client *openapi.APIClient, orgID, teamName, stackID string, resource *openapi.StackResource) *openapi.StackResource {
+	ctx := context.Background()
+	resp, httpResp, err := client.DefaultApi.CreateStackResource(ctx, orgID, teamName, stackID).StackResource(*resource).Execute()
+	Expect(err).NotTo(HaveOccurred(), "failed to create stack resource")
+	Expect(httpResp.StatusCode).To(Equal(http.StatusCreated), "unexpected status code")
+	Expect(resp).NotTo(BeNil(), "expected stack resource response")
+
+	return resp
+}
+
+func UpdateStackResourceH(client *openapi.APIClient, orgID, teamName, stackID, resourceName string, resource *openapi.StackResource) *openapi.StackResource {
+	ctx := context.Background()
+	resp, httpResp, err := client.DefaultApi.UpdateStackResource(ctx, orgID, teamName, stackID, resourceName).StackResource(*resource).Execute()
+	Expect(err).NotTo(HaveOccurred(), "failed to update stack resource")
+	Expect(httpResp.StatusCode).To(Equal(http.StatusOK), "unexpected status code")
+	Expect(resp).NotTo(BeNil(), "expected stack resource response")
+
+	return resp
+}
+
+func DeleteStackResourceH(client *openapi.APIClient, orgID, teamName, stackID, resourceName string) {
+	ctx := context.Background()
+	httpResp, err := client.DefaultApi.DeleteStackResource(ctx, orgID, teamName, stackID, resourceName).Execute()
+	Expect(err).NotTo(HaveOccurred(), "failed to delete stack resource")
+	Expect(httpResp.StatusCode).To(Equal(http.StatusNoContent), "unexpected status code")
+}
+
+func AddStackResourceExpectError(client *openapi.APIClient, orgID, teamName, stackID string, resource *openapi.StackResource, expectedStatus int) *openapi.GenericOpenAPIError {
+	ctx := context.Background()
+	_, httpResp, err := client.DefaultApi.CreateStackResource(ctx, orgID, teamName, stackID).StackResource(*resource).Execute()
 	Expect(err).To(HaveOccurred(), "expected error")
 	Expect(httpResp.StatusCode).To(Equal(expectedStatus), "unexpected status code")
 

--- a/test/int/stack_dual_flow_test.go
+++ b/test/int/stack_dual_flow_test.go
@@ -1,0 +1,165 @@
+package int
+
+import (
+	"sort"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Stackdome/stackdome/pkg/api/openapi"
+	"github.com/Stackdome/stackdome/pkg/models"
+	"github.com/Stackdome/stackdome/test/int/shared"
+)
+
+var _ = Describe("Stack dual-flow (thin vs fat)", func() {
+	var client *openapi.APIClient
+	var orgID string
+	teamName := models.DefaultTeamName
+
+	BeforeEach(func() {
+		testEnv := GetEnvironment()
+		Expect(testEnv).NotTo(BeNil(), "Test environment should be initialized")
+		client = testEnv.Client
+		orgID = testEnv.OrgID
+	})
+
+	// buildThin drives the thin flow: POST a shell, then add each resource and
+	// connection from the multi-resource fixture incrementally. It uses the
+	// fixture only as a source of resource/connection objects and registers its
+	// own cleanup. Returns the created shell stack.
+	buildThin := func(name string) *openapi.Stack {
+		fat := shared.CreateMultiResourceStack(name)
+
+		shell := shared.CreateShellStack(client, orgID, teamName, openapi.NewStack(name, *openapi.NewStackSpec()))
+		DeferCleanup(func() {
+			shared.DeleteStack(client, orgID, teamName, shell.GetId())
+			shared.WaitForStackDeleted(client, orgID, teamName, shell.GetId(), 2*time.Minute)
+		})
+
+		// Resources must exist before connections that reference them.
+		for i := range fat.Spec.StackResources {
+			res := fat.Spec.StackResources[i]
+			shared.AddStackResource(client, orgID, teamName, shell.GetId(), &res)
+		}
+		for i := range fat.Spec.Connections {
+			conn := fat.Spec.Connections[i]
+			shared.CreateStackConnection(client, orgID, teamName, shell.GetId(), &conn)
+		}
+
+		return shell
+	}
+
+	nodeLabels := func(topology *openapi.StackTopology) []string {
+		labels := []string{}
+		for _, n := range topology.GetNodes() {
+			labels = append(labels, n.GetLabel())
+		}
+		sort.Strings(labels)
+		return labels
+	}
+
+	It("thin flow: shell + incremental children deploys to Ready", func() {
+		shell := buildThin("dual-thin")
+
+		By("Releasing the incrementally-built stack")
+		shared.CreateRelease(client, orgID, teamName, shell.GetId())
+
+		By("Waiting for the stack to become Ready")
+		ready := shared.WaitForStackReady(client, orgID, teamName, shell.GetId(), 5*time.Minute)
+
+		status, ok := ready.GetStatusOk()
+		Expect(ok).To(BeTrue(), "ready stack should have status")
+		Expect(status.GetState()).To(Equal(string(models.StackReady)))
+		Expect(status.GetConditions()).NotTo(BeEmpty(), "ready stack should have conditions")
+	})
+
+	It("fat flow: apply full document deploys to Ready", func() {
+		created, _ := shared.CreateStackAndDeploy(client, orgID, teamName, shared.CreateMultiResourceStack("dual-fat"))
+		stackID := created.GetId()
+
+		DeferCleanup(func() {
+			shared.DeleteStack(client, orgID, teamName, stackID)
+			shared.WaitForStackDeleted(client, orgID, teamName, stackID, 2*time.Minute)
+		})
+
+		By("Waiting for the stack to become Ready")
+		ready := shared.WaitForStackReady(client, orgID, teamName, stackID, 5*time.Minute)
+
+		status, ok := ready.GetStatusOk()
+		Expect(ok).To(BeTrue(), "ready stack should have status")
+		Expect(status.GetState()).To(Equal(string(models.StackReady)))
+	})
+
+	It("both flows produce the same topology", func() {
+		By("Building a stack via the thin flow")
+		thin := buildThin("dual-thin-topo")
+
+		By("Building an equivalent stack via the fat flow")
+		fat := shared.CreateStack(client, orgID, teamName, shared.CreateMultiResourceStack("dual-fat2"))
+		DeferCleanup(func() {
+			shared.DeleteStack(client, orgID, teamName, fat.GetId())
+			shared.WaitForStackDeleted(client, orgID, teamName, fat.GetId(), 2*time.Minute)
+		})
+
+		thinTopology := shared.GetStackTopology(client, orgID, teamName, thin.GetId())
+		fatTopology := shared.GetStackTopology(client, orgID, teamName, fat.GetId())
+
+		By("Comparing node identities")
+		Expect(nodeLabels(thinTopology)).To(Equal(nodeLabels(fatTopology)), "both flows should yield the same node set")
+
+		By("Comparing edge counts")
+		Expect(thinTopology.GetEdges()).To(HaveLen(len(fatTopology.GetEdges())), "both flows should yield the same number of edges")
+	})
+
+	It("thin update: PUT one resource leaves others intact", func() {
+		thin := buildThin("dual-thin-upd")
+
+		By("Updating only the backend resource")
+		updated := openapi.NewStackResource(shared.MultiResourceBackendName)
+		updated.SetSource(openapi.SourceSpec{Image: openapi.NewImageSource(shared.TestImage)})
+		updated.SetPorts([]openapi.Port{
+			*openapi.NewPort("http", shared.MultiResourceBackendPort, false),
+			*openapi.NewPort("metrics", shared.MultiResourceBackendPort+1, false),
+		})
+		exec := openapi.NewExecutionConfig()
+		exec.SetEnvironmentVariables([]openapi.EnvVar{
+			func() openapi.EnvVar { v := openapi.NewEnvVar("EXTRA"); v.SetValue("value"); return *v }(),
+		})
+		updated.SetExecutionConfig(*exec)
+		shared.UpdateStackResourceH(client, orgID, teamName, thin.GetId(), shared.MultiResourceBackendName, updated)
+
+		By("Verifying both resource nodes are still present")
+		topology := shared.GetStackTopology(client, orgID, teamName, thin.GetId())
+		Expect(topology.GetNodes()).To(HaveLen(2), "updating one resource must not drop the others")
+		Expect(nodeLabels(topology)).To(Equal([]string{shared.MultiResourceBackendName, shared.MultiResourceFrontendName}))
+	})
+
+	It("fat update: apply with a resource removed deletes it", func() {
+		fatDoc := shared.CreateMultiResourceStack("dual-fat-del")
+		created := shared.CreateStack(client, orgID, teamName, fatDoc)
+		stackID := created.GetId()
+
+		DeferCleanup(func() {
+			shared.DeleteStack(client, orgID, teamName, stackID)
+			shared.WaitForStackDeleted(client, orgID, teamName, stackID, 2*time.Minute)
+		})
+
+		By("Confirming the full stack has two resources and one connection")
+		Expect(shared.GetStackTopology(client, orgID, teamName, stackID).GetNodes()).To(HaveLen(2))
+		Expect(shared.ListStackConnections(client, orgID, teamName, stackID)).To(HaveLen(1))
+
+		By("Applying a document containing only the backend resource and no connections")
+		backend := fatDoc.Spec.StackResources[0]
+		reducedSpec := openapi.NewStackSpec()
+		reducedSpec.SetStackResources([]openapi.StackResource{backend})
+		reduced := openapi.NewStack("dual-fat-del", *reducedSpec)
+		shared.UpdateStack(client, orgID, teamName, stackID, reduced)
+
+		By("Verifying the frontend node and the connection were delete-missing'd")
+		topology := shared.GetStackTopology(client, orgID, teamName, stackID)
+		Expect(topology.GetNodes()).To(HaveLen(1), "frontend resource should be removed")
+		Expect(topology.GetNodes()[0].GetLabel()).To(Equal(shared.MultiResourceBackendName))
+		Expect(shared.ListStackConnections(client, orgID, teamName, stackID)).To(BeEmpty(), "connection referencing the removed resource should be gone")
+	})
+})

--- a/test/int/stack_test.go
+++ b/test/int/stack_test.go
@@ -60,7 +60,8 @@ var _ = Describe("Stack", func() {
 			web := openapi.NewStackResource("web")
 			web.SetSource(openapi.SourceSpec{Image: openapi.NewImageSource("nginx:1.25-alpine")})
 
-			spec := openapi.NewStackSpec([]openapi.StackResource{*api, *web})
+			spec := openapi.NewStackSpec()
+			spec.SetStackResources([]openapi.StackResource{*api, *web})
 			stack := openapi.NewStack("test-connections", *spec)
 
 			created := shared.CreateStack(client, orgID, teamName, stack)
@@ -166,37 +167,47 @@ var _ = Describe("Stack", func() {
 		It("should reject a stack with empty name", func() {
 			resource := openapi.NewStackResource("web")
 			resource.SetSource(openapi.SourceSpec{Image: openapi.NewImageSource("nginx:1.25-alpine")})
-			spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
+			spec := openapi.NewStackSpec()
+			spec.SetStackResources([]openapi.StackResource{*resource})
 			stack := openapi.NewStack("", *spec)
 
 			shared.CreateStackExpectError(client, orgID, teamName, stack, http.StatusBadRequest)
 		})
 
-		It("should reject a stack with no resources", func() {
-			spec := openapi.NewStackSpec([]openapi.StackResource{})
+		It("should allow creating a stack with no resources", func() {
+			spec := openapi.NewStackSpec()
 			stack := openapi.NewStack("test-no-resources", *spec)
 
-			shared.CreateStackExpectError(client, orgID, teamName, stack, http.StatusBadRequest)
+			created := shared.CreateStack(client, orgID, teamName, stack)
+			Expect(created.Spec.StackResources).To(BeEmpty())
 		})
 
 		It("should reject a resource with neither build nor image spec", func() {
-			resource := openapi.NewStackResource("web")
-			spec := openapi.NewStackSpec([]openapi.StackResource{*resource})
-			stack := openapi.NewStack("test-no-image", *spec)
+			created := shared.CreateShellStack(client, orgID, teamName,
+				openapi.NewStack("test-no-image", *openapi.NewStackSpec()))
 
-			shared.CreateStackExpectError(client, orgID, teamName, stack, http.StatusBadRequest)
+			resource := openapi.NewStackResource("web")
+			spec := openapi.NewStackSpec()
+			spec.SetStackResources([]openapi.StackResource{*resource})
+			badStack := openapi.NewStack("test-no-image", *spec)
+
+			shared.ApplyStackExpectError(client, orgID, teamName, created.GetId(), badStack, http.StatusBadRequest)
 		})
 
 		It("should reject duplicate resource names", func() {
+			created := shared.CreateShellStack(client, orgID, teamName,
+				openapi.NewStack("test-dup-resources", *openapi.NewStackSpec()))
+
 			resource1 := openapi.NewStackResource("web")
 			resource1.SetSource(openapi.SourceSpec{Image: openapi.NewImageSource("nginx:1.25-alpine")})
 			resource2 := openapi.NewStackResource("web")
 			resource2.SetSource(openapi.SourceSpec{Image: openapi.NewImageSource("nginx:1.25-alpine")})
 
-			spec := openapi.NewStackSpec([]openapi.StackResource{*resource1, *resource2})
-			stack := openapi.NewStack("test-dup-resources", *spec)
+			spec := openapi.NewStackSpec()
+			spec.SetStackResources([]openapi.StackResource{*resource1, *resource2})
+			badStack := openapi.NewStack("test-dup-resources", *spec)
 
-			shared.CreateStackExpectError(client, orgID, teamName, stack, http.StatusBadRequest)
+			shared.ApplyStackExpectError(client, orgID, teamName, created.GetId(), badStack, http.StatusBadRequest)
 		})
 
 		It("should reject duplicate stack names", func() {
@@ -205,6 +216,53 @@ var _ = Describe("Stack", func() {
 
 			duplicate := shared.CreateSimpleStack("test-dup-name")
 			shared.CreateStackExpectError(client, orgID, teamName, duplicate, http.StatusConflict)
+		})
+	})
+
+	Context("Shell-only update", func() {
+		It("PUT /stacks/{id} preserves children", func() {
+			By("Creating a fat stack with two resources and a connection")
+			created := shared.CreateStack(client, orgID, teamName, shared.CreateMultiResourceStack("shell-preserve"))
+			stackID := created.GetId()
+
+			DeferCleanup(func() {
+				shared.DeleteStack(client, orgID, teamName, stackID)
+			})
+
+			By("PUT-ing a shell-only body with a new label and empty resources/connections")
+			shellUpdate := openapi.NewStack("shell-preserve", *openapi.NewStackSpec())
+			shellUpdate.SetLabels([]openapi.Label{*openapi.NewLabel("tier", "shell-only")})
+
+			updated := shared.UpdateStackShellH(client, orgID, teamName, stackID, shellUpdate)
+
+			By("Verifying the label change is reflected")
+			hasLabel := false
+			for _, l := range updated.GetLabels() {
+				if l.GetKey() == "tier" && l.GetValue() == "shell-only" {
+					hasLabel = true
+					break
+				}
+			}
+			Expect(hasLabel).To(BeTrue(), "shell PUT should apply the label change")
+
+			By("Verifying children were preserved, not wiped")
+			topology := shared.GetStackTopology(client, orgID, teamName, stackID)
+			Expect(topology.GetNodes()).To(HaveLen(2), "shell PUT must not drop resources")
+			Expect(topology.GetEdges()).To(HaveLen(1), "shell PUT must not drop the connection edge")
+			Expect(shared.ListStackConnections(client, orgID, teamName, stackID)).To(HaveLen(1), "shell PUT must preserve connections")
+		})
+
+		It("POST /stacks/{id}/resources with invalid source returns 400", func() {
+			shell := shared.CreateShellStack(client, orgID, teamName,
+				openapi.NewStack("shell-bad-resource", *openapi.NewStackSpec()))
+			stackID := shell.GetId()
+
+			DeferCleanup(func() {
+				shared.DeleteStack(client, orgID, teamName, stackID)
+			})
+
+			resource := openapi.NewStackResource("bad")
+			shared.AddStackResourceExpectError(client, orgID, teamName, stackID, resource, http.StatusBadRequest)
 		})
 	})
 })


### PR DESCRIPTION
## 📝 What this does
Splits the stack API into a thin path and a declarative one. Creating or updating a stack now touches only the shell (name, labels, settings); its resources, connections, and volumes are managed incrementally through the sub-resource endpoints. A new `PUT /stacks/{id}/apply` is the single place that accepts a whole stack document and reconciles children — so the destructive delete-missing behavior is opt-in by endpoint, never triggered by an accidental partial update.

## 🔌 API Reference
| Method | Route | Auth | Request | Response |
|--------|-------|------|---------|----------|
| **POST** | `/stacks` | `required` | thin shell (inline children ignored) | created shell |
| **PUT** | `/stacks/{id}` | `required` | shell fields only (children ignored) | updated shell |
| **PUT** | `/stacks/{id}/apply` | `required` | full stack document | reconciled stack |
| **POST/PUT/DELETE** | `/stacks/{id}/resources[/{name}]` | `required` | single resource | resource |

`/apply` semantics: resources and connections reconcile with delete-missing; volumes stay add-only to protect persistent data. `namespace` is immutable after create.

## 🔀 Changes
- Made POST and PUT shell-only and added the declarative apply endpoint backed by a connection-safe columns-only store update
- Moved resource-level validation onto the apply and sub-resource paths; wired input validation into the previously-unvalidated resource handlers
- Marked `stack_resources` optional in the contract and documented the apply and resource write endpoints
- Retargeted the frontend revert and new-stack wizard to create a shell then apply
- Migrated shared test helpers and added a dual-flow spec proving thin and fat builds converge to the same topology

## 🧪 How to test
- [ ] Create an empty stack, then add resources via `POST /stacks/{id}/resources`
- [ ] Apply a full document to the same stack and confirm it reconciles
- [ ] Remove a resource from an apply payload and confirm it is deleted
- [ ] Change a label via `PUT /stacks/{id}` and confirm resources are untouched