### PR TITLE
Feature: surface rich API validation errors in the stack editor

### DIFF
--- a/frontend/src/api/errors.test.ts
+++ b/frontend/src/api/errors.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { AxiosError } from "axios";
+import { parseApiError } from "./errors";
+
+function axiosErr(status: number, data: unknown): AxiosError {
+  return new AxiosError(
+    "Request failed",
+    "ERR_BAD_REQUEST",
+    { headers: {} } as never,
+    {},
+    {
+      status,
+      statusText: "Bad Request",
+      data,
+      headers: {},
+      config: { headers: {} } as never,
+    },
+  );
+}
+
+describe("parseApiError", () => {
+  it("extracts rich field errors from details.errors[]", () => {
+    const err = axiosErr(400, {
+      kind: "Error",
+      id: "8",
+      code: "8",
+      reason: "validation failed: 2 error(s)",
+      details: {
+        errors: [
+          { field: "spec.stack_resources[0].ports[1].protocol", code: "port_protocol_invalid", message: "protocol must be TCP or UDP" },
+          { field: "name", code: "stack_name_invalid", message: "stack name is invalid" },
+        ],
+      },
+    });
+    const parsed = parseApiError(err);
+    expect(parsed.status).toBe(400);
+    expect(parsed.fieldErrors).toHaveLength(2);
+    expect(parsed.fieldErrors[0]).toEqual({
+      field: "spec.stack_resources[0].ports[1].protocol",
+      code: "port_protocol_invalid",
+      message: "protocol must be TCP or UDP",
+    });
+    expect(parsed.topLevel).toBe("validation failed: 2 error(s)");
+    expect(parsed.credential).toBeUndefined();
+  });
+
+  it("falls back to reason with no field errors on a flat reject", () => {
+    const err = axiosErr(400, { kind: "Error", reason: "source.git.repo_url is required" });
+    const parsed = parseApiError(err);
+    expect(parsed.fieldErrors).toEqual([]);
+    expect(parsed.topLevel).toBe("source.git.repo_url is required");
+  });
+
+  it("parses the credential error shape", () => {
+    const err = axiosErr(400, {
+      kind: "Error",
+      reason: "credentials required",
+      details: {
+        code: "credentials_required",
+        target: { kind: "git_integration", host: "github.com", ref: "acme/repo" },
+      },
+    });
+    const parsed = parseApiError(err);
+    expect(parsed.fieldErrors).toEqual([]);
+    expect(parsed.credential).toEqual({
+      code: "credentials_required",
+      target: { kind: "git_integration", host: "github.com", ref: "acme/repo" },
+    });
+  });
+
+  it("reads details from the first item of an ErrorList", () => {
+    const err = axiosErr(400, {
+      kind: "ErrorList",
+      page: 0,
+      size: 1,
+      total: 1,
+      items: [
+        {
+          kind: "Error",
+          reason: "validation failed: 1 error(s)",
+          details: { errors: [{ field: "replicas", code: "replicas_invalid", message: "replicas cannot be negative" }] },
+        },
+      ],
+    });
+    const parsed = parseApiError(err);
+    expect(parsed.topLevel).toBe("validation failed: 1 error(s)");
+    expect(parsed.fieldErrors).toEqual([
+      { field: "replicas", code: "replicas_invalid", message: "replicas cannot be negative" },
+    ]);
+  });
+
+  it("drops malformed entries missing field or message", () => {
+    const err = axiosErr(400, {
+      kind: "Error",
+      reason: "validation failed",
+      details: {
+        errors: [
+          { field: "name", message: "ok", code: "resource_name_required" },
+          { code: "port_protocol_invalid" },
+          { field: "ports[0].number" },
+          null,
+        ],
+      },
+    });
+    const parsed = parseApiError(err);
+    expect(parsed.fieldErrors).toEqual([
+      { field: "name", code: "resource_name_required", message: "ok" },
+    ]);
+  });
+
+  it("handles a network error with no response body", () => {
+    const err = new AxiosError("Network Error", "ERR_NETWORK");
+    const parsed = parseApiError(err);
+    expect(parsed.status).toBeUndefined();
+    expect(parsed.fieldErrors).toEqual([]);
+    expect(parsed.topLevel).toBe("Network Error");
+  });
+
+  it("handles a plain Error", () => {
+    const parsed = parseApiError(new Error("boom"));
+    expect(parsed.fieldErrors).toEqual([]);
+    expect(parsed.topLevel).toBe("boom");
+  });
+});

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -1,0 +1,84 @@
+// Parses the backend Error envelope into a structured shape the UI can consume:
+// a top-level message plus per-field validation errors (details.errors[]) and
+// the credential-required detail variant. Falls back to the flat reason string
+// when no structured details are present.
+import { getErrorMessage, getErrorStatus, isAxiosError } from "./client";
+
+export type ParsedFieldError = {
+  field: string;
+  code: string;
+  message: string;
+};
+
+export type CredentialErrorTarget = {
+  kind: string;
+  host: string;
+  ref: string;
+};
+
+export type CredentialErrorInfo = {
+  code: string;
+  target: CredentialErrorTarget;
+};
+
+export type ParsedApiError = {
+  status: number | undefined;
+  topLevel: string;
+  fieldErrors: ParsedFieldError[];
+  credential?: CredentialErrorInfo;
+};
+
+const CREDENTIAL_CODES = new Set(["credentials_required", "credentials_invalid"]);
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+// The wire body is either an Error or an ErrorList; the structured details live
+// on the primary Error (the list's first item when it's a list).
+function primaryError(data: unknown): Record<string, unknown> | undefined {
+  const record = asRecord(data);
+  if (!record) return undefined;
+  if (Array.isArray(record.items)) {
+    return asRecord(record.items[0]);
+  }
+  return record;
+}
+
+function extractFieldErrors(details: Record<string, unknown> | undefined): ParsedFieldError[] {
+  if (!details || !Array.isArray(details.errors)) return [];
+  return details.errors.flatMap((entry): ParsedFieldError[] => {
+    const fe = asRecord(entry);
+    if (!fe || typeof fe.field !== "string" || typeof fe.message !== "string") return [];
+    return [{ field: fe.field, code: typeof fe.code === "string" ? fe.code : "", message: fe.message }];
+  });
+}
+
+function extractCredential(details: Record<string, unknown> | undefined): CredentialErrorInfo | undefined {
+  if (!details || typeof details.code !== "string" || !CREDENTIAL_CODES.has(details.code)) return undefined;
+  const target = asRecord(details.target);
+  if (!target) return undefined;
+  return {
+    code: details.code,
+    target: {
+      kind: String(target.kind ?? ""),
+      host: String(target.host ?? ""),
+      ref: String(target.ref ?? ""),
+    },
+  };
+}
+
+export function parseApiError(error: unknown): ParsedApiError {
+  const primary = isAxiosError(error) ? primaryError(error.response?.data) : undefined;
+  const details = asRecord(primary?.details);
+  // Derive topLevel from the primary error's reason so ErrorList bodies (whose
+  // reason lives on items[0]) resolve correctly; getErrorMessage matches any
+  // object body as a single Error first and would miss it.
+  const reason = typeof primary?.reason === "string" ? primary.reason : undefined;
+  return {
+    status: getErrorStatus(error),
+    topLevel: reason || getErrorMessage(error),
+    fieldErrors: extractFieldErrors(details),
+    credential: extractCredential(details),
+  };
+}

--- a/frontend/src/pages/stacks/components/canvas/ResourceDrawer.tsx
+++ b/frontend/src/pages/stacks/components/canvas/ResourceDrawer.tsx
@@ -5,7 +5,7 @@ import { X, ScrollText, Trash2 } from "lucide-react";
 import { useSecrets } from "@/pages/stacks/hooks/use-secrets";
 import { usePostgresAddons } from "@/pages/addons/hooks/use-postgres-addons";
 import type { PostgresAddon } from "@/api/addons";
-import type { UseStackEditSession } from "@/pages/stacks/hooks/use-stack-edit-session";
+import type { UseStackEditSession, EditSessionTab } from "@/pages/stacks/hooks/use-stack-edit-session";
 import type { FormStackResourceData } from "@/pages/stacks/schemas/form-schema";
 import { StackResourceConfigurationTab } from "@/pages/stacks/components/shared/stack-resource-configuration-tab";
 import { StackResourceDeploymentTab } from "@/pages/stacks/components/shared/stack-resource-deployment-tab";
@@ -16,6 +16,11 @@ import { NodeGlyph } from "./nodes/node-glyph";
 
 /** Radix tab values used by the sub-tab components (they render their own TabsContent). */
 const TAB_VALUE = { configuration: "general", deployment: "deployment", environment: "environment" } as const;
+const TAB_FROM_VALUE: Record<string, EditSessionTab> = {
+  general: "configuration",
+  deployment: "deployment",
+  environment: "environment",
+};
 
 interface ResourceDrawerProps {
   /** Index into `session.draft.resources` of the resource being configured. */
@@ -120,7 +125,9 @@ export function ResourceDrawer({
       },
     });
 
-  const defaultTab = session.openTab ? TAB_VALUE[session.openTab] : TAB_VALUE.configuration;
+  // Controlled tab: driven by session.openTab so a banner "jump to error" can
+  // switch to the tab holding the offending field even while the drawer is open.
+  const activeTab = session.openTab ? TAB_VALUE[session.openTab] : TAB_VALUE.configuration;
 
   // Kind glyph + summary sub-line, derived the same way the node card is.
   const pres = useMemo(
@@ -188,7 +195,11 @@ export function ResourceDrawer({
       </div>
 
       {/* Tabs */}
-      <Tabs defaultValue={defaultTab} className="flex min-h-0 flex-1 flex-col">
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => session.setOpenTab(TAB_FROM_VALUE[v] ?? "configuration")}
+        className="flex min-h-0 flex-1 flex-col"
+      >
         <TabsList className="h-auto w-full flex-none justify-start gap-1 rounded-none border-b border-border bg-transparent p-0 px-1">
           <TabsTrigger value={TAB_VALUE.configuration} className={tabTriggerClass}>
             Configuration

--- a/frontend/src/pages/stacks/components/canvas/StackCanvasTab.tsx
+++ b/frontend/src/pages/stacks/components/canvas/StackCanvasTab.tsx
@@ -14,7 +14,7 @@ import type {
   FormStackResourceData,
   FormVolumeExtendedData as VolumeFormData,
 } from "@/pages/stacks/schemas/form-schema";
-import type { EditSessionDraft, UseStackEditSession } from "@/pages/stacks/hooks/use-stack-edit-session";
+import type { EditSessionDraft, EditSessionTab, UseStackEditSession } from "@/pages/stacks/hooks/use-stack-edit-session";
 import { useStackTopology } from "@/pages/stacks/hooks/use-stack-topology";
 import { deriveGraph } from "@/pages/stacks/lib/canvas/graph-from-connections";
 import { mergeTopology } from "@/pages/stacks/lib/canvas/merge-topology";
@@ -93,6 +93,10 @@ interface StackCanvasTabProps {
   /** A release is in flight — node status dots show pending until it terminates
    *  (per-resource server state lags the deploy and would flash a stale Ready). */
   releaseInFlight?: boolean;
+  /** Bumped by the parent to request opening a resource drawer (banner "jump to
+   *  error") on the tab holding the field; the nonce distinguishes repeat jumps
+   *  to the same resource. */
+  openResourceSignal?: { index: number; tab: EditSessionTab; nonce: number } | null;
 }
 
 function StackCanvasFlow({
@@ -113,6 +117,7 @@ function StackCanvasFlow({
   deletingVolume,
   persistedVolumeNames,
   releaseInFlight,
+  openResourceSignal,
 }: StackCanvasTabProps) {
   // Read from the live draft when the session is active, server state otherwise.
   const resources = session.isActive ? session.draft.resources : draftResources;
@@ -309,7 +314,7 @@ function StackCanvasFlow({
   }, [mergedGraph, setNodes, fitView]);
 
   const openResourceDrawer = useCallback(
-    (idx: number) => {
+    (idx: number, tab: EditSessionTab = "configuration") => {
       // Activate an edit session lazily so drawer edits land in a draft.
       if (!session.isActive) {
         session.start(
@@ -317,15 +322,27 @@ function StackCanvasFlow({
           {
             linkedAddonIds: new Set(connectionAddonIds),
             openResourceIdx: idx,
-            openTab: "configuration",
+            openTab: tab,
             draft: { resources: draftResources, volumes: draftVolumes },
           },
         );
+      } else {
+        session.setOpenTab(tab);
       }
       setDrawerStack(replaceStack({ kind: "resource", index: idx }));
     },
     [session, baselineResources, baselineVolumes, draftResources, draftVolumes, connectionAddonIds],
   );
+
+  // Open the requested resource drawer when the parent bumps the signal (banner
+  // jump). Gated on the nonce so an unrelated re-render can't reopen the drawer.
+  const lastJumpNonceRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!openResourceSignal) return;
+    if (lastJumpNonceRef.current === openResourceSignal.nonce) return;
+    lastJumpNonceRef.current = openResourceSignal.nonce;
+    openResourceDrawer(openResourceSignal.index, openResourceSignal.tab);
+  }, [openResourceSignal, openResourceDrawer]);
 
   const openVolumeFromCanvas = useCallback(
     (volumeName: string) => {

--- a/frontend/src/pages/stacks/components/detail/ValidationBanner.tsx
+++ b/frontend/src/pages/stacks/components/detail/ValidationBanner.tsx
@@ -1,0 +1,72 @@
+import { AlertTriangle, ChevronRight, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { EditSessionTab } from "@/pages/stacks/hooks/use-stack-edit-session";
+
+export interface ValidationBannerItem {
+  /** Human label for where the error lives, e.g. "api" or "Stack settings". */
+  label: string;
+  /** Backend message, shown verbatim. */
+  message: string;
+  /** Resource index to open on click; absent for stack-level errors. */
+  resourceIndex?: number;
+  /** Resource-drawer tab holding the offending field (defaults to configuration). */
+  tab?: EditSessionTab;
+}
+
+interface ValidationBannerProps {
+  items: ValidationBannerItem[];
+  onJump?: (resourceIndex: number, tab: EditSessionTab) => void;
+  onDismiss: () => void;
+}
+
+export function ValidationBanner({ items, onJump, onDismiss }: ValidationBannerProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <div className="mb-3 rounded-lg border border-destructive/30 bg-destructive/5 px-3.5 py-3 text-destructive">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="size-4 shrink-0" />
+          <span className="text-sm font-semibold">
+            {items.length} validation {items.length === 1 ? "error" : "errors"}
+          </span>
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss validation errors"
+          onClick={onDismiss}
+          className="shrink-0 rounded p-0.5 text-destructive/60 transition-colors hover:bg-destructive/10 hover:text-destructive"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+      <ul className="mt-2 flex flex-col gap-0.5">
+        {items.map((item, i) => {
+          const jumpable = item.resourceIndex !== undefined && onJump !== undefined;
+          return (
+            <li key={i}>
+              <button
+                type="button"
+                disabled={!jumpable}
+                onClick={jumpable ? () => onJump!(item.resourceIndex!, item.tab ?? "configuration") : undefined}
+                className={cn(
+                  "group flex w-full items-start gap-1.5 rounded px-1.5 py-1 text-left text-sm leading-snug text-destructive/90 transition-colors",
+                  jumpable ? "cursor-pointer hover:bg-destructive/10 hover:text-destructive" : "cursor-default",
+                )}
+              >
+                {jumpable && (
+                  <ChevronRight className="mt-0.5 size-3.5 shrink-0 opacity-50 transition-opacity group-hover:opacity-100" />
+                )}
+                <span className={cn(!jumpable && "pl-[1.25rem]")}>
+                  <span className="font-medium">{item.label}</span>
+                  <span className="text-destructive/50"> — </span>
+                  {item.message}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/stacks/components/detail/index.tsx
+++ b/frontend/src/pages/stacks/components/detail/index.tsx
@@ -1,12 +1,15 @@
 import { useParams, useLocation, useNavigate, Link } from "react-router-dom";
 import { getErrorMessage } from "@/api/client";
+import { parseApiError, type ParsedFieldError } from "@/api/errors";
+import { mapFieldErrors } from "@/pages/stacks/lib/map-field-errors";
+import { ValidationBanner, type ValidationBannerItem } from "@/pages/stacks/components/detail/ValidationBanner";
 import { useStacks } from "@/pages/stacks/contexts/stack-context";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 import { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import { usePostgresAddons } from "@/pages/addons/hooks/use-postgres-addons";
 import type { PostgresAddon } from "@/api/addons";
-import { useStackEditSession } from "@/pages/stacks/hooks/use-stack-edit-session";
+import { useStackEditSession, type EditSessionTab } from "@/pages/stacks/hooks/use-stack-edit-session";
 import { StackLogsTab } from "@/pages/stacks/components/detail/logs/stack-logs-tab";
 import { StackMetricsTab } from "@/pages/stacks/components/detail/metrics/stack-metrics-tab";
 import { DeploymentsTab } from "@/pages/stacks/components/detail/deployments/deployments-tab";
@@ -394,14 +397,22 @@ export default function StackDetailPage() {
     [stackToShow?.spec?.volumes],
   );
 
-  // Backend validation errors from a failed autosave, mapped onto the offending
-  // env-var field so the row shows them inline. Keyed by resource NAME → env-var
-  // name → message (NOT by index): the resource may be reordered/removed before
-  // the user fixes it, so the current index + env index are resolved at render
-  // time when merging into the index-keyed errors prop.
+  // Backend structured field errors (from a failed autosave or draft deploy),
+  // mapped onto the editor's inner field keys so the offending inputs show them
+  // inline. Keyed by resource NAME → field key → message (NOT by index): the
+  // resource may be reordered/removed before the user fixes it, so the current
+  // index is resolved at render time when merging into the index-keyed errors prop.
   const [serverFieldErrors, setServerFieldErrors] = useState<{
-    [resourceName: string]: { [envName: string]: string };
+    [resourceName: string]: { [fieldKey: string]: string };
   }>({});
+  // Raw structured errors from the last draft-deploy attempt, used to render the
+  // summary banner. Cleared when a deploy is retried or the banner is dismissed.
+  const [deployFieldErrors, setDeployFieldErrors] = useState<ParsedFieldError[]>([]);
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  // Bumped to ask the canvas to open a resource drawer (banner "jump to error").
+  const [openResourceSignal, setOpenResourceSignal] = useState<
+    { index: number; tab: EditSessionTab; nonce: number } | null
+  >(null);
 
   // Dedupe for autosave-failure toasts: the backoff retry loop and re-edits after
   // a terminal 400 re-run the same ops and would re-toast the same reason every
@@ -422,26 +433,26 @@ export default function StackDetailPage() {
       setStacks((prev) => prev.map((s) => (s.id === fresh.id ? fresh : s)));
       setTopologyRefreshKey((k) => k + 1);
     },
-    onSyncError: ({ message, op }) => {
+    onSyncError: ({ message, op, fieldErrors }) => {
       // No op → the save actually landed and only the post-save refetch failed;
       // don't alarm the user with a "Save failed" toast or field error.
       if (!op) return;
-      // Dedupe: skip if this exact reason is already on screen (retry/re-edit).
-      if (lastSyncErrorMsgRef.current === message) return;
-      lastSyncErrorMsgRef.current = message;
-      toast({ title: "Save failed", description: message, variant: "destructive" });
-      // Only resource create/update ops carry env vars; others just toast.
+      // Dedupe the toast: skip if this exact reason is already on screen.
+      if (lastSyncErrorMsgRef.current !== message) {
+        lastSyncErrorMsgRef.current = message;
+        toast({ title: "Save failed", description: message, variant: "destructive" });
+      }
+      // Only resource create/update ops carry mappable field errors.
       if (op.kind !== "createResource" && op.kind !== "updateResource") return;
       const resourceName = op.resource.name;
-      if (!resourceName) return;
-      // The backend reason names the offending var: `env var '<NAME>'`.
-      const envName = message.match(/env var '([^']+)'/)?.[1];
-      if (!envName) return;
-      // Key by resource + env-var NAME; the current row indices are resolved at
-      // render time so a reorder/removal can't misattach the inline error.
+      if (!resourceName || fieldErrors.length === 0) return;
+      // Thin op → all errors belong to this one resource; map to editor field keys
+      // and store by resource NAME so a reorder/removal can't misattach them.
+      const fields = mapFieldErrors(fieldErrors, { dialect: "thin", resourceIndex: 0 }).resources[0];
+      if (!fields) return;
       setServerFieldErrors((prev) => ({
         ...prev,
-        [resourceName]: { ...(prev[resourceName] ?? {}), [envName]: message },
+        [resourceName]: { ...(prev[resourceName] ?? {}), ...fields },
       }));
     },
   });
@@ -473,29 +484,47 @@ export default function StackDetailPage() {
     return { resources, volumes: {} };
   }, [desiredState.resourceIssues]);
 
-  // Merge live zod validation (index-keyed) with backend field errors from a
-  // failed autosave (name-keyed). Resolve each server error's resource NAME and
-  // env-var NAME to their CURRENT indices here so the merged map stays index-keyed
-  // for consumers but survives a reorder/removal since the error was captured.
+  // Merge live zod validation (index-keyed) with backend field errors (name-keyed).
+  // Resolve each server error's resource NAME to its CURRENT index here so the
+  // merged map stays index-keyed for consumers but survives a reorder/removal
+  // since the error was captured.
   const mergedResourceErrors = useMemo(() => {
     const merged: { [index: number]: { [field: string]: string | undefined } } = {};
     for (const [k, v] of Object.entries(validationErrors.resources)) {
       merged[Number(k)] = { ...v };
     }
-    for (const [resourceName, envErrors] of Object.entries(serverFieldErrors)) {
+    for (const [resourceName, fields] of Object.entries(serverFieldErrors)) {
       const idx = session.draft.resources.findIndex((r) => r.name === resourceName);
       if (idx < 0) continue;
-      const draftEnv = (session.draft.resources[idx]?.execution_config
-        ?.environment_variables ?? []) as FormEnvVarData[];
-      for (const [envName, message] of Object.entries(envErrors)) {
-        const envIdx = draftEnv.findIndex((e) => e.name === envName);
-        if (envIdx < 0) continue;
-        const fieldKey = `execution_config.environment_variables.${envIdx}.value`;
-        merged[idx] = { ...(merged[idx] ?? {}), [fieldKey]: message };
-      }
+      merged[idx] = { ...(merged[idx] ?? {}), ...fields };
     }
     return merged;
   }, [validationErrors.resources, serverFieldErrors, session.draft.resources]);
+
+  // Summary-banner rows for the last draft-deploy failure. Fat dialect: resource
+  // errors carry a jump index; stack-level errors (name/settings/connections) do not.
+  const bannerItems = useMemo<ValidationBannerItem[]>(() => {
+    if (deployFieldErrors.length === 0) return [];
+    const mapped = mapFieldErrors(deployFieldErrors, { dialect: "fat" });
+    const items: ValidationBannerItem[] = [];
+    if (mapped.stackName) items.push({ label: "Stack name", message: mapped.stackName });
+    for (const [idxStr, fields] of Object.entries(mapped.resources)) {
+      const idx = Number(idxStr);
+      const label = session.draft.resources[idx]?.name?.trim() || `Resource ${idx + 1}`;
+      for (const [fieldKey, message] of Object.entries(fields)) {
+        // Env errors live on the Environment tab; everything else renders on
+        // Configuration. Jump opens the tab holding the offending field.
+        const tab = fieldKey.startsWith("execution_config.environment_variables")
+          ? "environment"
+          : "configuration";
+        items.push({ label, message, resourceIndex: idx, tab });
+      }
+    }
+    for (const m of mapped.settings) items.push({ label: "Stack settings", message: m });
+    for (const m of mapped.connections) items.push({ label: "Connection", message: m });
+    for (const u of mapped.unmapped) items.push({ label: u.field, message: u.message });
+    return items;
+  }, [deployFieldErrors, session.draft.resources]);
 
   const lifecycle = useDeployLifecycle({
     stack: stackToShow ?? undefined,
@@ -550,6 +579,15 @@ export default function StackDetailPage() {
       draftSync.notifyExternalUpdate(fresh);
       session.discard(); // auto-start effect restarts the session on the reverted baseline
       toast({ title: "Draft discarded", description: "Stack restored to the last deployment.", variant: "success" });
+    },
+    onError: (message) => {
+      // Revert isn't atomic (apply + volume deletes), so warn about partial state
+      // alongside the backend reason.
+      toast({
+        title: "Discard failed",
+        description: `${message} The stack may be partially reverted; reload to see its current state.`,
+        variant: "destructive",
+      });
     },
   });
 
@@ -617,6 +655,9 @@ export default function StackDetailPage() {
     if (!isDraft) return;
     setDraftDeploying(true);
     setNameError(undefined);
+    // Clear stale validation state from a previous failed attempt.
+    setDeployFieldErrors([]);
+    setServerFieldErrors({});
 
     // A draft needs a name before it can be created. The stack name field is not
     // min-length-constrained in the schema (empty passes zod and only fails at
@@ -715,11 +756,33 @@ export default function StackDetailPage() {
       navigate(`/stacks/${created.id}`, { replace: true, state: null });
     } catch (err) {
       console.error('Failed to create stack:', err);
-      toast({
-        title: "Failed to create stack",
-        description: getErrorMessage(err),
-        variant: "destructive"
-      });
+      const parsed = parseApiError(err);
+      if (parsed.fieldErrors.length > 0) {
+        // Rich validation failure: paint each field inline and summarize in the banner.
+        const mapped = mapFieldErrors(parsed.fieldErrors, { dialect: "fat" });
+        if (mapped.stackName) setNameError(mapped.stackName);
+        setServerFieldErrors((prev) => {
+          const next = { ...prev };
+          for (const [idxStr, fields] of Object.entries(mapped.resources)) {
+            const nm = session.draft.resources[Number(idxStr)]?.name;
+            if (nm) next[nm] = { ...(next[nm] ?? {}), ...fields };
+          }
+          return next;
+        });
+        setDeployFieldErrors(parsed.fieldErrors);
+        setBannerDismissed(false);
+        toast({
+          title: "Deploy failed",
+          description: `${parsed.fieldErrors.length} validation ${parsed.fieldErrors.length === 1 ? "error" : "errors"}`,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "Failed to create stack",
+          description: parsed.topLevel,
+          variant: "destructive",
+        });
+      }
     } finally {
       setDraftDeploying(false);
     }
@@ -900,25 +963,37 @@ export default function StackDetailPage() {
         onDelete={() => setDeleteConfirmOpen(true)}
         publicEndpoints={publicEndpoints}
         architecture={
-          <StackCanvasTab
-            session={session}
-            baselineResources={baselineResources}
-            baselineVolumes={baselineVolumes}
-            draftResources={draftResources}
-            draftVolumes={draftVolumes}
-            serverOutputsByName={serverOutputsByName}
-            connectionAddonIds={connectionAddonIds}
-            addonNameById={addonNameById}
-            addonStateById={addonStateById}
-            errors={mergedResourceErrors}
-            onViewLogs={() => setActiveTab("logs")}
-            topologyIds={!isDraft && deployIds.stackId ? deployIds : null}
-            topologyRefreshKey={topologyRefreshKey}
-            onDeleteVolume={deployIds.stackId ? volumeDelete.deleteVolume : undefined}
-            deletingVolume={volumeDelete.deleting}
-            persistedVolumeNames={persistedVolumeNames}
-            releaseInFlight={deployBusy || lifecycle.phase === "deploying"}
-          />
+          <>
+            {!bannerDismissed && bannerItems.length > 0 && (
+              <div className="px-4 pt-3">
+                <ValidationBanner
+                  items={bannerItems}
+                  onJump={(index, tab) => setOpenResourceSignal({ index, tab, nonce: Date.now() })}
+                  onDismiss={() => setBannerDismissed(true)}
+                />
+              </div>
+            )}
+            <StackCanvasTab
+              session={session}
+              openResourceSignal={openResourceSignal}
+              baselineResources={baselineResources}
+              baselineVolumes={baselineVolumes}
+              draftResources={draftResources}
+              draftVolumes={draftVolumes}
+              serverOutputsByName={serverOutputsByName}
+              connectionAddonIds={connectionAddonIds}
+              addonNameById={addonNameById}
+              addonStateById={addonStateById}
+              errors={mergedResourceErrors}
+              onViewLogs={() => setActiveTab("logs")}
+              topologyIds={!isDraft && deployIds.stackId ? deployIds : null}
+              topologyRefreshKey={topologyRefreshKey}
+              onDeleteVolume={deployIds.stackId ? volumeDelete.deleteVolume : undefined}
+              deletingVolume={volumeDelete.deleting}
+              persistedVolumeNames={persistedVolumeNames}
+              releaseInFlight={deployBusy || lifecycle.phase === "deploying"}
+            />
+          </>
         }
         deployments={deploymentsBody}
         logs={logsBody}
@@ -967,14 +1042,8 @@ export default function StackDetailPage() {
                 void (async () => {
                   // Flush any pending autosave before reverting (don't block on failure)
                   await draftSync.flush();
-                  const ok = await stackRevert.revert();
-                  if (!ok) {
-                    toast({
-                      title: "Discard failed",
-                      description: "The stack may be partially reverted. Reload the page to see its current state.",
-                      variant: "destructive",
-                    });
-                  }
+                  // Failure surfaces via the hook's onError toast.
+                  await stackRevert.revert();
                 })();
               }}
               disabled={stackRevert.reverting}

--- a/frontend/src/pages/stacks/components/shared/stack-resource-configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/shared/stack-resource-configuration-tab.tsx
@@ -671,7 +671,11 @@ function StackResourceConfigurationTabImpl({
                     required
                   />
                 </FieldShell>
-                <FieldShell label="Protocol" htmlFor={`port-protocol-${index}-${pidx}`}>
+                <FieldShell
+                  label="Protocol"
+                  htmlFor={`port-protocol-${index}-${pidx}`}
+                  error={getError(errors, `ports.${pidx}.protocol`)}
+                >
                   <Select
                     value={port.protocol || "tcp"}
                     onValueChange={(value) => updatePort(pidx, { protocol: value as "tcp" | "http" })}

--- a/frontend/src/pages/stacks/hooks/use-draft-sync.ts
+++ b/frontend/src/pages/stacks/hooks/use-draft-sync.ts
@@ -16,17 +16,21 @@ import {
 import { serverStateFromStack, type ServerStackState } from "@/pages/stacks/lib/draft-sync/server-state";
 import { buildDesiredState } from "@/pages/stacks/lib/draft-sync/desired-state";
 import { computeSyncOps, type SyncOp } from "@/pages/stacks/lib/draft-sync/ops";
-import { getErrorMessage, getErrorStatus, isBadRequestError } from "@/api/client";
+import { isBadRequestError } from "@/api/client";
+import { parseApiError, type ParsedFieldError } from "@/api/errors";
 import type { EditSessionDraft, UseStackEditSession } from "./use-stack-edit-session";
 
 /** Surfaced to the caller when an autosave op fails, carrying the offending op
  *  so the UI can toast the reason and mark the responsible field inline. `op` is
  *  absent when the ops all landed but the post-save refetch failed — the save
- *  actually succeeded, so there is no op-level field error to attribute. */
+ *  actually succeeded, so there is no op-level field error to attribute.
+ *  `fieldErrors` are the structured per-field validation errors from the
+ *  response (empty for non-validation failures). */
 export interface SyncErrorInfo {
   status?: number;
   message: string;
   op?: SyncOp;
+  fieldErrors: ParsedFieldError[];
 }
 
 export interface UseDraftSyncArgs {
@@ -180,9 +184,11 @@ export function useDraftSync({
         failuresRef.current += 1;
         setFailureCount(failuresRef.current);
         setStatus(SYNC_STATUS.error);
+        const parsed = parseApiError(err);
         onSyncErrorRef.current?.({
-          status: getErrorStatus(err),
-          message: getErrorMessage(err),
+          status: parsed.status,
+          message: parsed.topLevel,
+          fieldErrors: parsed.fieldErrors,
           // Ops all landed → the refetch failed, not an op. Leave op undefined so
           // the caller doesn't pin a spurious field error on a save that landed.
           op: opsSucceeded ? undefined : failingOp,

--- a/frontend/src/pages/stacks/hooks/use-stack-edit-session.ts
+++ b/frontend/src/pages/stacks/hooks/use-stack-edit-session.ts
@@ -77,6 +77,9 @@ export interface UseStackEditSession {
       | ((prev: VolumeArr) => VolumeArr),
   ) => void;
   setLinkedAddonIds: (next: Set<string> | ((prev: Set<string>) => Set<string>)) => void;
+  /** Switch the active resource-drawer tab (drives the controlled Tabs). No-op
+   *  when no session is active. */
+  setOpenTab: (tab: EditSessionTab | null) => void;
   /** Advance the baseline to a synced snapshot; the draft is untouched, so
    *  edits made after the snapshot remain dirty. */
   rebase: (baseline: EditSessionDraft) => void;
@@ -180,6 +183,10 @@ export function useStackEditSession(): UseStackEditSession {
     [],
   );
 
+  const setOpenTab = useCallback((tab: EditSessionTab | null) => {
+    setState((prev) => (prev.isActive && prev.openTab !== tab ? { ...prev, openTab: tab } : prev));
+  }, []);
+
   const rebase = useCallback((baseline: EditSessionDraft) => {
     setState((prev) => {
       if (!prev.isActive) return prev;
@@ -213,6 +220,7 @@ export function useStackEditSession(): UseStackEditSession {
     updateResources,
     updateVolumes,
     setLinkedAddonIds,
+    setOpenTab,
     rebase,
   };
 }

--- a/frontend/src/pages/stacks/hooks/use-stack-revert.ts
+++ b/frontend/src/pages/stacks/hooks/use-stack-revert.ts
@@ -4,6 +4,7 @@ import { getStackById, applyStack } from "@/api/stacks";
 import { deleteVolume } from "@/api/volumes";
 import type { StackReleaseSnapshot } from "@/api/releases";
 import { snapshotToUpdateRequest, volumesToDelete } from "@/pages/stacks/lib/draft-sync/snapshot-to-update";
+import { parseApiError } from "@/api/errors";
 
 export interface UseStackRevertArgs {
   ids: { orgId: string; teamName: string; stackId: string } | null;
@@ -11,10 +12,12 @@ export interface UseStackRevertArgs {
   liveSnapshot: StackReleaseSnapshot | undefined;
   /** session.discard — the page's session auto-start effect re-seeds from the refreshed stack. */
   onReverted: (fresh: Stack) => void;
+  /** Called with the backend reason when the revert throws. */
+  onError?: (message: string) => void;
 }
 
 /** Restore the authored stack to the last deployed snapshot. */
-export function useStackRevert({ ids, stack, liveSnapshot, onReverted }: UseStackRevertArgs) {
+export function useStackRevert({ ids, stack, liveSnapshot, onReverted, onError }: UseStackRevertArgs) {
   const [reverting, setReverting] = useState(false);
 
   const revert = useCallback(async (): Promise<boolean> => {
@@ -31,12 +34,13 @@ export function useStackRevert({ ids, stack, liveSnapshot, onReverted }: UseStac
       const fresh = await getStackById(ids.orgId, ids.teamName, ids.stackId);
       onReverted(fresh);
       return true;
-    } catch {
+    } catch (err) {
+      onError?.(parseApiError(err).topLevel);
       return false;
     } finally {
       setReverting(false);
     }
-  }, [ids, stack, liveSnapshot, onReverted]);
+  }, [ids, stack, liveSnapshot, onReverted, onError]);
 
   return { reverting, revert };
 }

--- a/frontend/src/pages/stacks/lib/map-field-errors.test.ts
+++ b/frontend/src/pages/stacks/lib/map-field-errors.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { mapFieldErrors } from "./map-field-errors";
+import type { ParsedFieldError } from "@/api/errors";
+
+function fe(field: string, message = "msg", code = "x"): ParsedFieldError {
+  return { field, code, message };
+}
+
+describe("mapFieldErrors — fat dialect", () => {
+  it("strips the spec.stack_resources[N]. prefix and converts brackets to dots", () => {
+    const out = mapFieldErrors([fe("spec.stack_resources[0].ports[1].protocol", "bad protocol")], { dialect: "fat" });
+    expect(out.resources[0]).toEqual({ "ports.1.protocol": "bad protocol" });
+  });
+
+  it("routes bare `name` to the stack name, not a resource", () => {
+    const out = mapFieldErrors([fe("name", "stack name invalid")], { dialect: "fat" });
+    expect(out.stackName).toBe("stack name invalid");
+    expect(out.resources).toEqual({});
+  });
+
+  it("routes spec.stack_resources[N].name to that resource's name", () => {
+    const out = mapFieldErrors([fe("spec.stack_resources[2].name", "dup")], { dialect: "fat" });
+    expect(out.resources[2]).toEqual({ name: "dup" });
+    expect(out.stackName).toBeUndefined();
+  });
+
+  it("translates env paths to the frontend env-tab key with .name / .value leaf", () => {
+    const out = mapFieldErrors(
+      [
+        fe("spec.stack_resources[0].execution_config.env[2].name", "name required"),
+        fe("spec.stack_resources[0].execution_config.env[3]", "value missing"),
+        fe("spec.stack_resources[0].execution_config.env[4].secret_key_ref", "secret missing"),
+        fe("spec.stack_resources[0].execution_config.env[5].self_output", "unknown output"),
+      ],
+      { dialect: "fat" },
+    );
+    expect(out.resources[0]).toEqual({
+      "execution_config.environment_variables.2.name": "name required",
+      "execution_config.environment_variables.3.value": "value missing",
+      "execution_config.environment_variables.4.value": "secret missing",
+      "execution_config.environment_variables.5.value": "unknown output",
+    });
+  });
+
+  it("collects settings and connections separately", () => {
+    const out = mapFieldErrors(
+      [fe("spec.settings", "retention too high"), fe("spec.connections[0]", "bad connection")],
+      { dialect: "fat" },
+    );
+    expect(out.settings).toEqual(["retention too high"]);
+    expect(out.connections).toEqual(["bad connection"]);
+  });
+
+  it("puts unrecognized paths in unmapped", () => {
+    const err = fe("spec.something_new", "huh");
+    const out = mapFieldErrors([err], { dialect: "fat" });
+    expect(out.unmapped).toEqual([err]);
+  });
+});
+
+describe("mapFieldErrors — thin dialect", () => {
+  it("assigns every bare path to the edited resource's index", () => {
+    const out = mapFieldErrors(
+      [fe("name", "resource name required"), fe("ports[0].number", "bad number")],
+      { dialect: "thin", resourceIndex: 3 },
+    );
+    expect(out.resources[3]).toEqual({ name: "resource name required", "ports.0.number": "bad number" });
+    expect(out.stackName).toBeUndefined();
+  });
+
+  it("translates thin env paths too", () => {
+    const out = mapFieldErrors([fe("execution_config.env[0].name", "required")], { dialect: "thin", resourceIndex: 1 });
+    expect(out.resources[1]).toEqual({ "execution_config.environment_variables.0.name": "required" });
+  });
+
+  it("routes an unexpected spec-prefixed path to unmapped", () => {
+    const err = fe("spec.settings", "unexpected");
+    const out = mapFieldErrors([err], { dialect: "thin", resourceIndex: 0 });
+    expect(out.unmapped).toEqual([err]);
+    expect(out.resources).toEqual({});
+  });
+});

--- a/frontend/src/pages/stacks/lib/map-field-errors.ts
+++ b/frontend/src/pages/stacks/lib/map-field-errors.ts
@@ -1,0 +1,77 @@
+// Maps backend validation field paths onto the resource-tab error map the stack
+// editor already consumes. Backend paths use bracket indices and a different
+// taxonomy for env vars; the editor keys are two-level (resource index → bare
+// dot-notation leaf path). See use-resource-tab-props / getError for the target
+// shape. Env keys must be exact because the env tab looks them up directly (no
+// prefix-walk); everything else is matched by getError's prefix walk.
+import type { ParsedFieldError } from "@/api/errors";
+
+export type MapDialect =
+  | { dialect: "fat" }
+  | { dialect: "thin"; resourceIndex: number };
+
+export type MappedFieldErrors = {
+  stackName?: string;
+  settings: string[];
+  connections: string[];
+  resources: Record<number, Record<string, string>>;
+  unmapped: ParsedFieldError[];
+};
+
+const RESOURCE_PREFIX = /^spec\.stack_resources\[(\d+)\]\.(.+)$/;
+// The backend keys env errors under `execution_config.env[i]` (bare index, or
+// with a `.name`/`.secret_key_ref`/`.self_output` leaf); the editor's env tab
+// keys them under `execution_config.environment_variables.i.(name|value)`.
+const ENV_PREFIX = /^execution_config\.env\.(\d+)/;
+const ENV_TAB_KEY = "execution_config.environment_variables";
+
+// Convert backend bracket indices (`ports[1]`) to the editor's dot segments
+// (`ports.1`), then remap the env taxonomy onto the env-tab key with the
+// correct .name / .value leaf.
+function toEditorKey(barePath: string): string {
+  const dotted = barePath.replace(/\[(\d+)\]/g, ".$1");
+  const env = dotted.match(ENV_PREFIX);
+  if (env) {
+    const leaf = dotted.endsWith(".name") ? "name" : "value";
+    return `${ENV_TAB_KEY}.${env[1]}.${leaf}`;
+  }
+  return dotted;
+}
+
+function put(resources: Record<number, Record<string, string>>, index: number, key: string, message: string) {
+  const bucket = (resources[index] ??= {});
+  if (bucket[key] === undefined) bucket[key] = message;
+}
+
+export function mapFieldErrors(errors: ParsedFieldError[], opts: MapDialect): MappedFieldErrors {
+  const out: MappedFieldErrors = { settings: [], connections: [], resources: {}, unmapped: [] };
+
+  for (const err of errors) {
+    const { field, message } = err;
+
+    if (opts.dialect === "thin") {
+      if (field.startsWith("spec.")) {
+        out.unmapped.push(err);
+      } else {
+        put(out.resources, opts.resourceIndex, toEditorKey(field), message);
+      }
+      continue;
+    }
+
+    // fat dialect
+    const resourceMatch = field.match(RESOURCE_PREFIX);
+    if (resourceMatch) {
+      put(out.resources, Number(resourceMatch[1]), toEditorKey(resourceMatch[2]), message);
+    } else if (field === "name") {
+      out.stackName ??= message;
+    } else if (field.startsWith("spec.settings")) {
+      out.settings.push(message);
+    } else if (field.startsWith("spec.connections")) {
+      out.connections.push(message);
+    } else {
+      out.unmapped.push(err);
+    }
+  }
+
+  return out;
+}

--- a/pkg/stores/pgstore/stack_resource.go
+++ b/pkg/stores/pgstore/stack_resource.go
@@ -46,8 +46,7 @@ func (w *stackResourceStore) CreateWithTx(ctx context.Context, spec *models.Stac
 }
 
 func (w *stackResourceStore) Update(ctx context.Context, ID string, spec *models.StackResource, stack *models.Stack) (*models.StackResource, *errors.ServiceError) {
-	spec.Status = nil
-	if err := w.sessionFactory.New(ctx).Model(&models.StackResource{}).Omit(clause.Associations).Where("id = ?", ID).Updates(spec).Error; err != nil {
+	if err := applyStackResourceUpdate(w.sessionFactory.New(ctx), ID, spec); err != nil {
 		return nil, errors.GeneralError("failed to update stack resource: %s", err.Error())
 	}
 	return w.GetByID(ctx, ID)
@@ -58,11 +57,21 @@ func (w *stackResourceStore) UpdateWithTx(ctx context.Context, ID string, spec *
 	if tx == nil {
 		return nil, errors.GeneralError("transaction not found in context")
 	}
-	spec.Status = nil
-	if err := tx.Model(&models.StackResource{}).Omit(clause.Associations).Where("id = ?", ID).Updates(spec).Error; err != nil {
+	if err := applyStackResourceUpdate(tx, ID, spec); err != nil {
 		return nil, errors.GeneralError("failed to update stack resource: %s", err.Error())
 	}
 	return w.GetByID(ctx, ID)
+}
+
+// applyStackResourceUpdate writes all spec columns, including ones zeroed by
+// the caller, so cleared fields (e.g. image_config on an image→git switch)
+// don't survive the update. Status is agent-owned and never written here.
+func applyStackResourceUpdate(dbSession *gorm.DB, ID string, spec *models.StackResource) error {
+	return dbSession.Model(&models.StackResource{}).
+		Select("*").
+		Omit(clause.Associations, "status", "version", "created_at").
+		Where("id = ?", ID).
+		Updates(spec).Error
 }
 
 func (w *stackResourceStore) UpdatePortsWithTx(ctx context.Context, resourceID string, resource *models.StackResource) *errors.ServiceError {

--- a/pkg/stores/pgstore/stack_resource_test.go
+++ b/pkg/stores/pgstore/stack_resource_test.go
@@ -1,0 +1,140 @@
+package pgstore_test
+
+import (
+	"context"
+
+	"github.com/Stackdome/stackdome/pkg/db"
+	"github.com/Stackdome/stackdome/pkg/models"
+	"github.com/Stackdome/stackdome/pkg/stores"
+	"github.com/Stackdome/stackdome/pkg/stores/pgstore"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const stackResourcesDDL = `
+	CREATE TABLE stack_resources (
+		id text PRIMARY KEY,
+		user_id text NOT NULL,
+		stack_id text NOT NULL,
+		name text NOT NULL,
+		namespace text,
+		labels jsonb,
+		annotations jsonb,
+		version bigint DEFAULT 1,
+		build_config jsonb,
+		image_config jsonb,
+		init jsonb,
+		execution_config jsonb,
+		depends_on jsonb,
+		lifecycle_config jsonb,
+		ports jsonb,
+		status jsonb,
+		workload_type text NOT NULL DEFAULT 'Service',
+		schedule text,
+		replicas integer,
+		created_at datetime,
+		updated_at datetime
+	)
+`
+
+var _ = Describe("StackResourceStore", func() {
+	var (
+		sf    *sqliteSessionFactory
+		store stores.StackResourceStore
+		ctx   context.Context
+	)
+
+	seedResource := func() *models.StackResource {
+		seeded := &models.StackResource{
+			ID:           "res-1",
+			UserID:       "user-1",
+			StackID:      "stack-1",
+			Name:         "test",
+			Namespace:    "ns-1",
+			ImageConfig:  &models.ImageConfigSpec{Image: "nginx"},
+			WorkloadType: models.WorkloadTypeCronJob,
+			Schedule:     "*/5 * * * *",
+			Status:       &models.StackResourceStatus{State: models.StackResourcePhaseReady},
+		}
+		Expect(sf.New(ctx).Create(seeded).Error).NotTo(HaveOccurred())
+		return seeded
+	}
+
+	gitUpdateSpec := func() *models.StackResource {
+		return &models.StackResource{
+			ID:      "res-1",
+			UserID:  "user-1",
+			StackID: "stack-1",
+			Name:    "test",
+			BuildConfig: &models.BuildConfigSpec{
+				SourceContext: models.BuildContextSource{
+					Git: &models.GitBuildSource{RepoURL: "https://github.com/Stackdome/test-repo"},
+				},
+				DockerfilePath:          "Dockerfile",
+				ContextPathWithinSource: ".",
+			},
+			WorkloadType: models.WorkloadTypeService,
+		}
+	}
+
+	BeforeEach(func() {
+		sf = newSQLiteSessionFactory(stackResourcesDDL)
+		store = pgstore.NewStackResourceStore(pgstore.StackResourceStoreSpec{SessionFactory: sf})
+		ctx = context.Background()
+	})
+
+	Describe("UpdateWithTx", func() {
+		runUpdate := func(spec *models.StackResource) *models.StackResource {
+			tx := sf.New(ctx).Begin()
+			txCtx := db.CtxWithTransaction(ctx, tx)
+			_, serr := store.UpdateWithTx(txCtx, "res-1", spec, &models.Stack{ID: "stack-1"})
+			Expect(serr).To(BeNil())
+			Expect(tx.Commit().Error).NotTo(HaveOccurred())
+
+			fetched, gerr := store.GetByID(ctx, "res-1")
+			Expect(gerr).To(BeNil())
+			return fetched
+		}
+
+		It("clears fields that are zero in the update spec", func() {
+			seedResource()
+
+			fetched := runUpdate(gitUpdateSpec())
+
+			Expect(fetched.BuildConfig).NotTo(BeNil())
+			Expect(fetched.BuildConfig.SourceContext.Git).NotTo(BeNil())
+			Expect(fetched.BuildConfig.SourceContext.Git.RepoURL).To(Equal("https://github.com/Stackdome/test-repo"))
+			Expect(fetched.ImageConfig).To(BeNil())
+			Expect(fetched.Schedule).To(BeEmpty())
+			Expect(fetched.WorkloadType).To(Equal(models.WorkloadTypeService))
+		})
+
+		It("preserves status and created-only fields", func() {
+			seeded := seedResource()
+
+			fetched := runUpdate(gitUpdateSpec())
+
+			Expect(fetched.Status).NotTo(BeNil())
+			Expect(fetched.Status.State).To(Equal(models.StackResourcePhaseReady))
+			Expect(fetched.Name).To(Equal(seeded.Name))
+			Expect(fetched.Namespace).To(Equal(seeded.Namespace))
+			Expect(fetched.CreatedAt).To(BeTemporally("~", seeded.CreatedAt, 0))
+		})
+	})
+
+	Describe("Update", func() {
+		It("clears fields that are zero in the update spec", func() {
+			seedResource()
+
+			_, serr := store.Update(ctx, "res-1", gitUpdateSpec(), &models.Stack{ID: "stack-1"})
+			Expect(serr).To(BeNil())
+
+			fetched, gerr := store.GetByID(ctx, "res-1")
+			Expect(gerr).To(BeNil())
+			Expect(fetched.BuildConfig).NotTo(BeNil())
+			Expect(fetched.ImageConfig).To(BeNil())
+			Expect(fetched.Schedule).To(BeEmpty())
+			Expect(fetched.Status).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/stores/pgstore/testhelpers_test.go
+++ b/pkg/stores/pgstore/testhelpers_test.go
@@ -6,6 +6,7 @@ import (
 	stderrors "errors"
 
 	"github.com/Stackdome/stackdome/config"
+	"github.com/Stackdome/stackdome/pkg/db"
 	sqlitedriver "github.com/glebarez/go-sqlite"
 	"github.com/glebarez/sqlite"
 	. "github.com/onsi/gomega"
@@ -57,7 +58,10 @@ func newSQLiteSessionFactory(ddlStatements ...string) *sqliteSessionFactory {
 
 func (f *sqliteSessionFactory) Init(*config.DatabaseConfig) {}
 func (f *sqliteSessionFactory) DirectDB() *sql.DB           { d, _ := f.db.DB(); return d }
-func (f *sqliteSessionFactory) New(context.Context) *gorm.DB {
+func (f *sqliteSessionFactory) New(ctx context.Context) *gorm.DB {
+	if tx := db.TxFromContext(ctx); tx != nil {
+		return tx
+	}
 	return f.db.Session(&gorm.Session{})
 }
 func (f *sqliteSessionFactory) CheckConnection() error { return nil }


### PR DESCRIPTION
## 📝 What this does
The backend returns structured, per-field validation errors on stack create/update/apply and resource edits, but the editor only ever showed the top-level reason string (and faked env-var field errors with a regex). This parses the structured errors and surfaces them where they belong — inline on the offending field, plus a summary banner that jumps you to the exact tab.

## 🔀 Changes
- Parsed the structured `details.errors[]` payload into per-field errors, with a fallback to the flat reason string.
- Mapped backend field paths (both the thin per-resource and fat whole-document shapes) onto the editor's fields, including the env-var name/taxonomy mismatch.
- Added a dismissable validation banner; clicking a row opens the offending resource on the tab holding the field.
- Wired the port-protocol selector to its inline error and surfaced the previously swallowed stack-revert error.
- Dropped the old env-var regex scrape.

## 🧪 How to test
- [ ] Create a draft stack with a public port set to TCP, deploy — banner + inline protocol error appear.
- [ ] Add an env var with an empty value, deploy — inline value error shows; click the banner row and confirm it opens the Environment tab.
- [ ] Confirm a non-validation failure still shows a plain error toast.