### PR TITLE
Fix: Compose-created stacks lose their volume attachments

### DIFF
--- a/frontend/src/pages/stacks/schemas/form-schema.ts
+++ b/frontend/src/pages/stacks/schemas/form-schema.ts
@@ -13,8 +13,8 @@ import {
 } from "./api-schema";
 import type { StackUpdateRequest, StackResourceUpdateRequest, VolumeUpdateRequest } from "@/api/stacks";
 import { ADDON_OUTPUT_FIELDS } from "@/pages/stacks/lib/addon-presets";
-import { buildDesiredConnections } from "@/pages/stacks/lib/connection-mapping";
-import type { FormEnvRow } from "@/pages/stacks/lib/connection-mapping";
+import { buildDesiredConnections, mountsToConnections } from "@/pages/stacks/lib/connection-mapping";
+import type { FormEnvRow, FormMountRow } from "@/pages/stacks/lib/connection-mapping";
 
 /**
  * Form-specific UI schema additions
@@ -433,8 +433,15 @@ function convertFormStackToApiStack(
     return hasName && (hasImage || hasGit);
   });
 
-  // Process all valid stack resources by removing UI-only fields
-  const apiStackResources = validResources.map(prepareFormResourceForApi);
+  // Process all valid stack resources by removing UI-only fields. Mounts are
+  // fully represented as volume_mount connections (built below) — strip
+  // volume_mounts so the payload has one source of truth, matching the
+  // draft-sync save path (the server returns volume_mounts: [] and stores
+  // mounts in connections).
+  const apiStackResources = validResources.map((resource) => ({
+    ...prepareFormResourceForApi(resource),
+    volume_mounts: undefined,
+  }));
 
   // Filter out empty or invalid volumes (volumes with empty names)
   const validVolumes = stackData.spec.volumes?.filter(volume => {
@@ -455,6 +462,17 @@ function convertFormStackToApiStack(
       rows: (r.execution_config?.environment_variables ?? []) as FormEnvRow[],
     })),
   );
+
+  // Volume mounts persist as volume_mount connections too (compose blocks and
+  // the canvas record mounts as form rows on the resource). Mounts referencing
+  // volumes absent from the payload are dangling — never emit them.
+  const volumeNames = new Set((validVolumes ?? []).map((v) => v.name));
+  for (const r of validResources) {
+    const liveMounts = ((r.volume_mounts ?? []) as FormMountRow[]).filter(
+      (m) => volumeNames.has(m.source_volume_name ?? ""),
+    );
+    connections.push(...mountsToConnections(r.name ?? "", liveMounts));
+  }
 
   // Create a new clean spec object that will only include API-expected fields
   const apiSpec = {


### PR DESCRIPTION
## 📝 What this does
Stacks created from compose blocks (MySQL, Postgres, Mongo, and the rest of the data stores) showed their volumes detached after creation — the create payload never carried the volume-mount connections the canvas had drawn.

## 🔀 Changes
- The create payload now converts each resource's volume-mount rows into `volume_mount` connections (the server's source of truth for mounts), the same conversion the save path already performed.
- `volume_mounts` is stripped from resource payloads so mounts have one representation, and mounts referencing volumes absent from the request are dropped as dangling.

## 📸 Screenshots
Before: `mysql-data` floats detached after creating a compose MySQL stack. After: volumes render attached to their resources (`mysql-data` → mysql, `pgdata` → postgres), verified in a live browser against the dev server.

## 🧪 How to test
- [ ] New Stack → Build from blocks → pick MySQL (or any data store) → Continue → Create stack
- [ ] The created stack's canvas shows the volume attached to its resource, and the apply payload carries a `volume_mount` connection