### PR TITLE
fix(stacks): canvas UI bugs — changes panel, outputs, node overlap, template defaults, autosave errors

### DIFF
--- a/frontend/src/pages/stacks/components/canvas/ResourceDrawer.tsx
+++ b/frontend/src/pages/stacks/components/canvas/ResourceDrawer.tsx
@@ -22,6 +22,10 @@ interface ResourceDrawerProps {
   resourceIndex: number;
   session: UseStackEditSession;
   baselineResources: Partial<FormStackResourceData>[];
+  /** Server-computed resource outputs keyed by resource name. The draft copy of a
+   *  newly-added resource has no outputs, so the env-var output pickers read from
+   *  this server-truth map (matched by name) instead. */
+  serverOutputsByName?: ReadonlyMap<string, string[]>;
   /** Addon ids linked to the stack — filters the addon picker + drives bindings. */
   connectionAddonIds: ReadonlySet<string>;
   errors: { [field: string]: string | undefined };
@@ -43,6 +47,7 @@ export function ResourceDrawer({
   resourceIndex,
   session,
   baselineResources,
+  serverOutputsByName,
   connectionAddonIds,
   errors,
   onClose,
@@ -68,14 +73,19 @@ export function ResourceDrawer({
       ),
     [allAddons],
   );
+  // Keep the draft's resource name/index/order (preserves unsaved edits &
+  // ordering) but source outputs from the server-truth map by name — a
+  // resource added on the canvas has none in its draft copy until saved.
   const allResources = useMemo(
     () =>
       session.draft.resources.map((r, i) => ({
         name: r.name || `Resource ${i + 1}`,
         index: i,
-        outputs: (r.outputs ?? []).map((o: { name: string }) => o.name),
+        outputs:
+          serverOutputsByName?.get(r.name ?? "") ??
+          (r.outputs ?? []).map((o: { name: string }) => o.name),
       })),
-    [session.draft.resources],
+    [session.draft.resources, serverOutputsByName],
   );
 
   // Replace just this resource in the draft.
@@ -99,6 +109,7 @@ export function ResourceDrawer({
         // cycle advances the baseline.
         volumes: session.draft.volumes,
         allResources,
+        serverOutputsByName,
         secrets,
         addons,
         addonNameById,

--- a/frontend/src/pages/stacks/components/canvas/StackCanvasTab.tsx
+++ b/frontend/src/pages/stacks/components/canvas/StackCanvasTab.tsx
@@ -18,7 +18,7 @@ import type { EditSessionDraft, UseStackEditSession } from "@/pages/stacks/hooks
 import { useStackTopology } from "@/pages/stacks/hooks/use-stack-topology";
 import { deriveGraph } from "@/pages/stacks/lib/canvas/graph-from-connections";
 import { mergeTopology } from "@/pages/stacks/lib/canvas/merge-topology";
-import { layoutGraph } from "@/pages/stacks/lib/canvas/layout-graph";
+import { layoutGraph, NEW_NODE_GAP_X, NEW_NODE_OFFSET_Y } from "@/pages/stacks/lib/canvas/layout-graph";
 import { addBlockToStack } from "@/pages/stacks/lib/block-to-form";
 import { blockCatalog, getBlockById } from "@/pages/stacks/data/blocks/registry";
 import { CanvasEditor } from "./CanvasEditor";
@@ -68,6 +68,9 @@ interface StackCanvasTabProps {
    *  and what a lazily-started session's working draft seeds from. */
   draftResources: Partial<FormStackResourceData>[];
   draftVolumes: Partial<VolumeFormData>[];
+  /** Server-computed resource outputs keyed by resource name — used to populate
+   *  the env-var output pickers for resources whose draft copy has no outputs. */
+  serverOutputsByName?: ReadonlyMap<string, string[]>;
   connectionAddonIds: ReadonlySet<string>;
   addonNameById: ReadonlyMap<string, string>;
   errors: { [index: number]: { [field: string]: string | undefined } };
@@ -92,6 +95,7 @@ function StackCanvasFlow({
   baselineVolumes,
   draftResources,
   draftVolumes,
+  serverOutputsByName,
   connectionAddonIds,
   addonNameById,
   errors,
@@ -229,7 +233,34 @@ function StackCanvasFlow({
     const laid = layoutGraph(mergedGraph);
     setNodes((prev) => {
       const posById = new Map(prev.map((n) => [n.id, n.position]));
-      return laid.nodes.map((n) => ({ ...n, position: posById.get(n.id) ?? n.position })) as CanvasFlowNode[];
+      // Empty canvas (no preserved nodes): use the fresh dagre layout as-is.
+      if (posById.size === 0) return laid.nodes as CanvasFlowNode[];
+      // Bounding box of the PRESERVED nodes — new nodes land below-left of it so
+      // they never overlap the frozen layout (their fresh dagre coords belong to a
+      // different frame and would collide).
+      const preserved = [...posById.values()];
+      const minX = Math.min(...preserved.map((p) => p.x));
+      const maxY = Math.max(...preserved.map((p) => p.y));
+      let newCount = 0;
+      const next = laid.nodes.map((n) => {
+        const kept = posById.get(n.id);
+        if (kept) return { ...n, position: kept } as CanvasFlowNode;
+        // Stagger multiple new nodes in one pass so they don't stack on each other.
+        const position = {
+          x: minX + newCount * NEW_NODE_GAP_X,
+          y: maxY + NEW_NODE_OFFSET_Y,
+        };
+        newCount += 1;
+        return { ...n, position } as CanvasFlowNode;
+      });
+      // TODO: a genuinely-new node parks below-left of the frozen layout and can
+      // land outside the current viewport (the user never sees it appear). A blind
+      // fitView here would work but is unsafe: this effect also re-runs on server
+      // topology refreshes (autosave), so it would reset the user's pan/zoom
+      // mid-edit and could jump the board during a drag. A clean "ensure-visible"
+      // (pan only when the new node is off-screen, no zoom reset) needs viewport
+      // math that risks disrupting drag UX, so it's deferred over forcing a fit.
+      return next;
     });
     setEdges(mergedGraph.edges as Edge[]);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally keyed on topology only
@@ -520,6 +551,7 @@ function StackCanvasFlow({
         resourceIndex={frontEntry.index}
         session={session}
         baselineResources={baselineResources}
+        serverOutputsByName={serverOutputsByName}
         connectionAddonIds={connectionAddonIds}
         errors={errors[frontEntry.index] ?? {}}
         onClose={popDrawer}

--- a/frontend/src/pages/stacks/components/canvas/ViewChangesModal.tsx
+++ b/frontend/src/pages/stacks/components/canvas/ViewChangesModal.tsx
@@ -23,6 +23,12 @@ export interface ViewChangesModalProps {
   diff?: SnapshotDiff;
   /** Total pending changes (drives the header count). */
   count: number;
+  /** Autosave is in a terminal error state — the empty diff means "not saved",
+   *  not "nothing pending". */
+  errored?: boolean;
+  /** Unsaved session dirt exists even though the staged diff (saved-vs-release)
+   *  is empty — the edit is still in flight, so the diff can't show it yet. */
+  dirty?: boolean;
   stackName: string;
   /** Revert one resource/volume by name. Removed entries can't be reverted in
    *  isolation (no draft slot to restore into) — use Discard all for those. */
@@ -181,6 +187,8 @@ export function ViewChangesModal({
   onOpenChange,
   diff,
   count,
+  errored,
+  dirty,
   stackName,
   onDiscardResource,
   onDiscardVolume,
@@ -208,8 +216,16 @@ export function ViewChangesModal({
 
         <div className="flex max-h-[56vh] flex-col gap-1.5 overflow-auto px-5 pb-4 pt-3">
           {empty ? (
-            <p className="py-8 text-center text-[13px] text-fg-muted">
-              {diff ? "No pending changes." : "Saving changes… they'll appear here once saved."}
+            <p
+              className={`py-8 text-center text-[13px] ${errored ? "text-danger" : "text-fg-muted"}`}
+            >
+              {errored
+                ? "Changes couldn't be saved. Fix the highlighted error and try again."
+                : dirty
+                  ? "Saving changes… they'll appear here once saved."
+                  : diff
+                    ? "No pending changes."
+                    : "Saving changes… they'll appear here once saved."}
             </p>
           ) : (
             <>

--- a/frontend/src/pages/stacks/components/detail/deployments/use-deploy-lifecycle.ts
+++ b/frontend/src/pages/stacks/components/detail/deployments/use-deploy-lifecycle.ts
@@ -40,6 +40,25 @@ function diffIsEmpty(d: SnapshotDiff): boolean {
   return d.resources.length === 0 && d.volumes.length === 0 && d.connections.length === 0;
 }
 
+/** Baseline for a stack that has never converged: every saved resource reads as "added". */
+const EMPTY_SNAPSHOT: StackReleaseSnapshot = { resources: [], volumes: [], connections: [] };
+
+/**
+ * Baseline snapshot the saved/draft spec is diffed against, mirroring the phase rules:
+ * the in-flight release while one is deploying, otherwise the live release, and an empty
+ * baseline when the stack has never converged (first deploy). Undefined when a live release
+ * exists but its snapshot hasn't loaded yet — no honest baseline is available, so no diff
+ * is derivable (the drift heuristic covers phase in that transient window).
+ */
+function baselineSnapshot(args: DeriveDeployLifecycleArgs): StackReleaseSnapshot | undefined {
+  const { stack, activeRelease, activeSnapshot, liveSnapshot } = args;
+  const deploying = !!activeRelease && !isTerminal(activeRelease.state);
+  if (deploying) return activeSnapshot;
+  if (liveSnapshot) return liveSnapshot;
+  if (!stack?.status?.last_converged?.release_id) return EMPTY_SNAPSHOT;
+  return undefined;
+}
+
 /**
  * Pure lifecycle derivation. Mutually-exclusive phases, in priority:
  *   editing   — unsaved edits in the session.
@@ -57,7 +76,16 @@ export function deriveDeployLifecycle(args: DeriveDeployLifecycleArgs): DeployLi
   if (!stack) return { phase: "clean", nextSeq };
 
   if (unsaved) {
-    return { phase: "editing", nextSeq };
+    // Keep the "editing" phase, but surface a diff so the changes panel lists the
+    // saved-so-far changes instead of a placeholder. Baseline follows the same rules
+    // as the staged path; undefined only while a live snapshot is still loading.
+    const base = baselineSnapshot(args);
+    const stagedDiff = base ? diffSnapshots(base, specToSnapshot(stack)) : undefined;
+    // Mirror the staged path's "vs #N" anchor so the label doesn't vanish while an
+    // edit is still autosaving: the in-flight release when deploying, else live.
+    const deploying = !!activeRelease && !isTerminal(activeRelease.state);
+    const vsSeq = deploying ? activeRelease!.sequence : liveSeq;
+    return { phase: "editing", stagedDiff, vsSeq, nextSeq };
   }
 
   const spec = specToSnapshot(stack);
@@ -83,14 +111,20 @@ export function deriveDeployLifecycle(args: DeriveDeployLifecycleArgs): DeployLi
 
   const liveReleaseId = stack.status?.last_converged?.release_id;
   if (!liveReleaseId) {
-    // Never converged a release — any saved resources are staged for the first deploy.
-    const hasSpec = (stack.spec?.stack_resources?.length ?? 0) > 0;
-    return { phase: hasSpec ? "staged" : "clean", vsSeq: liveSeq, nextSeq };
+    // Never converged a release — the whole saved spec is staged for the first deploy,
+    // so diff against an empty baseline (every resource/volume/connection reads as added).
+    const d = diffSnapshots(EMPTY_SNAPSHOT, spec);
+    return diffIsEmpty(d)
+      ? { phase: "clean", vsSeq: liveSeq, nextSeq }
+      : { phase: "staged", stagedDiff: d, vsSeq: liveSeq, nextSeq };
   }
 
   // Live snapshot not loaded yet: fall back to a timestamp drift heuristic (else stay clean,
-  // not a false "staged"). Known false-positive: a metadata-only update or clock skew reads as
-  // drift — accepted, since it self-corrects once the live snapshot loads and the real diff runs.
+  // not a false "staged"). No stagedDiff here on purpose — a live release exists but its
+  // snapshot is missing, so there is no honest baseline to diff against (an empty baseline
+  // would mislabel already-deployed resources as added). The panel body shows its "saving"
+  // hint for this transient window; it self-corrects once the live snapshot loads and the
+  // real diff runs. Known false-positive: a metadata-only update or clock skew reads as drift.
   if (liveRelease) {
     const drift = !!stack.updated_at && !!liveRelease.completed_at
       && new Date(stack.updated_at) > new Date(liveRelease.completed_at);

--- a/frontend/src/pages/stacks/components/detail/index.tsx
+++ b/frontend/src/pages/stacks/components/detail/index.tsx
@@ -246,6 +246,21 @@ export default function StackDetailPage() {
     [stackToShow],
   );
 
+  // Server-computed outputs (host, port.<n>, url.<n>, public.<n>.*) keyed by
+  // resource name. The working draft never computes outputs, so a resource added
+  // on the canvas carries none until it is saved. The env-var OUTPUT pickers read
+  // from this server-truth map (matched by name) instead of the draft copy, and
+  // it refreshes with stackToShow after every autosave — no page reload needed.
+  const serverOutputsByName = useMemo<Map<string, string[]>>(
+    () =>
+      new Map(
+        (stackToShow?.spec?.stack_resources ?? [])
+          .filter((r): r is StackResource & { name: string } => !!r.name)
+          .map((r) => [r.name, (r.outputs ?? []).map((o) => o.name)] as [string, string[]]),
+      ),
+    [stackToShow?.spec?.stack_resources],
+  );
+
   // Diff baseline: the deployed snapshot when one exists, so autosaved edits stay
   // visibly dirty/revertable until deployed. Never-deployed stacks fall back to
   // the server state (everything reads as staged for the first deploy).
@@ -368,6 +383,21 @@ export default function StackDetailPage() {
     [stackToShow?.spec?.volumes],
   );
 
+  // Backend validation errors from a failed autosave, mapped onto the offending
+  // env-var field so the row shows them inline. Keyed by resource NAME → env-var
+  // name → message (NOT by index): the resource may be reordered/removed before
+  // the user fixes it, so the current index + env index are resolved at render
+  // time when merging into the index-keyed errors prop.
+  const [serverFieldErrors, setServerFieldErrors] = useState<{
+    [resourceName: string]: { [envName: string]: string };
+  }>({});
+
+  // Dedupe for autosave-failure toasts: the backoff retry loop and re-edits after
+  // a terminal 400 re-run the same ops and would re-toast the same reason every
+  // cycle. Remember the last-shown message and only toast when it changes; cleared
+  // on a successful sync so a later distinct failure still toasts.
+  const lastSyncErrorMsgRef = useRef<string | null>(null);
+
   // Autosave engine: debounces draft changes and syncs thin per-resource ops to
   // the server. Disabled for drafts (nothing exists server-side to sync yet).
   const draftSync = useDraftSync({
@@ -381,7 +411,39 @@ export default function StackDetailPage() {
       setStacks((prev) => prev.map((s) => (s.id === fresh.id ? fresh : s)));
       setTopologyRefreshKey((k) => k + 1);
     },
+    onSyncError: ({ message, op }) => {
+      // No op → the save actually landed and only the post-save refetch failed;
+      // don't alarm the user with a "Save failed" toast or field error.
+      if (!op) return;
+      // Dedupe: skip if this exact reason is already on screen (retry/re-edit).
+      if (lastSyncErrorMsgRef.current === message) return;
+      lastSyncErrorMsgRef.current = message;
+      toast({ title: "Save failed", description: message, variant: "destructive" });
+      // Only resource create/update ops carry env vars; others just toast.
+      if (op.kind !== "createResource" && op.kind !== "updateResource") return;
+      const resourceName = op.resource.name;
+      if (!resourceName) return;
+      // The backend reason names the offending var: `env var '<NAME>'`.
+      const envName = message.match(/env var '([^']+)'/)?.[1];
+      if (!envName) return;
+      // Key by resource + env-var NAME; the current row indices are resolved at
+      // render time so a reorder/removal can't misattach the inline error.
+      setServerFieldErrors((prev) => ({
+        ...prev,
+        [resourceName]: { ...(prev[resourceName] ?? {}), [envName]: message },
+      }));
+    },
   });
+
+  // A successful sync clears any stale server-side field errors (the draft that
+  // failed has since been fixed and persisted) and the toast-dedupe memory so a
+  // later, distinct failure toasts again.
+  useEffect(() => {
+    if (draftSync.status === SYNC_STATUS.saved) {
+      lastSyncErrorMsgRef.current = null;
+      setServerFieldErrors((prev) => (Object.keys(prev).length === 0 ? prev : {}));
+    }
+  }, [draftSync.status]);
 
   // Live drawer validation: compute desired state from draft and expose zod issues
   // per resource index. Issue paths are relative to the resource root (no
@@ -399,6 +461,30 @@ export default function StackDetailPage() {
     });
     return { resources, volumes: {} };
   }, [desiredState.resourceIssues]);
+
+  // Merge live zod validation (index-keyed) with backend field errors from a
+  // failed autosave (name-keyed). Resolve each server error's resource NAME and
+  // env-var NAME to their CURRENT indices here so the merged map stays index-keyed
+  // for consumers but survives a reorder/removal since the error was captured.
+  const mergedResourceErrors = useMemo(() => {
+    const merged: { [index: number]: { [field: string]: string | undefined } } = {};
+    for (const [k, v] of Object.entries(validationErrors.resources)) {
+      merged[Number(k)] = { ...v };
+    }
+    for (const [resourceName, envErrors] of Object.entries(serverFieldErrors)) {
+      const idx = session.draft.resources.findIndex((r) => r.name === resourceName);
+      if (idx < 0) continue;
+      const draftEnv = (session.draft.resources[idx]?.execution_config
+        ?.environment_variables ?? []) as FormEnvVarData[];
+      for (const [envName, message] of Object.entries(envErrors)) {
+        const envIdx = draftEnv.findIndex((e) => e.name === envName);
+        if (envIdx < 0) continue;
+        const fieldKey = `execution_config.environment_variables.${envIdx}.value`;
+        merged[idx] = { ...(merged[idx] ?? {}), [fieldKey]: message };
+      }
+    }
+    return merged;
+  }, [validationErrors.resources, serverFieldErrors, session.draft.resources]);
 
   const lifecycle = useDeployLifecycle({
     stack: stackToShow ?? undefined,
@@ -731,18 +817,25 @@ export default function StackDetailPage() {
   const dirtyTotal =
     session.dirty.dirtyResourceIdx.size + session.dirty.dirtyVolumeIdx.size + session.dirty.addonLinkCount;
 
-  // "View changes" badge + modal count must agree with the modal's BODY, which
-  // renders lifecycle.stagedDiff (saved spec vs release). Session dirt can
-  // diverge from it — e.g. a mount added and disconnected after the deploy nets
-  // to zero staged changes while the session still reads dirty. Once a staged
-  // diff exists, count its rows; fall back to session dirt only while an edit
-  // is still syncing (stagedDiff undefined).
+  // "View changes" badge + modal count must agree with the modal's BODY. The body
+  // renders lifecycle.stagedDiff (saved spec vs release), which only sees SAVED
+  // content. When a sync is in flight or has errored (e.g. a fresh resource whose
+  // autosave 400s), the unsaved edit is absent from the staged diff — so the diff
+  // can be empty while real session dirt exists. In that unsettled state, never let
+  // the (stale) staged count hide the dirt: take the larger of the two. Once the
+  // sync settles, the staged diff is authoritative (session dirt can overcount,
+  // e.g. a mount added then removed nets to zero staged while the session still
+  // reads dirty), so trust it and fall back to dirt only until the diff resolves.
   const stagedCount = lifecycle.stagedDiff
     ? lifecycle.stagedDiff.resources.length +
       lifecycle.stagedDiff.volumes.length +
       lifecycle.stagedDiff.connections.length
     : null;
-  const changeCount = stagedCount ?? dirtyTotal;
+  const syncUnsettled =
+    draftSync.status === SYNC_STATUS.saving || draftSync.status === SYNC_STATUS.error;
+  const changeCount = syncUnsettled
+    ? Math.max(stagedCount ?? 0, dirtyTotal)
+    : stagedCount ?? dirtyTotal;
 
   return (
     <>
@@ -780,9 +873,10 @@ export default function StackDetailPage() {
             baselineVolumes={baselineVolumes}
             draftResources={draftResources}
             draftVolumes={draftVolumes}
+            serverOutputsByName={serverOutputsByName}
             connectionAddonIds={connectionAddonIds}
             addonNameById={addonNameById}
-            errors={validationErrors.resources}
+            errors={mergedResourceErrors}
             onViewLogs={() => setActiveTab("logs")}
             topologyIds={!isDraft && deployIds.stackId ? deployIds : null}
             topologyRefreshKey={topologyRefreshKey}
@@ -800,6 +894,8 @@ export default function StackDetailPage() {
         onOpenChange={setViewChangesOpen}
         diff={lifecycle.stagedDiff}
         count={changeCount}
+        errored={draftSync.status === SYNC_STATUS.error}
+        dirty={dirtyTotal > 0}
         stackName={effectiveStack?.name ?? ""}
         onDiscardResource={discardResourceByName}
         onDiscardVolume={discardVolumeByName}

--- a/frontend/src/pages/stacks/components/shared/env-row.tsx
+++ b/frontend/src/pages/stacks/components/shared/env-row.tsx
@@ -27,6 +27,7 @@ export type AddonBindingPatch = {
 
 export type EnvRowErrors = {
   name?: string;
+  value?: string;
   addonId?: string;
   database?: string;
   credField?: string;
@@ -138,7 +139,9 @@ export function EnvRow({
             <Input
               value={row.value || ""}
               onChange={(e) => onChangeValue(e.target.value)}
-              className="h-8 w-full font-mono text-xs md:text-xs"
+              className={`h-8 w-full font-mono text-xs md:text-xs ${
+                rowErrors?.value ? "border-danger" : ""
+              }`}
               placeholder="value"
             />
           )}
@@ -180,6 +183,9 @@ export function EnvRow({
               selfOutput={row.selfOutput}
               onChange={(out) => onChangeSelf?.(out)}
             />
+          )}
+          {rowErrors?.value && (
+            <p className="text-xs text-danger mt-1">{rowErrors.value}</p>
           )}
         </div>
 

--- a/frontend/src/pages/stacks/components/shared/hooks/use-resource-tab-props.ts
+++ b/frontend/src/pages/stacks/components/shared/hooks/use-resource-tab-props.ts
@@ -26,6 +26,9 @@ export interface ResourceTabContext {
   errors: { [field: string]: string | undefined };
   volumes?: Partial<VolumeFormData>[];
   allResources?: { name: string; index: number; outputs: string[] }[];
+  /** Server-computed outputs keyed by resource name. Used for the Self output
+   *  picker, whose draft copy carries no outputs for a newly-added resource. */
+  serverOutputsByName?: ReadonlyMap<string, string[]>;
   secrets: UseSecretsReturn;
   addons: PostgresAddon[];
   addonNameById: Map<string, string>;
@@ -163,7 +166,14 @@ export function useResourceTabProps(args: {
         .map((r) => ({ name: r.name, outputs: r.outputs })),
     [context.allResources, thisResourceName],
   );
-  const selfOutputs = useMemo(() => (resource.outputs ?? []).map((o: { name: string }) => o.name), [resource.outputs]);
+  // Prefer the server-truth outputs for this resource's own name; fall back to
+  // the draft copy's outputs (empty for a resource added but not yet saved).
+  const selfOutputs = useMemo(
+    () =>
+      context.serverOutputsByName?.get(resource.name ?? "") ??
+      (resource.outputs ?? []).map((o: { name: string }) => o.name),
+    [context.serverOutputsByName, resource.name, resource.outputs],
+  );
 
   return {
     dirtyTabs,

--- a/frontend/src/pages/stacks/components/shared/stack-resource-environment-tab.tsx
+++ b/frontend/src/pages/stacks/components/shared/stack-resource-environment-tab.tsx
@@ -355,6 +355,10 @@ function StackResourceEnvironmentTabImpl({
               if ((dirty || errPath("credField")) && !r.credField) out.credField = "Pick a field";
             }
             if ((dirty || errPath("name")) && !r.name) out.name = "Required";
+            // Server-reported value error (e.g. a backend validation reason pinned
+            // to this env var by the autosave engine); always surfaced when present.
+            const valueErr = errPath("value");
+            if (valueErr) out.value = valueErr;
             return Object.keys(out).length === 0 ? undefined : out;
           };
 

--- a/frontend/src/pages/stacks/data/blocks/registry.ts
+++ b/frontend/src/pages/stacks/data/blocks/registry.ts
@@ -1,5 +1,10 @@
 import { BlockId, type BlockCategoryMeta, type BlockPreset } from "./types";
 
+// Placeholder root/admin password baked into the datastore preset compose
+// snippets. Users are expected to change it before deploying. MS SQL Server
+// rejects weak passwords, so it keeps its own stronger placeholder below.
+const PLACEHOLDER_PASSWORD = "changeme";
+
 export const BLOCK_CATEGORY_META: BlockCategoryMeta[] = [
   { id: "services", label: "SERVICES" },
   { id: "data", label: "DATA STORES" },
@@ -17,7 +22,7 @@ export const blockCatalog: BlockPreset[] = [
       '    ports: ["5432:5432"]',
       '    volumes: ["pgdata:/var/lib/postgresql/data"]',
       "    environment:",
-      '      POSTGRES_PASSWORD: ""',
+      `      POSTGRES_PASSWORD: "${PLACEHOLDER_PASSWORD}"`,
       "volumes:",
       "  pgdata: {}",
       "",
@@ -31,7 +36,7 @@ export const blockCatalog: BlockPreset[] = [
     id: BlockId.Mysql, name: "MySQL", category: "data", icon: "mysql", summary: "mysql:8 · :3306",
     compose: [
       "services:", "  mysql:", "    image: mysql:8", '    ports: ["3306:3306"]',
-      '    volumes: ["mysql-data:/var/lib/mysql"]', "    environment:", '      MYSQL_ROOT_PASSWORD: ""',
+      '    volumes: ["mysql-data:/var/lib/mysql"]', "    environment:", `      MYSQL_ROOT_PASSWORD: "${PLACEHOLDER_PASSWORD}"`,
       "volumes:", "  mysql-data: {}", "",
     ].join("\n"),
   },
@@ -46,7 +51,7 @@ export const blockCatalog: BlockPreset[] = [
     id: BlockId.Mariadb, name: "MariaDB", category: "data", icon: "mariadb", summary: "mariadb:11.4 · :3306",
     compose: [
       "services:", "  mariadb:", "    image: mariadb:11.4", '    ports: ["3306:3306"]',
-      '    volumes: ["mariadb-data:/var/lib/mysql"]', "    environment:", '      MARIADB_ROOT_PASSWORD: ""',
+      '    volumes: ["mariadb-data:/var/lib/mysql"]', "    environment:", `      MARIADB_ROOT_PASSWORD: "${PLACEHOLDER_PASSWORD}"`,
       "volumes:", "  mariadb-data: {}", "",
     ].join("\n"),
   },
@@ -54,7 +59,7 @@ export const blockCatalog: BlockPreset[] = [
     id: BlockId.Mssql, name: "MS SQL Server", category: "data", icon: "mssql", summary: "mssql:2022 · :1433",
     compose: [
       "services:", "  mssql:", "    image: mcr.microsoft.com/mssql/server:2022-latest", '    ports: ["1433:1433"]',
-      '    volumes: ["mssql-data:/var/opt/mssql"]', "    environment:", '      ACCEPT_EULA: "Y"', '      MSSQL_SA_PASSWORD: ""',
+      '    volumes: ["mssql-data:/var/opt/mssql"]', "    environment:", '      ACCEPT_EULA: "Y"', '      MSSQL_SA_PASSWORD: "Change_me_123"',
       "volumes:", "  mssql-data: {}", "",
     ].join("\n"),
   },
@@ -71,7 +76,7 @@ export const blockCatalog: BlockPreset[] = [
     id: BlockId.Couchdb, name: "CouchDB", category: "data", icon: "couchdb", summary: "couchdb:3.3 · :5984",
     compose: [
       "services:", "  couchdb:", "    image: couchdb:3.3", '    ports: ["5984:5984"]',
-      '    volumes: ["couchdb-data:/opt/couchdb/data"]', "    environment:", '      COUCHDB_USER: "admin"', '      COUCHDB_PASSWORD: ""',
+      '    volumes: ["couchdb-data:/opt/couchdb/data"]', "    environment:", '      COUCHDB_USER: "admin"', `      COUCHDB_PASSWORD: "${PLACEHOLDER_PASSWORD}"`,
       "volumes:", "  couchdb-data: {}", "",
     ].join("\n"),
   },
@@ -86,7 +91,7 @@ export const blockCatalog: BlockPreset[] = [
     id: BlockId.Clickhouse, name: "ClickHouse", category: "data", icon: "clickhouse", summary: "clickhouse:24 · :8123",
     compose: [
       "services:", "  clickhouse:", "    image: clickhouse/clickhouse-server:24.8", '    ports: ["8123:8123", "9000:9000"]',
-      '    volumes: ["clickhouse-data:/var/lib/clickhouse"]', "    environment:", '      CLICKHOUSE_PASSWORD: ""',
+      '    volumes: ["clickhouse-data:/var/lib/clickhouse"]', "    environment:", `      CLICKHOUSE_PASSWORD: "${PLACEHOLDER_PASSWORD}"`,
       "volumes:", "  clickhouse-data: {}", "",
     ].join("\n"),
   },

--- a/frontend/src/pages/stacks/hooks/use-draft-sync.ts
+++ b/frontend/src/pages/stacks/hooks/use-draft-sync.ts
@@ -16,7 +16,18 @@ import {
 import { serverStateFromStack, type ServerStackState } from "@/pages/stacks/lib/draft-sync/server-state";
 import { buildDesiredState } from "@/pages/stacks/lib/draft-sync/desired-state";
 import { computeSyncOps, type SyncOp } from "@/pages/stacks/lib/draft-sync/ops";
+import { getErrorMessage, getErrorStatus, isBadRequestError } from "@/api/client";
 import type { EditSessionDraft, UseStackEditSession } from "./use-stack-edit-session";
+
+/** Surfaced to the caller when an autosave op fails, carrying the offending op
+ *  so the UI can toast the reason and mark the responsible field inline. `op` is
+ *  absent when the ops all landed but the post-save refetch failed — the save
+ *  actually succeeded, so there is no op-level field error to attribute. */
+export interface SyncErrorInfo {
+  status?: number;
+  message: string;
+  op?: SyncOp;
+}
 
 export interface UseDraftSyncArgs {
   enabled: boolean;
@@ -24,6 +35,8 @@ export interface UseDraftSyncArgs {
   session: UseStackEditSession;
   ids: { orgId: string; teamName: string; stackId: string } | null;
   onStackRefreshed: (stack: Stack) => void;
+  /** Called when a sync op throws, before the mirror heals. */
+  onSyncError?: (info: SyncErrorInfo) => void;
 }
 
 export interface UseDraftSync {
@@ -74,6 +87,7 @@ export function useDraftSync({
   session,
   ids,
   onStackRefreshed,
+  onSyncError,
 }: UseDraftSyncArgs): UseDraftSync {
   const [status, setStatus] = useState<SyncStatus>(SYNC_STATUS.idle);
   const [failureCount, setFailureCount] = useState(0);
@@ -84,6 +98,8 @@ export function useDraftSync({
   idsRef.current = ids;
   const onRefreshedRef = useRef(onStackRefreshed);
   onRefreshedRef.current = onStackRefreshed;
+  const onSyncErrorRef = useRef(onSyncError);
+  onSyncErrorRef.current = onSyncError;
 
   const mirrorRef = useRef<ServerStackState | null>(null);
   const runningRef = useRef<Promise<boolean> | null>(null);
@@ -137,8 +153,19 @@ export function useDraftSync({
       }
 
       setStatus(SYNC_STATUS.saving);
+      // Track the op in flight so a throw can be pinned to it (ops.length > 0
+      // here, so ops[0] is a safe non-null seed for the type checker).
+      let failingOp: SyncOp = ops[0];
+      // Flips true once every op has landed; a later throw then comes from the
+      // post-save refetch, not from an op, so it must not misattribute a field
+      // error to the last (successful) op.
+      let opsSucceeded = false;
       try {
-        for (const op of ops) await executeOp(op, currentIds);
+        for (const op of ops) {
+          failingOp = op;
+          await executeOp(op, currentIds);
+        }
+        opsSucceeded = true;
         const fresh = await getStackById(currentIds.orgId, currentIds.teamName, currentIds.stackId);
         mirrorRef.current = serverStateFromStack(fresh);
         onRefreshedRef.current(fresh);
@@ -149,10 +176,17 @@ export function useDraftSync({
         setFailureCount(0);
         setStatus(SYNC_STATUS.saved);
         return true;
-      } catch {
+      } catch (err) {
         failuresRef.current += 1;
         setFailureCount(failuresRef.current);
         setStatus(SYNC_STATUS.error);
+        onSyncErrorRef.current?.({
+          status: getErrorStatus(err),
+          message: getErrorMessage(err),
+          // Ops all landed → the refetch failed, not an op. Leave op undefined so
+          // the caller doesn't pin a spurious field error on a save that landed.
+          op: opsSucceeded ? undefined : failingOp,
+        });
         // Heal the mirror from server truth; the draft stays authoritative locally.
         try {
           const fresh = await getStackById(currentIds.orgId, currentIds.teamName, currentIds.stackId);
@@ -161,11 +195,17 @@ export function useDraftSync({
         } catch {
           /* keep the stale mirror; the next attempt refetches again */
         }
-        const backoff = Math.min(RETRY_BASE_MS * 2 ** (failuresRef.current - 1), RETRY_MAX_MS);
-        if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
-        retryTimerRef.current = setTimeout(() => {
-          void startCycle();
-        }, backoff);
+        // A 400 is a client-side validation error: retrying the identical draft
+        // can only fail again. Leave the error status set (terminal) and wait for
+        // the next draft edit to re-trigger a cycle via the debounce effect.
+        // Non-400 (network/5xx) stays on the backoff-retry path.
+        if (!isBadRequestError(err)) {
+          const backoff = Math.min(RETRY_BASE_MS * 2 ** (failuresRef.current - 1), RETRY_MAX_MS);
+          if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+          retryTimerRef.current = setTimeout(() => {
+            void startCycle();
+          }, backoff);
+        }
         return false;
       }
     })().finally(() => {

--- a/frontend/src/pages/stacks/lib/block-to-form.ts
+++ b/frontend/src/pages/stacks/lib/block-to-form.ts
@@ -26,6 +26,29 @@ function genericResource(block: BlockPreset): FormStackResourceData {
   return base as unknown as FormStackResourceData;
 }
 
+/**
+ * Datastore presets ship a compose snippet purely as a convenient way to
+ * describe the image/ports/volume — they are never public HTTP endpoints.
+ * The shared compose converter defaults ports to public http (correct for the
+ * real docker-compose import flow), so for "data" blocks we override every
+ * derived port back to a private tcp port after conversion.
+ */
+function asPrivateTcpPorts(
+  resources: FormStackResourceData[]
+): FormStackResourceData[] {
+  return resources.map((resource) => {
+    if (!resource.ports?.length) return resource;
+    return {
+      ...resource,
+      ports: resource.ports.map((port) => ({
+        ...port,
+        protocol: "tcp",
+        exposed_to_public: false,
+      })),
+    };
+  });
+}
+
 export function blockToResources(block: BlockPreset): {
   resources: FormStackResourceData[];
   volumes: FormVolumeData[];
@@ -40,8 +63,10 @@ export function blockToResources(block: BlockPreset): {
       `Block "${block.id}" failed to convert: ${result.errors?.[0]?.message ?? "unknown"}`
     );
   }
+  const resources = result.data.spec.stack_resources ?? [];
   return {
-    resources: result.data.spec.stack_resources ?? [],
+    resources:
+      block.category === "data" ? asPrivateTcpPorts(resources) : resources,
     volumes: (result.data.spec.volumes ?? []) as FormVolumeData[],
   };
 }

--- a/frontend/src/pages/stacks/lib/canvas/layout-graph.ts
+++ b/frontend/src/pages/stacks/lib/canvas/layout-graph.ts
@@ -2,8 +2,13 @@ import dagre from "dagre";
 import type { CanvasGraph } from "./graph-from-connections";
 
 /** Card dimensions dagre reserves per node (matches ResourceNode's box). */
-const NODE_WIDTH = 216;
-const NODE_HEIGHT = 88;
+export const NODE_WIDTH = 216;
+export const NODE_HEIGHT = 88;
+
+/** Horizontal pitch between consecutive freshly-added nodes so they don't stack. */
+export const NEW_NODE_GAP_X = NODE_WIDTH + NODE_HEIGHT;
+/** Vertical drop below the preserved layout where new nodes are parked. */
+export const NEW_NODE_OFFSET_Y = NODE_HEIGHT * 2;
 
 export interface LayoutOptions {
   direction?: "LR" | "TB";


### PR DESCRIPTION
## What
Fixes a batch of stack-canvas UI bugs found during manual testing.

### Changes
- **Undeployed-changes panel** — populate `stagedDiff` in the editing/first-deploy lifecycle branches so the panel body lists pending changes instead of a placeholder; badge and body now share one source (`max(stagedCount, dirtyTotal)` while a sync is unsettled, error/dirty-aware empty state).
- **Resource output picker** — source a resource's outputs from the server stack copy (`stackToShow`) keyed by name, so a just-added resource shows `host`/`port.*` immediately after autosave, no page reload.
- **Canvas node overlap** — a newly added node is placed in a free spot below the existing bounding box instead of overlapping a frozen node; existing/dragged positions preserved. Named gap constants.
- **Resource templates** — valid placeholder passwords for datastore templates; `tcp` protocol + non-public port defaults **scoped to datastore blocks** in `block-to-form.ts` (the shared docker-compose converter is reverted, so the real compose-import flow is unchanged).
- **Autosave error surfacing** — surface backend validation errors as a (deduped) toast + inline env-field marking; treat a 400 as terminal (no infinite retry); fix error misattribution (post-save refetch failures) and make inline field errors robust to resource reorder/rename (name-keyed).

## Testing
- `tsc -b` clean; eslint clean on touched files; docker-compose converter suite 35/35.
- Browser-verified: template defaults (new datastore → TCP / Internal Only / prefilled password), outputs appear without reload, new node placement, changes panel lists changes, error toast fires with the backend reason.

## Known follow-up
Autosave op batch is fail-fast and can starve a `deleteResource` behind a failing `createConnection` (the wedge). Tracked in #136 — separate fix (needs rename-pair care).

🤖 Generated with [Claude Code](https://claude.com/claude-code)