### PR TITLE
feat(logging): production-ready structured JSON logging

### DIFF
--- a/cmd/environment/common.go
+++ b/cmd/environment/common.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 
 	"github.com/Stackdome/stackdome/config"
-	"github.com/golang/glog"
+	"github.com/Stackdome/stackdome/pkg/logger"
 )
+
+var log = logger.NewLogger()
 
 const (
 	DEVELOPMENT_ENV = "DEVELOPMENT"
@@ -16,7 +18,7 @@ const (
 func GetEnvironmentStrFromEnv() string {
 	val, ok := config.EnvStackdomeEnv.Lookup()
 	if !ok || val == "" {
-		glog.Infof("Environment variable %q not specified, using default %q", config.EnvStackdomeEnv.Name, DEVELOPMENT_ENV)
+		log.Infof("Environment variable %q not specified, using default %q", config.EnvStackdomeEnv.Name, DEVELOPMENT_ENV)
 		return DEVELOPMENT_ENV
 	}
 	return val

--- a/cmd/environment/development_environment.go
+++ b/cmd/environment/development_environment.go
@@ -249,35 +249,36 @@ func (d *developmentEnvironment) initializeClusterManager(ctx context.Context) e
 	d.ClusterManager = clustermanager.NewClusterManager(clustermanager.ClusterManagerConfig{
 		LeadershipFlag:      leadershipFlag,
 		CredentialDecryptor: d.EncryptionService,
+		Logger:              applogger.NewLoggerWithPrefix(ctx, "cluster-manager").SetLevel(d.Logger.GetLevel()),
 		ControllersToRegister: []clustermanager.ControllerFn{
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return volumecontroller.NewVolumeReconciler(volumecontroller.VolumeReconcilerSpec{
-					Log:            applogger.NewLoggerWithPrefix(ctx, "volume-controller").SetLevel(d.Logger.GetLevel()),
+					Log:            applogger.NewLoggerWithPrefix(ctx, "volume-controller").SetLevel(d.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					StorageService: d.Services.StackStorageService,
 					VolumeService:  d.Services.VolumeService,
 					Env:            d.Name,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return workspaceusercontroller.NewWorkspaceUserReconciler(workspaceusercontroller.WorkspaceUserReconcilerSpec{
-					Log:                  applogger.NewLoggerWithPrefix(ctx, "workspace-user-controller").SetLevel(d.Logger.GetLevel()),
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "workspace-user-controller").SetLevel(d.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					WorkspaceUserService: d.Services.WorkspaceUserService,
 					ClusterService:       d.Services.ClusterService,
 					Env:                  d.Name,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return stackcontroller.NewStackReconciler(stackcontroller.StackReconcilerSpec{
-					Log:            applogger.NewLoggerWithPrefix(ctx, "stack-controller").SetLevel(d.Logger.GetLevel()),
+					Log:            applogger.NewLoggerWithPrefix(ctx, "stack-controller").SetLevel(d.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					StackService:   d.Services.StackService,
 					Env:            d.Name,
 					ReleaseChecker: d.Services.StackReleaseService,
 					Enqueuer:       d.WorkerManager,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return stackresourcecontroller.NewStackResourceReconciler(stackresourcecontroller.StackResourceReconcilerSpec{
-					Log:                  applogger.NewLoggerWithPrefix(ctx, "stack-resource-controller").SetLevel(d.Logger.GetLevel()),
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "stack-resource-controller").SetLevel(d.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					StackService:         d.Services.StackService,
 					StackResourceService: d.Services.StackResourceService,
 					Env:                  d.Name,
@@ -285,9 +286,9 @@ func (d *developmentEnvironment) initializeClusterManager(ctx context.Context) e
 					EventRecorder:        d.Services.ReleaseEventRecorder,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return imagebuildcontroller.NewImageBuildReconciler(imagebuildcontroller.ImageBuildReconcilerSpec{
-					Log:                   applogger.NewLoggerWithPrefix(ctx, "image-build-controller").SetLevel(d.Logger.GetLevel()),
+					Log:                   applogger.NewLoggerWithPrefix(ctx, "image-build-controller").SetLevel(d.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					DBImageBuildService:   d.Services.ImageBuildService,
 					DBResourceService:     d.Services.StackResourceService,
 					GitIntegrationService: d.Services.GitIntegrationService,
@@ -295,22 +296,22 @@ func (d *developmentEnvironment) initializeClusterManager(ctx context.Context) e
 					EventRecorder:         d.Services.ReleaseEventRecorder,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return clusterimageregistry.NewClusterImageRegistryReconciler(clusterimageregistry.ClusterImageRegistryReconcilerSpec{
-					Logger:                 applogger.NewLoggerWithPrefix(ctx, "cluster-image-registry-controller").SetLevel(d.Logger.GetLevel()),
+					Logger:                 applogger.NewLoggerWithPrefix(ctx, "cluster-image-registry-controller").SetLevel(d.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					DBImageRegistryService: d.Services.ClusterImageRegistryService,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return postgresaddoncontroller.NewPostgresAddonReconciler(postgresaddoncontroller.PostgresAddonReconcilerSpec{
-					Log:                  applogger.NewLoggerWithPrefix(ctx, "postgres-addon-controller").SetLevel(d.Logger.GetLevel()),
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "postgres-addon-controller").SetLevel(d.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					PostgresAddonService: d.Services.PostgresAddonService,
 					Env:                  d.Name,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return postgresbackupcontroller.NewPostgresBackupReconciler(postgresbackupcontroller.PostgresBackupReconcilerSpec{
-					Log:                   applogger.NewLoggerWithPrefix(ctx, "postgres-backup-controller").SetLevel(d.Logger.GetLevel()),
+					Log:                   applogger.NewLoggerWithPrefix(ctx, "postgres-backup-controller").SetLevel(d.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					PostgresBackupService: d.Services.PostgresBackupService,
 				})
 			},

--- a/cmd/environment/test_environment.go
+++ b/cmd/environment/test_environment.go
@@ -596,8 +596,9 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 	te.ClusterManager = clustermanager.NewClusterManager(clustermanager.ClusterManagerConfig{
 		LeadershipFlag:      leadershipFlag,
 		CredentialDecryptor: te.EncryptionService,
+		Logger:              applogger.NewLoggerWithPrefix(ctx, "cluster-manager").SetLevel(te.Logger.GetLevel()),
 		ControllersToRegister: []clustermanager.ControllerFn{
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return volumecontroller.NewVolumeReconciler(volumecontroller.VolumeReconcilerSpec{
 					Log:            applogger.NewLoggerWithPrefix(ctx, "test-volume-controller").SetLevel(te.Logger.GetLevel()),
 					StorageService: te.Services.StackStorageService,
@@ -605,7 +606,7 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 					Env:            te.Name,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return workspaceusercontroller.NewWorkspaceUserReconciler(workspaceusercontroller.WorkspaceUserReconcilerSpec{
 					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-workspace-user-controller").SetLevel(te.Logger.GetLevel()),
 					WorkspaceUserService: te.Services.WorkspaceUserService,
@@ -613,7 +614,7 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 					Env:                  te.Name,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return stackcontroller.NewStackReconciler(stackcontroller.StackReconcilerSpec{
 					Log:            applogger.NewLoggerWithPrefix(ctx, "test-stack-controller").SetLevel(te.Logger.GetLevel()),
 					StackService:   te.Services.StackService,
@@ -622,7 +623,7 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 					Enqueuer:       te.WorkerManager,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return stackresourcecontroller.NewStackResourceReconciler(stackresourcecontroller.StackResourceReconcilerSpec{
 					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-stack-resource-controller").SetLevel(te.Logger.GetLevel()),
 					StackService:         te.Services.StackService,
@@ -632,7 +633,7 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 					EventRecorder:        te.Services.ReleaseEventRecorder,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return imagebuildcontroller.NewImageBuildReconciler(imagebuildcontroller.ImageBuildReconcilerSpec{
 					Log:                   applogger.NewLoggerWithPrefix(ctx, "test-image-build-controller").SetLevel(te.Logger.GetLevel()),
 					DBImageBuildService:   te.Services.ImageBuildService,
@@ -642,20 +643,20 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 					EventRecorder:         te.Services.ReleaseEventRecorder,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return clusterimageregistry.NewClusterImageRegistryReconciler(clusterimageregistry.ClusterImageRegistryReconcilerSpec{
 					Logger:                 applogger.NewLoggerWithPrefix(ctx, "test-cluster-image-registry-controller").SetLevel(te.Logger.GetLevel()),
 					DBImageRegistryService: te.Services.ClusterImageRegistryService,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return postgresaddoncontroller.NewPostgresAddonReconciler(postgresaddoncontroller.PostgresAddonReconcilerSpec{
 					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-postgres-addon-controller").SetLevel(te.Logger.GetLevel()),
 					PostgresAddonService: te.Services.PostgresAddonService,
 					Env:                  te.Name,
 				})
 			},
-			func() clustermanager.Controller {
+			func(clusterID string) clustermanager.Controller {
 				return postgresbackupcontroller.NewPostgresBackupReconciler(postgresbackupcontroller.PostgresBackupReconcilerSpec{
 					Log:                   applogger.NewLoggerWithPrefix(ctx, "test-postgres-backup-controller").SetLevel(te.Logger.GetLevel()),
 					PostgresBackupService: te.Services.PostgresBackupService,

--- a/cmd/environment/test_environment.go
+++ b/cmd/environment/test_environment.go
@@ -600,7 +600,7 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 		ControllersToRegister: []clustermanager.ControllerFn{
 			func(clusterID string) clustermanager.Controller {
 				return volumecontroller.NewVolumeReconciler(volumecontroller.VolumeReconcilerSpec{
-					Log:            applogger.NewLoggerWithPrefix(ctx, "test-volume-controller").SetLevel(te.Logger.GetLevel()),
+					Log:            applogger.NewLoggerWithPrefix(ctx, "test-volume-controller").SetLevel(te.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					StorageService: te.Services.StackStorageService,
 					VolumeService:  te.Services.VolumeService,
 					Env:            te.Name,
@@ -608,7 +608,7 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 			},
 			func(clusterID string) clustermanager.Controller {
 				return workspaceusercontroller.NewWorkspaceUserReconciler(workspaceusercontroller.WorkspaceUserReconcilerSpec{
-					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-workspace-user-controller").SetLevel(te.Logger.GetLevel()),
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-workspace-user-controller").SetLevel(te.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					WorkspaceUserService: te.Services.WorkspaceUserService,
 					ClusterService:       te.Services.ClusterService,
 					Env:                  te.Name,
@@ -616,7 +616,7 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 			},
 			func(clusterID string) clustermanager.Controller {
 				return stackcontroller.NewStackReconciler(stackcontroller.StackReconcilerSpec{
-					Log:            applogger.NewLoggerWithPrefix(ctx, "test-stack-controller").SetLevel(te.Logger.GetLevel()),
+					Log:            applogger.NewLoggerWithPrefix(ctx, "test-stack-controller").SetLevel(te.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					StackService:   te.Services.StackService,
 					Env:            te.Name,
 					ReleaseChecker: te.Services.StackReleaseService,
@@ -625,7 +625,7 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 			},
 			func(clusterID string) clustermanager.Controller {
 				return stackresourcecontroller.NewStackResourceReconciler(stackresourcecontroller.StackResourceReconcilerSpec{
-					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-stack-resource-controller").SetLevel(te.Logger.GetLevel()),
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-stack-resource-controller").SetLevel(te.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					StackService:         te.Services.StackService,
 					StackResourceService: te.Services.StackResourceService,
 					Env:                  te.Name,
@@ -635,7 +635,7 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 			},
 			func(clusterID string) clustermanager.Controller {
 				return imagebuildcontroller.NewImageBuildReconciler(imagebuildcontroller.ImageBuildReconcilerSpec{
-					Log:                   applogger.NewLoggerWithPrefix(ctx, "test-image-build-controller").SetLevel(te.Logger.GetLevel()),
+					Log:                   applogger.NewLoggerWithPrefix(ctx, "test-image-build-controller").SetLevel(te.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					DBImageBuildService:   te.Services.ImageBuildService,
 					DBResourceService:     te.Services.StackResourceService,
 					GitIntegrationService: te.Services.GitIntegrationService,
@@ -645,20 +645,20 @@ func (te *testEnvironment) initializeClusterManager(ctx context.Context) error {
 			},
 			func(clusterID string) clustermanager.Controller {
 				return clusterimageregistry.NewClusterImageRegistryReconciler(clusterimageregistry.ClusterImageRegistryReconcilerSpec{
-					Logger:                 applogger.NewLoggerWithPrefix(ctx, "test-cluster-image-registry-controller").SetLevel(te.Logger.GetLevel()),
+					Logger:                 applogger.NewLoggerWithPrefix(ctx, "test-cluster-image-registry-controller").SetLevel(te.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					DBImageRegistryService: te.Services.ClusterImageRegistryService,
 				})
 			},
 			func(clusterID string) clustermanager.Controller {
 				return postgresaddoncontroller.NewPostgresAddonReconciler(postgresaddoncontroller.PostgresAddonReconcilerSpec{
-					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-postgres-addon-controller").SetLevel(te.Logger.GetLevel()),
+					Log:                  applogger.NewLoggerWithPrefix(ctx, "test-postgres-addon-controller").SetLevel(te.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					PostgresAddonService: te.Services.PostgresAddonService,
 					Env:                  te.Name,
 				})
 			},
 			func(clusterID string) clustermanager.Controller {
 				return postgresbackupcontroller.NewPostgresBackupReconciler(postgresbackupcontroller.PostgresBackupReconcilerSpec{
-					Log:                   applogger.NewLoggerWithPrefix(ctx, "test-postgres-backup-controller").SetLevel(te.Logger.GetLevel()),
+					Log:                   applogger.NewLoggerWithPrefix(ctx, "test-postgres-backup-controller").SetLevel(te.Logger.GetLevel()).WithField(applogger.FieldClusterID, clusterID),
 					PostgresBackupService: te.Services.PostgresBackupService,
 				})
 			},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"flag"
-
 	"github.com/Stackdome/stackdome/cmd/migratecmd"
 	"github.com/Stackdome/stackdome/cmd/servecmd"
-	"github.com/golang/glog"
+	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/spf13/cobra"
 )
+
+var log = logger.NewLogger()
 
 func main() {
 	rootCmd := &cobra.Command{
@@ -15,16 +15,11 @@ func main() {
 		Long: "stackdome-server",
 	}
 
-	// Always log to stderr by default
-	if err := flag.Set("logtostderr", "true"); err != nil {
-		glog.Infof("Unable to set logtostderr to true")
-	}
-
 	serveCmd := servecmd.NewServeCommand()
 	migrateCmd := migratecmd.NewMigrateCommand()
 	rootCmd.AddCommand(serveCmd, migrateCmd)
 
 	if err := rootCmd.Execute(); err != nil {
-		glog.Fatalf("error running command: %v", err)
+		log.Fatalf("error running command: %v", err)
 	}
 }

--- a/cmd/migratecmd/migrate.go
+++ b/cmd/migratecmd/migrate.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/Stackdome/stackdome/cmd/environment"
 	"github.com/Stackdome/stackdome/pkg/db"
-	"github.com/golang/glog"
+	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/spf13/cobra"
 )
+
+var log = logger.NewLogger()
 
 func NewMigrateCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -24,7 +26,7 @@ func NewMigrateCommand() *cobra.Command {
 
 func runMigrate(env environment.EnvImpl) {
 	if err := env.InitDatabase(context.Background()); err != nil {
-		glog.Exitf("Unable to initialize environment: %s", err.Error())
+		log.Fatalf("Unable to initialize environment: %s", err.Error())
 	}
 	db.Migrate(env.Environment().DBSession.New(context.Background()))
 }

--- a/cmd/servecmd/server.go
+++ b/cmd/servecmd/server.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/Stackdome/stackdome/cmd/environment"
 	"github.com/Stackdome/stackdome/cmd/server"
-	"github.com/golang/glog"
+	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/spf13/cobra"
 )
+
+var log = logger.NewLogger()
 
 func NewServeCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -24,7 +26,7 @@ func NewServeCommand() *cobra.Command {
 
 func runServe(env environment.EnvImpl) {
 	if err := env.Init(context.Background()); err != nil {
-		glog.Exitf("Unable to initialize environment: %s", err.Error())
+		log.Fatalf("Unable to initialize environment: %s", err.Error())
 	}
 	// Run the servers
 	go func() {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -13,7 +15,7 @@ import (
 	"github.com/Stackdome/stackdome/config/openapi"
 	"github.com/Stackdome/stackdome/pkg/auth"
 	applogger "github.com/Stackdome/stackdome/pkg/logger"
-	"github.com/golang/glog"
+	"github.com/google/uuid"
 	gorillahandlers "github.com/gorilla/handlers"
 )
 
@@ -30,6 +32,10 @@ type apiServer struct {
 }
 
 var _ Server = &apiServer{}
+
+// bootstrapLog handles server lifecycle logging before/around the request
+// logger; it reads LOG_LEVEL/LOG_FORMAT like every other logger.
+var bootstrapLog = applogger.NewLogger()
 
 func (a *apiServer) env() environment.EnvImpl {
 	return a.environment
@@ -84,13 +90,71 @@ func NewAPIServer(env environment.EnvImpl) Server {
 	return s
 }
 
-func injectLoggerMiddleware(next http.Handler, logger applogger.Logger) http.Handler {
+const requestIDHeader = "X-Request-Id"
+
+// statusRecorder wraps ResponseWriter to capture the status code for logging.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	return r.ResponseWriter.Write(b)
+}
+
+// Flush forwards to the wrapped writer so SSE/streaming handlers keep working
+// through the logging middleware.
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack forwards to the wrapped writer for websocket/connection-takeover handlers.
+func (r *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := r.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, fmt.Errorf("underlying ResponseWriter does not support Hijack")
+}
+
+// injectLoggerMiddleware assigns a request ID (honouring an inbound
+// X-Request-Id), binds a per-request logger carrying that ID into the context,
+// and emits a single structured completion line with status and duration.
+func injectLoggerMiddleware(next http.Handler, baseLogger applogger.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := applogger.AddLoggerToContext(r.Context(), logger)
+		requestID := r.Header.Get(requestIDHeader)
+		if requestID == "" {
+			requestID = uuid.NewString()
+		}
+		w.Header().Set(requestIDHeader, requestID)
+
+		reqLogger := baseLogger.WithField(applogger.FieldRequestID, requestID)
+		ctx := applogger.WithRequestID(r.Context(), requestID)
+		ctx = applogger.AddLoggerToContext(ctx, reqLogger)
 		r = r.WithContext(ctx)
-		logger.Infof("Received request: %s %s", r.Method, r.URL.Path)
-		next.ServeHTTP(w, r)
-		logger.Infof("Response sent for: %s %s", r.Method, r.URL.Path)
+
+		rec := &statusRecorder{ResponseWriter: w}
+		start := time.Now()
+		next.ServeHTTP(rec, r)
+		if rec.status == 0 {
+			rec.status = http.StatusOK
+		}
+
+		reqLogger.WithFields(map[string]interface{}{
+			"method":      r.Method,
+			"path":        r.URL.Path,
+			"status":      rec.status,
+			"duration_ms": time.Since(start).Milliseconds(),
+		}).Info(ctx, "request completed")
 	})
 }
 
@@ -136,12 +200,12 @@ func setupAuthenticationMiddleWare(mainHandler http.Handler, env environment.Env
 // Useful for breaking up ListenAndServer (Start) when you require the server to be listening before continuing
 func (s apiServer) Serve(listener net.Listener) {
 	var err error
-	glog.Infof("Serving without TLS at %s", s.env().Environment().Config.Server.BindAddress)
+	bootstrapLog.Infof("Serving without TLS at %s", s.env().Environment().Config.Server.BindAddress)
 	err = s.httpServer.Serve(listener)
 
 	// Web server terminated.
 	check(err, "Web server terminated with errors")
-	glog.Info("Web server terminated")
+	bootstrapLog.Infof("Web server terminated")
 }
 
 // Listen only start the listener, not the server.
@@ -154,13 +218,13 @@ func (s apiServer) Listen() (listener net.Listener, err error) {
 func (s apiServer) Start() {
 	listener, err := s.Listen()
 	if err != nil {
-		glog.Fatalf("Unable to start API server: %s", err)
+		bootstrapLog.Fatalf("Unable to start API server: %s", err)
 	}
 	s.Serve(listener)
 
 	err = s.env().Environment().DBSession.Close()
 	if err != nil {
-		glog.Errorf("Cannot close all sql connections: %v", err)
+		bootstrapLog.Errorf("Cannot close all sql connections: %v", err)
 	}
 }
 
@@ -186,7 +250,7 @@ func WithRequestTimeoutMiddleware(next http.Handler, timeoutDuration time.Durati
 
 func check(err error, msg string) {
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		glog.Errorf("%s: %s", msg, err)
+		bootstrapLog.Errorf("%s: %s", msg, err)
 		os.Exit(1)
 	}
 }

--- a/config/application_config.go
+++ b/config/application_config.go
@@ -18,6 +18,7 @@ type ApplicationConfig struct {
 	JwtSecret     string             `json:"jwt_secret"`
 	EncryptionKey string             `json:"encryption_key"`
 	LogLevel      string             `json:"log_level"`
+	LogFormat     string             `json:"log_format"`
 	GitHubOAuth   *GitHubOAuthConfig `json:"github_oauth"`
 	// ServerExternalURL is the externally reachable base URL of the hub,
 	// required for the GitHub App manifest flow (browser redirects, webhooks).
@@ -36,6 +37,10 @@ func (c *ApplicationConfig) LoadEnvVariables() {
 
 	if val, ok := EnvLogLevel.Lookup(); ok {
 		c.LogLevel = val
+	}
+
+	if val, ok := EnvLogFormat.Lookup(); ok {
+		c.LogFormat = val
 	}
 
 	if val, ok := EnvEncryptionKey.Lookup(); ok {
@@ -206,6 +211,7 @@ func NewApplicationConfig() *ApplicationConfig {
 		Server:      NewServerConfig(),
 		Database:    NewDatabaseConfig(),
 		LogLevel:    "info",
+		LogFormat:   "json",
 		GitHubOAuth: NewGitHubOAuthConfig(),
 	}
 }

--- a/config/env_registry.go
+++ b/config/env_registry.go
@@ -4,6 +4,7 @@ var (
 	// Application
 	EnvJWTSecret     = StringVar("JWT_SECRET", "JWT token signing secret", nil, true)
 	EnvLogLevel      = StringVar("LOG_LEVEL", "Logging level (debug, info, warn, error)", ptr("info"), false)
+	EnvLogFormat     = StringVar("LOG_FORMAT", "Log output format (json or text)", ptr("json"), false)
 	EnvEncryptionKey = StringVar("ENCRYPTION_KEY", "Master encryption key (64-1024 chars)", nil, true)
 	// GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are used for GitHub OAuth login
 	EnvGitHubClientID     = StringVar("GITHUB_CLIENT_ID", "GitHub OAuth app client ID", nil, false)

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/stdr v1.2.2
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/golang/glog v1.2.5
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/go-github/v88 v88.0.0
 	github.com/google/uuid v1.6.0
@@ -112,6 +111,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -6,9 +6,10 @@ import (
 	"net/http"
 
 	"github.com/Stackdome/stackdome/pkg/errors"
-
-	"github.com/golang/glog"
+	"github.com/Stackdome/stackdome/pkg/logger"
 )
+
+var log = logger.NewLogger()
 
 // SendNotFound sends a 404 response with some details about the non existing resource.
 func SendNotFound(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +38,7 @@ func SendNotFound(w http.ResponseWriter, r *http.Request) {
 	_, err = w.Write(data)
 	if err != nil {
 		err = fmt.Errorf("can't send response body for request '%s'", r.URL.Path)
-		glog.Error(err)
+		log.Errorf("%v", err)
 		return
 	}
 }
@@ -58,7 +59,7 @@ func SendUnauthorized(w http.ResponseWriter, r *http.Request, message string) {
 	_, err = w.Write(data)
 	if err != nil {
 		err = fmt.Errorf("can't send response body for request '%s'", r.URL.Path)
-		glog.Error(err)
+		log.Errorf("%v", err)
 		return
 	}
 }
@@ -75,6 +76,6 @@ func SendPanic(w http.ResponseWriter, r *http.Request) {
 			r.URL.Path,
 			err.Error(),
 		)
-		glog.Error(err)
+		log.Errorf("%v", err)
 	}
 }

--- a/pkg/auth/authn_middleware.go
+++ b/pkg/auth/authn_middleware.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/Stackdome/stackdome/pkg/errors"
+	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/models"
 )
 
@@ -85,6 +86,16 @@ func (a *jwtAuthenticator) AuthenticaticationHandler(w http.ResponseWriter, r *h
 		Role:       string(user.Role),
 		AuthMethod: AuthMethodJWT,
 	})
+
+	// Stamp identity onto the context and the per-request logger so every
+	// downstream log line is attributable to a user/org.
+	ctx = logger.WithUserID(ctx, user.ID)
+	ctx = logger.WithOrgID(ctx, user.OrganisationID)
+	reqLogger := logger.GetLoggerFromContext(ctx).WithFields(map[string]interface{}{
+		logger.FieldUserID: user.ID,
+		logger.FieldOrgID:  user.OrganisationID,
+	})
+	ctx = logger.AddLoggerToContext(ctx, reqLogger)
 	*r = *r.WithContext(ctx)
 
 	next.ServeHTTP(w, r)

--- a/pkg/clients/k8s.go
+++ b/pkg/clients/k8s.go
@@ -103,7 +103,7 @@ func (k *kubernetesClient) StreamPodLogs(ctx context.Context, pod *corev1.Pod, l
 	if logOpts.Since() != "" {
 		sinceTime, err := time.ParseDuration(logOpts.Since())
 		if err != nil {
-			k.logger.Warnf("invalid since time format: %v. Ignoring set log since options", err)
+			k.logger.Warn(ctx, "invalid since time format: %v. Ignoring set log since options", err)
 		} else {
 			logOptions.SinceSeconds = ptr.To(int64(sinceTime.Seconds()))
 		}
@@ -134,15 +134,15 @@ func (k *kubernetesClient) StreamPodLogs(ctx context.Context, pod *corev1.Pod, l
 					return
 				}
 				if err == io.EOF {
-					k.logger.Debugf("log stream for pod %s/%s ended", pod.Namespace, pod.Name)
+					k.logger.Debug(ctx, "log stream for pod %s/%s ended", pod.Namespace, pod.Name)
 					return
 				}
 				if numStreamErrors >= logOpts.MaxErrors() {
-					k.logger.Warnf("maximum number of stream errors reached (%d), stopping log stream", logOpts.MaxErrors())
+					k.logger.Warn(ctx, "maximum number of stream errors reached (%d), stopping log stream", logOpts.MaxErrors())
 					safeWriteToChannel(ctx, logChannel, &LogStreamObject{Error: fmt.Errorf("maximum number of stream errors reached")})
 					return
 				}
-				k.logger.Errorf("error reading log line: %v", err)
+				k.logger.Error(ctx, "error reading log line: %v", err)
 				safeWriteToChannel(ctx, logChannel, &LogStreamObject{Error: fmt.Errorf("error reading log line: %w", err)})
 				numStreamErrors++
 				continue
@@ -211,7 +211,7 @@ func (k *kubernetesClient) StreamNamespaceMetrics(ctx context.Context, namespace
 	}
 
 	streamChannel := make(chan *MetricsStreamObject)
-	k.logger.Infof("starting metrics stream for namespace %s with poll interval %s", namespace, metricsStreamOpts.PollInterval().String())
+	k.logger.Info(ctx, "starting metrics stream for namespace %s with poll interval %s", namespace, metricsStreamOpts.PollInterval().String())
 	pollingTicker := time.NewTicker(metricsStreamOpts.PollInterval())
 
 	ticker := make(chan struct{})
@@ -244,11 +244,11 @@ func (k *kubernetesClient) StreamNamespaceMetrics(ctx context.Context, namespace
 				podMetricsList, err := metricsClient.MetricsV1beta1().PodMetricses(namespace).List(ctx, metav1.ListOptions{})
 				if err != nil {
 					if numStreamErrors >= metricsStreamOpts.MaxErrors() {
-						k.logger.Warnf("maximum number of stream errors reached (%d), stopping metrics stream", metricsStreamOpts.MaxErrors())
+						k.logger.Warn(ctx, "maximum number of stream errors reached (%d), stopping metrics stream", metricsStreamOpts.MaxErrors())
 						safeWriteToChannel(ctx, streamChannel, &MetricsStreamObject{Error: fmt.Errorf("maximum number of stream errors reached")})
 						return
 					}
-					k.logger.Errorf("error fetching pod metrics: %v", err)
+					k.logger.Error(ctx, "error fetching pod metrics: %v", err)
 					safeWriteToChannel(ctx, streamChannel, &MetricsStreamObject{Error: fmt.Errorf("error fetching pod metrics: %w", err)})
 					numStreamErrors++
 					continue

--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/models"
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -55,7 +56,7 @@ type Controller interface {
 	Name() string
 }
 
-type ControllerFn func() Controller
+type ControllerFn func(clusterID string) Controller
 
 // ClusterControl represents a control structure for a single cluster
 type ClusterControl struct {
@@ -78,6 +79,7 @@ type ClusterManagerImpl struct {
 	supervisorCancelFn    context.CancelFunc
 	supervisorErr         error
 	isRunning             bool
+	log                   logger.Logger
 }
 
 func (cc *ClusterControl) Serve(ctx context.Context) error {
@@ -137,6 +139,7 @@ type ClusterManagerConfig struct {
 	LeadershipFlag        *leadership.Flag
 	ControllersToRegister []ControllerFn
 	CredentialDecryptor   CredentialDecryptor
+	Logger                logger.Logger
 }
 
 // NewClusterManager creates a new ClusterManager instance
@@ -147,6 +150,7 @@ func NewClusterManager(config ClusterManagerConfig) ClusterManager {
 		credentialDecryptor:   config.CredentialDecryptor,
 		registeredClusters:    make(map[string]*ClusterControl),
 		supervisor:            suture.NewSimple("cluster-manager"),
+		log:                   config.Logger,
 	}
 }
 
@@ -180,7 +184,7 @@ func (cm *ClusterManagerImpl) RegisterCluster(cluster *models.Cluster) error {
 
 	controllers := make([]Controller, len(cm.controllersToRegister))
 	for i, fn := range cm.controllersToRegister {
-		controllers[i] = fn()
+		controllers[i] = fn(cluster.ID)
 	}
 
 	clusterCtrl := &ClusterControl{
@@ -194,6 +198,11 @@ func (cm *ClusterManagerImpl) RegisterCluster(cluster *models.Cluster) error {
 	serviceID := cm.supervisor.Add(clusterCtrl)
 	clusterCtrl.serviceID = serviceID
 	cm.registeredClusters[cluster.ID] = clusterCtrl
+	cm.log.WithFields(map[string]interface{}{
+		logger.FieldClusterID: cluster.ID,
+		"cluster_name":        cluster.Name,
+		"controllers":         len(controllers),
+	}).Infof("registered cluster")
 	return nil
 }
 
@@ -264,6 +273,7 @@ func (cm *ClusterManagerImpl) UnregisterCluster(clusterID string) error {
 		return fmt.Errorf("failed to remove cluster %s from supervisor: %w", clusterID, err)
 	}
 	delete(cm.registeredClusters, clusterID)
+	cm.log.WithField(logger.FieldClusterID, clusterID).Infof("unregistered cluster")
 	return nil
 }
 
@@ -273,10 +283,12 @@ func (cm *ClusterManagerImpl) Start(ctx context.Context) {
 }
 
 func (cm *ClusterManagerImpl) run(ctx context.Context) {
+	cm.log.Info(ctx, "waiting for leadership before starting cluster supervisor")
 	if err := wait.PollUntilContextCancel(ctx, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		return cm.leadershipFlag.Raised(), nil
 	}); err != nil {
 		cm.supervisorErr = fmt.Errorf("leadership poll failed: %w", err)
+		cm.log.Error(ctx, "leadership poll failed, cluster supervisor not started: %v", err)
 		return
 	}
 
@@ -289,13 +301,16 @@ func (cm *ClusterManagerImpl) run(ctx context.Context) {
 		<-ctx.Done()
 		cancelFn()
 	}()
+	cm.log.Info(ctx, "leadership acquired, cluster supervisor serving")
 	if err := cm.supervisor.Serve(childCtx); err != nil {
 		cm.supervisorErr = err
+		cm.log.Error(ctx, "cluster supervisor terminated with error: %v", err)
 	}
 }
 
 // Stop halts the cluster manager operations
 func (cm *ClusterManagerImpl) Stop(ctx context.Context) error {
+	cm.log.Info(ctx, "stopping cluster manager")
 	if cm.supervisorCancelFn != nil {
 		cm.supervisorCancelFn()
 	}

--- a/pkg/controllers/clusterimageregistry/image_registry_controller.go
+++ b/pkg/controllers/clusterimageregistry/image_registry_controller.go
@@ -65,12 +65,12 @@ func (r *clusterImageRegistryReconciler) Name() string {
 }
 
 func (r *clusterImageRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger.Infof("reconciling cluster image registry: %v", req.NamespacedName)
+	r.Logger.Info(ctx, "reconciling cluster image registry: %v", req.NamespacedName)
 
 	registryCr := &registryv1alpha1.ClusterRegistry{}
 	if err := r.Client.Get(ctx, req.NamespacedName, registryCr); err != nil {
 		if errors.IsNotFound(err) {
-			r.Logger.Infof("cluster registry %v not found", req.NamespacedName)
+			r.Logger.Info(ctx, "cluster registry %v not found", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -78,7 +78,7 @@ func (r *clusterImageRegistryReconciler) Reconcile(ctx context.Context, req ctrl
 
 	registryID, ok := registryCr.Labels[models.ImageRegistryIDLabel]
 	if !ok {
-		r.Logger.Errorf("clusterRegistry %v does not have cluster registry ID label", req.NamespacedName)
+		r.Logger.Error(ctx, "clusterRegistry %v does not have cluster registry ID label", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
@@ -95,6 +95,7 @@ func (r *clusterImageRegistryReconciler) Reconcile(ctx context.Context, req ctrl
 		if serr := r.DBImageRegistryService.UpdateStatus(ctx, dbImageRegistry.ID, dbImageRegistry.Status); serr != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update cluster image registry status: %w", serr)
 		}
+		r.Logger.WithField("registry_id", dbImageRegistry.ID).Debug(ctx, "synced cluster image registry status from cluster")
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controllers/imagebuild/git_token_refresher.go
+++ b/pkg/controllers/imagebuild/git_token_refresher.go
@@ -59,7 +59,7 @@ func (r *ImageBuildReconciler) reconcileGitTokenRefresh(ctx context.Context, ima
 	}
 	expiresAt, err := time.Parse(time.RFC3339, expiresRaw)
 	if err != nil {
-		r.Logger.Errorf("build %s/%s: malformed token expiry annotation %q: %v", imageBuild.Namespace, imageBuild.Name, expiresRaw, err)
+		r.Logger.Error(ctx, "build %s/%s: malformed token expiry annotation %q: %v", imageBuild.Namespace, imageBuild.Name, expiresRaw, err)
 		return ctrl.Result{}, nil
 	}
 
@@ -70,7 +70,7 @@ func (r *ImageBuildReconciler) reconcileGitTokenRefresh(ctx context.Context, ima
 
 	integrationID := secret.Annotations[models.GitIntegrationIDAnnotation]
 	if integrationID == "" {
-		r.Logger.Errorf("build %s/%s: token-backed git secret '%s' has no integration annotation", imageBuild.Namespace, imageBuild.Name, secretName)
+		r.Logger.Error(ctx, "build %s/%s: token-backed git secret '%s' has no integration annotation", imageBuild.Namespace, imageBuild.Name, secretName)
 		return ctrl.Result{}, nil
 	}
 
@@ -78,7 +78,7 @@ func (r *ImageBuildReconciler) reconcileGitTokenRefresh(ctx context.Context, ima
 	if serr != nil {
 		// The app may have been uninstalled mid-build. Record the failure on
 		// the build and stop refreshing; never crash the reconcile loop.
-		r.Logger.Errorf("build %s/%s: failed to refresh GitHub App token: %v", imageBuild.Namespace, imageBuild.Name, serr)
+		r.Logger.Error(ctx, "build %s/%s: failed to refresh GitHub App token: %v", imageBuild.Namespace, imageBuild.Name, serr)
 		r.recordTokenRefreshFailure(ctx, dbBuild, serr.Error())
 		return ctrl.Result{}, nil
 	}
@@ -97,7 +97,7 @@ func (r *ImageBuildReconciler) reconcileGitTokenRefresh(ctx context.Context, ima
 		return ctrl.Result{}, err
 	}
 
-	r.Logger.Infof("build %s/%s: refreshed GitHub App token for secret '%s'", imageBuild.Namespace, imageBuild.Name, secretName)
+	r.Logger.Info(ctx, "build %s/%s: refreshed GitHub App token for secret '%s'", imageBuild.Namespace, imageBuild.Name, secretName)
 	return ctrl.Result{RequeueAfter: floorRequeue(time.Until(mint.ExpiresAt) - tokenRefreshWindow)}, nil
 }
 
@@ -117,7 +117,7 @@ func (r *ImageBuildReconciler) recordTokenRefreshFailure(ctx context.Context, db
 		Message:            message,
 	})
 	if serr := r.DBImageBuildService.InternalUpdateStatus(ctx, dbBuild.ID, status); serr != nil {
-		r.Logger.Errorf("failed to record token refresh failure for build '%s': %v", dbBuild.ID, serr)
+		r.Logger.Error(ctx, "failed to record token refresh failure for build '%s': %v", dbBuild.ID, serr)
 	}
 }
 

--- a/pkg/controllers/imagebuild/image_build_controller.go
+++ b/pkg/controllers/imagebuild/image_build_controller.go
@@ -108,17 +108,17 @@ func (r *ImageBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	imageBuild := &buildsv1alpha1.ImageBuild{}
 	if err := r.Client.Get(ctx, req.NamespacedName, imageBuild); err != nil {
 		if errors.IsNotFound(err) {
-			r.Logger.Infof("imageBuild %v not found", req.NamespacedName)
+			r.Logger.Info(ctx, "imageBuild %v not found", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
 
-	r.Logger.Infof("reconciling image build: %v", req.NamespacedName)
+	r.Logger.Info(ctx, "reconciling image build: %v", req.NamespacedName)
 
 	stackID, ok := imageBuild.Labels[corev1alpha1.LabelStackID]
 	if !ok {
-		r.Logger.Errorf("imageBuild %v does not have stack ID label", req.NamespacedName)
+		r.Logger.Error(ctx, "imageBuild %v does not have stack ID label", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
@@ -126,7 +126,7 @@ func (r *ImageBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err != nil {
 		if err.Code == apperrors.ErrorNotFound {
 			// stack might have gotten deleted. We log and ignore this event.
-			r.Logger.Infof(
+			r.Logger.Info(ctx,
 				"stack resource with name '%s' for stack '%s' not found, it might have been deleted. Ignoring image build '%s'",
 				imageBuild.Spec.ResourceName,
 				stackID,
@@ -134,14 +134,14 @@ func (r *ImageBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			)
 			return ctrl.Result{}, nil
 		}
-		r.Logger.Errorf("failed to get stack resource %s for build '%s'", imageBuild.Spec.ResourceName, client.ObjectKeyFromObject(imageBuild).String())
+		r.Logger.Error(ctx, "failed to get stack resource %s for build '%s'", imageBuild.Spec.ResourceName, client.ObjectKeyFromObject(imageBuild).String())
 		return ctrl.Result{}, err
 	}
 
 	dbResourceBuild, serr := r.DBImageBuildService.InternalGetByID(ctx, imageBuild.Name)
 	if serr != nil {
 		if serr.Code == apperrors.ErrorNotFound {
-			r.Logger.Infof("imageBuild %s not found in DB, creating a new build", imageBuild.Name)
+			r.Logger.Info(ctx, "imageBuild %s not found in DB, creating a new build", imageBuild.Name)
 			return ctrl.Result{Requeue: true}, r.createImageBuildInDB(ctx, imageBuild, dbStackResouce)
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get image build from db: %w", serr)
@@ -199,7 +199,7 @@ func (r *ImageBuildReconciler) createImageBuildInDB(
 
 	_, serr := r.DBImageBuildService.InternalCreate(ctx, dbImageBuild)
 	if serr != nil {
-		r.Logger.Errorf("Failed to create image build '%s': %s", imageBuildCr.Name, serr)
+		r.Logger.Error(ctx, "Failed to create image build '%s': %s", imageBuildCr.Name, serr)
 		return serr.AsError()
 	}
 	return nil
@@ -312,11 +312,11 @@ func (r *ImageBuildReconciler) recordBuildEvent(
 
 	active, serr := r.releaseChecker.InternalGetActiveByStackID(ctx, stackID)
 	if serr != nil {
-		r.Logger.Debugf("no active release lookup for stack %s: %v", stackID, serr)
+		r.Logger.Debug(ctx, "no active release lookup for stack %s: %v", stackID, serr)
 		return
 	}
 	if active == nil {
-		r.Logger.Debugf("no active release for stack %s; skipping build event", stackID)
+		r.Logger.Debug(ctx, "no active release for stack %s; skipping build event", stackID)
 		return
 	}
 
@@ -330,7 +330,7 @@ func (r *ImageBuildReconciler) recordBuildEvent(
 	if recErr := r.eventRecorder.RecordBuildEvent(
 		ctx, active, cr.Spec.ResourceName, eventType, build.ID, attribution, failure,
 	); recErr != nil {
-		r.Logger.Errorf("failed to record build event for build %s: %v", build.ID, recErr)
+		r.Logger.Error(ctx, "failed to record build event for build %s: %v", build.ID, recErr)
 	}
 }
 

--- a/pkg/controllers/postgres_addon/postgres_addon_controller.go
+++ b/pkg/controllers/postgres_addon/postgres_addon_controller.go
@@ -71,24 +71,24 @@ func (r *postgresAddonReconciler) Name() string {
 }
 
 func (r *postgresAddonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log.Infof("reconciling postgres addon: %s in namespace %s", req.Name, req.Namespace)
+	r.Log.Info(ctx, "reconciling postgres addon: %s in namespace %s", req.Name, req.Namespace)
 
 	clusterInstance := &addonsv1alpha1.PostgresCluster{}
 	if err := r.Client.Get(ctx, req.NamespacedName, clusterInstance); err != nil {
-		r.Log.Errorf("failed to get postgres cluster from cluster: %v", err)
+		r.Log.Error(ctx, "failed to get postgres cluster from cluster: %v", err)
 		return ctrl.Result{}, nil
 	}
 
 	postgresAddonID, ok := clusterInstance.Labels[models.PostgresAddonIDLabel]
 	if !ok {
-		r.Log.Errorf("postgres addon ID not found in PostgresCluster labels")
+		r.Log.Error(ctx, "postgres addon ID not found in PostgresCluster labels")
 		return ctrl.Result{}, nil
 	}
 
 	dbInstance, serr := r.PostgresAddonService.InternalGetPostgresAddon(ctx, postgresAddonID)
 	if serr != nil {
 		if serr.Code == apperrors.ErrorNotFound {
-			r.Log.Infof("postgres addon %s in namespace %s not found in DB", clusterInstance.Name, clusterInstance.Namespace)
+			r.Log.Info(ctx, "postgres addon %s in namespace %s not found in DB", clusterInstance.Name, clusterInstance.Namespace)
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get postgres addon from db: %w", serr)
@@ -117,7 +117,7 @@ func (r *postgresAddonReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		if equality.Semantic.DeepEqual(dbInstance.Status, &newStatus) {
-			r.Log.Infof("postgres addon %s status is up to date, skipping DB update", postgresAddonID)
+			r.Log.Info(ctx, "postgres addon %s status is up to date, skipping DB update", postgresAddonID)
 			return ctrl.Result{}, nil
 		}
 
@@ -125,7 +125,7 @@ func (r *postgresAddonReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if serr != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update postgres addon status in db: %w", serr)
 		}
-		r.Log.Infof("updated postgres addon %s status: phase=%s", postgresAddonID, newStatus.State)
+		r.Log.Info(ctx, "updated postgres addon %s status: phase=%s", postgresAddonID, newStatus.State)
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/controllers/postgres_backup/postgres_backup_controller.go
+++ b/pkg/controllers/postgres_backup/postgres_backup_controller.go
@@ -62,17 +62,17 @@ func (r *postgresBackupReconciler) Name() string {
 }
 
 func (r *postgresBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log.Infof("reconciling backup: %s in namespace %s", req.Name, req.Namespace)
+	r.Log.Info(ctx, "reconciling backup: %s in namespace %s", req.Name, req.Namespace)
 
 	backup := &cnpgv1.Backup{}
 	if err := r.Client.Get(ctx, req.NamespacedName, backup); err != nil {
-		r.Log.Errorf("failed to get CNPG Backup: %v", err)
+		r.Log.Error(ctx, "failed to get CNPG Backup: %v", err)
 		return ctrl.Result{}, nil
 	}
 
 	addonID, err := r.resolveAddonID(ctx, backup)
 	if err != nil {
-		r.Log.Errorf("failed to resolve addon ID for backup %s: %v", backup.Name, err)
+		r.Log.Error(ctx, "failed to resolve addon ID for backup %s: %v", backup.Name, err)
 		return ctrl.Result{}, nil
 	}
 	if addonID == "" {
@@ -133,7 +133,7 @@ func (r *postgresBackupReconciler) createBackupRecord(ctx context.Context, addon
 		return ctrl.Result{}, fmt.Errorf("failed to create backup record: %w", serr)
 	}
 
-	r.Log.Infof("created backup record for %s (addon %s)", backup.Name, addonID)
+	r.Log.Info(ctx, "created backup record for %s (addon %s)", backup.Name, addonID)
 	return ctrl.Result{}, nil
 }
 
@@ -159,7 +159,7 @@ func (r *postgresBackupReconciler) updateBackupRecord(ctx context.Context, exist
 		return ctrl.Result{}, fmt.Errorf("failed to update backup record: %w", serr)
 	}
 
-	r.Log.Infof("updated backup %s phase to %s", backup.Name, newPhase)
+	r.Log.Info(ctx, "updated backup %s phase to %s", backup.Name, newPhase)
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controllers/stack/stack_controller.go
+++ b/pkg/controllers/stack/stack_controller.go
@@ -86,11 +86,11 @@ func (w *stackReconciler) Name() string {
 
 // Reconcile reconciles the workspace storage resource
 func (w *stackReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
-	w.Log.Infof("Reconciling stack %v", req.NamespacedName)
+	w.Log.Info(ctx, "Reconciling stack %v", req.NamespacedName)
 	stackCr := &corev1alpha1.Stack{}
 	if err := w.Client.Get(ctx, req.NamespacedName, stackCr); err != nil {
 		if errors.IsNotFound(err) {
-			w.Log.Infof("Stack %s not found", req.NamespacedName)
+			w.Log.Info(ctx, "Stack %s not found", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -99,13 +99,13 @@ func (w *stackReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 	stackID, ok := stackCr.Labels[corev1alpha1.LabelStackID]
 	if !ok {
 		// How are we here? The predicate should have prevented this.
-		w.Log.Errorf("Stack %s does not have a workspace id label", stackCr.Name)
+		w.Log.Error(ctx, "Stack %s does not have a workspace id label", stackCr.Name)
 		return ctrl.Result{}, nil
 	}
 	dbStack, serr := w.StackService.InternalGetStack(ctx, stackID)
 	if serr != nil {
 		if serr.Code == apperrors.ErrorNotFound {
-			w.Log.Infof("Stack %s not found in DB", stackCr.Name)
+			w.Log.Info(ctx, "Stack %s not found in DB", stackCr.Name)
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get stack from db: %w", serr)
@@ -122,9 +122,13 @@ func (w *stackReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 		dbStack.Status.LastValidationRun = lastValidationRun
 		serr = w.StackService.UpdateStatus(ctx, stackID, dbStack.Status)
 		if serr != nil {
-			w.Log.Errorf("Failed to update stack '%s' status : %s", dbStack.ID, serr)
+			w.Log.Error(ctx, "Failed to update stack '%s' status : %s", dbStack.ID, serr)
 			return ctrl.Result{}, fmt.Errorf("failed to update stack status: %w", serr)
 		}
+		w.Log.WithFields(map[string]interface{}{
+			logger.FieldStackID: stackID,
+			"state":             string(currentStackCrState),
+		}).Debug(ctx, "synced stack status from cluster")
 
 		// Kick the release worker so it can observe the new status quickly.
 		w.enqueueActiveRelease(ctx, stackID)
@@ -140,14 +144,14 @@ func (w *stackReconciler) enqueueActiveRelease(ctx context.Context, stackID stri
 	}
 	active, serr := w.releaseChecker.InternalGetActiveByStackID(ctx, stackID)
 	if serr != nil {
-		w.Log.Errorf("Failed to check active release for stack '%s': %s", stackID, serr)
+		w.Log.Error(ctx, "Failed to check active release for stack '%s': %s", stackID, serr)
 		return
 	}
 	if active == nil {
 		return
 	}
 	if err := w.enqueuer.Enqueue(&models.StackRelease{ID: active.ID}); err != nil {
-		w.Log.Errorf("Failed to enqueue release '%s': %v", active.ID, err)
+		w.Log.Error(ctx, "Failed to enqueue release '%s': %v", active.ID, err)
 	}
 }
 

--- a/pkg/controllers/stackresource/stack_resource_controller.go
+++ b/pkg/controllers/stackresource/stack_resource_controller.go
@@ -98,12 +98,12 @@ func (w *stackResourceReconciler) Name() string {
 }
 
 func (w *stackResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	w.logger.Infof("Reconciling stack resource: %v", req.NamespacedName)
+	w.logger.Info(ctx, "Reconciling stack resource: %v", req.NamespacedName)
 
 	stackResourceCr := &corev1alpha1.StackResource{}
 	if err := w.client.Get(ctx, req.NamespacedName, stackResourceCr); err != nil {
 		if errors.IsNotFound(err) {
-			w.logger.Infof("StackResource %v not found", req.NamespacedName)
+			w.logger.Info(ctx, "StackResource %v not found", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -112,14 +112,14 @@ func (w *stackResourceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	stackID, ok := stackResourceCr.Labels[corev1alpha1.LabelStackID]
 	if !ok {
 		// How are we here? The predicate should have prevented this.
-		w.logger.Errorf("StackResource %s does not have a stack id label", stackResourceCr.Name)
+		w.logger.Error(ctx, "StackResource %s does not have a stack id label", stackResourceCr.Name)
 		return ctrl.Result{}, nil
 	}
 
 	dbStackResource, serr := w.stackResourceService.InternalGetByStackIDAndResourceName(ctx, stackID, stackResourceCr.Name)
 	if serr != nil {
 		if serr.Code == apperrors.ErrorNotFound {
-			w.logger.Infof("StackResource %s not found in DB", stackResourceCr.Name)
+			w.logger.Info(ctx, "StackResource %s not found in DB", stackResourceCr.Name)
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get stack resource from db: %w", serr)
@@ -130,6 +130,10 @@ func (w *stackResourceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if serr := w.stackResourceService.UpdateStatus(ctx, dbStackResource.ID, dbStackResource.Status); serr != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update stack resource status: %w", serr)
 		}
+		w.logger.WithFields(map[string]interface{}{
+			logger.FieldStackID:  stackID,
+			logger.FieldResource: stackResourceCr.Name,
+		}).Debug(ctx, "synced stack resource status from cluster")
 		w.recordResourceEvent(ctx, stackID, dbStackResource, stackResourceCr)
 		return ctrl.Result{}, nil
 	}
@@ -151,11 +155,11 @@ func (w *stackResourceReconciler) recordResourceEvent(ctx context.Context, stack
 	}
 	active, serr := w.releaseChecker.InternalGetActiveByStackID(ctx, stackID)
 	if serr != nil || active == nil {
-		w.logger.Debugf("no active release for stack %s; skipping resource event for %s", stackID, resource.Name)
+		w.logger.Debug(ctx, "no active release for stack %s; skipping resource event for %s", stackID, resource.Name)
 		return
 	}
 	if recErr := w.eventRecorder.RecordResourceEvent(ctx, active, resource.Name, eventType, reason, message); recErr != nil {
-		w.logger.Errorf("failed to record resource event for %s: %v", resource.Name, recErr)
+		w.logger.Error(ctx, "failed to record resource event for %s: %v", resource.Name, recErr)
 	}
 }
 

--- a/pkg/controllers/volume/volume_controller.go
+++ b/pkg/controllers/volume/volume_controller.go
@@ -72,23 +72,23 @@ func (w *volumeReconciler) Name() string {
 }
 
 func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log.Infof("reconciling volume: %s in namespace %s", req.Name, req.Namespace)
+	r.Log.Info(ctx, "reconciling volume: %s in namespace %s", req.Name, req.Namespace)
 	clusterInstance := &storagev1alpha1.Volume{}
 	if err := r.Client.Get(ctx, req.NamespacedName, clusterInstance); err != nil {
-		r.Log.Errorf("failed to get volume from cluster: %v", err)
+		r.Log.Error(ctx, "failed to get volume from cluster: %v", err)
 		return ctrl.Result{}, nil
 	}
 
 	volumeID, ok := clusterInstance.Labels[models.VolumeIDLabel]
 	if !ok {
-		r.Log.Errorf("storage ID not found in volumeCR labels")
+		r.Log.Error(ctx, "storage ID not found in volumeCR labels")
 		return ctrl.Result{}, nil
 	}
 
 	dbInstance, serr := r.VolumeService.InternalGet(ctx, volumeID)
 	if serr != nil {
 		if serr.Code == apperrors.ErrorNotFound {
-			r.Log.Infof("volume %s in namespace %s not found in DB", clusterInstance.Name, clusterInstance.Namespace)
+			r.Log.Info(ctx, "volume %s in namespace %s not found in DB", clusterInstance.Name, clusterInstance.Namespace)
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get volume from db: %w", serr)
@@ -101,6 +101,7 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if serr != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update  volume status in db: %w", serr)
 		}
+		r.Log.WithField("volume_id", dbInstance.ID).Debug(ctx, "synced volume status from cluster")
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controllers/workspaceuser/workspace_user_controller.go
+++ b/pkg/controllers/workspaceuser/workspace_user_controller.go
@@ -71,16 +71,16 @@ func (w *WorkspaceUserReconciler) Name() string {
 }
 
 func (r *WorkspaceUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log.Infof("reconciling workspace user: %s in namespace %s", req.Name, req.Namespace)
+	r.Log.Info(ctx, "reconciling workspace user: %s in namespace %s", req.Name, req.Namespace)
 	clusterInstance := &usersv1alpha1.User{}
 	if err := r.Client.Get(ctx, req.NamespacedName, clusterInstance); err != nil {
-		r.Log.Errorf("failed to get workspace user from cluster: %v", err)
+		r.Log.Error(ctx, "failed to get workspace user from cluster: %v", err)
 		return ctrl.Result{}, nil
 	}
 
 	workspaceUserID, ok := clusterInstance.Labels[models.WorkspaceUserIDLabel]
 	if !ok {
-		r.Log.Errorf("workspace user ID not found in workspaceuser labels")
+		r.Log.Error(ctx, "workspace user ID not found in workspaceuser labels")
 		return ctrl.Result{}, nil
 	}
 
@@ -105,6 +105,7 @@ func (r *WorkspaceUserReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if serr != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update workspace user status in db: %w", serr)
 		}
+		r.Log.WithField("workspace_user_id", workspaceuser.ID).Debug(ctx, "synced workspace user status from cluster")
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/db/migrate.go
+++ b/pkg/db/migrate.go
@@ -2,16 +2,18 @@ package db
 
 import (
 	"github.com/Stackdome/stackdome/pkg/db/migrations"
+	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/go-gormigrate/gormigrate/v2"
-	"github.com/golang/glog"
 	"gorm.io/gorm"
 )
+
+var log = logger.NewLogger()
 
 func Migrate(g2 *gorm.DB) {
 	options := gormigrate.DefaultOptions
 	options.UseTransaction = true
 	m := gormigrate.New(g2, options, migrations.MigrationList)
 	if err := m.Migrate(); err != nil {
-		glog.Fatalf("Could not migrate: %v", err)
+		log.Fatalf("Could not migrate: %v", err)
 	}
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -7,8 +7,10 @@ import (
 	"strconv"
 
 	"github.com/Stackdome/stackdome/pkg/api/openapi"
-	"github.com/golang/glog"
+	"github.com/Stackdome/stackdome/pkg/logger"
 )
+
+var log = logger.NewLogger()
 
 const (
 
@@ -159,7 +161,7 @@ func New(code ServiceErrorCode, reason string, values ...interface{}) *ServiceEr
 	var err *ServiceError
 	exists, err := Find(code)
 	if !exists {
-		glog.Errorf("Undefined error code used: %d", code)
+		log.Errorf("Undefined error code used: %d", code)
 		err = &ServiceError{ErrorGeneral, "Unspecified error", 500, nil}
 	}
 

--- a/pkg/handlers/handler_helper.go
+++ b/pkg/handlers/handler_helper.go
@@ -33,9 +33,9 @@ func handleError(ctx context.Context, w http.ResponseWriter, err *errors.Service
 	logger := logger.GetLoggerFromContext(ctx)
 	// If this is a 400 error, its the user's issue, log as info rather than error
 	if err.HttpCode >= 400 && err.HttpCode <= 499 {
-		logger.Infof(err.Error())
+		logger.Info(ctx, "%s", err.Error())
 	} else {
-		logger.Errorf(err.Error())
+		logger.Error(ctx, "%s", err.Error())
 	}
 	writeJSONResponse(w, err.HttpCode, err.AsOpenapiError())
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"context"
+	"os"
 
 	"github.com/sirupsen/logrus"
 )
@@ -10,6 +11,40 @@ type loggerInCtx string
 
 const (
 	loggerKey loggerInCtx = "logger"
+)
+
+// logFormatEnv selects the output encoder at logger construction time. "text"
+// yields the human-friendly formatter for local dev; anything else (default)
+// yields structured JSON for production log aggregation.
+const logFormatEnv = "LOG_FORMAT"
+
+// logLevelEnv sets the default level for every constructed logger so that
+// prefixed loggers (workers, reconcilers) inherit the configured level instead
+// of silently defaulting to Info. Callers may still override via SetLevel.
+const logLevelEnv = "LOG_LEVEL"
+
+// Structured field keys. Correlation values travel on the context and are
+// attached to every context-aware log call via withFields.
+type contextKey string
+
+const (
+	requestIDKey contextKey = "request_id"
+	userIDKey    contextKey = "user_id"
+	orgIDKey     contextKey = "org_id"
+	clusterIDKey contextKey = "cluster_id"
+)
+
+// Field name constants for structured logging. Callers attach these via
+// WithField/WithFields instead of interpolating IDs into message strings.
+const (
+	FieldRequestID = "request_id"
+	FieldUserID    = "user_id"
+	FieldOrgID     = "org_id"
+	FieldClusterID = "cluster_id"
+	FieldStackID   = "stack_id"
+	FieldReleaseID = "release_id"
+	FieldResource  = "resource"
+	FieldComponent = "component"
 )
 
 func AddLoggerToContext(ctx context.Context, logger Logger) context.Context {
@@ -23,11 +58,42 @@ func GetLoggerFromContext(ctx context.Context) Logger {
 	return NewLogger()
 }
 
+// WithRequestID stamps a request/correlation ID onto the context so every
+// context-aware log call made downstream carries it as a structured field.
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, requestIDKey, id)
+}
+
+func WithUserID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, userIDKey, id)
+}
+
+func WithOrgID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, orgIDKey, id)
+}
+
+func WithClusterID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, clusterIDKey, id)
+}
+
+func RequestIDFromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(requestIDKey).(string)
+	return id, ok
+}
+
 //go:generate mockgen -source=logger.go -destination=../mocks/mock_logger.go -package=mocks
 type Logger interface {
 	SetLevel(level logrus.Level) Logger
 
 	GetLevel() logrus.Level
+
+	// WithField returns a child logger that attaches the given key/value to
+	// every subsequent log entry. The parent is left unchanged.
+	WithField(key string, value interface{}) Logger
+
+	// WithFields returns a child logger that attaches all the given fields to
+	// every subsequent log entry. The parent is left unchanged.
+	WithFields(fields map[string]interface{}) Logger
 
 	DebugEnabled() bool
 
@@ -54,8 +120,8 @@ type Logger interface {
 	// given format and arguments.
 	Warn(ctx context.Context, format string, args ...interface{})
 
-	// Error sends to the log an error message formatted using the fmt.Sprintf function and the
-	// given format and arguments.
+	// Error sends to the log an error message formatted using the fmt.Sprintf function and
+	// the given format and arguments.
 	Error(ctx context.Context, format string, args ...interface{})
 
 	Errorf(format string, args ...interface{})
@@ -63,8 +129,8 @@ type Logger interface {
 	Fatalf(format string, args ...interface{})
 	Warnf(format string, args ...interface{})
 
-	// Fatal sends to the log an error message formatted using the fmt.Sprintf function and the
-	// given format and arguments; and then executes an os.Exit(1)
+	// Fatal sends to the log an error message formatted using the fmt.Sprintf function and
+	// the given format and arguments; and then executes an os.Exit(1)
 	// Fatal level is always enabled
 	Fatal(ctx context.Context, format string, args ...interface{})
 }
@@ -74,23 +140,44 @@ var _ Logger = &appLogger{}
 type appLogger struct {
 	debug  bool
 	prefix string
+	fields logrus.Fields
 	logger *logrus.Logger
 }
 
-const (
-	logTimestampFormat = "2006-01-02 15:04:05"
-	componentField     = "component"
-)
+// newFormatter picks the encoder based on the LOG_FORMAT env var. JSON is the
+// default so production defaults to structured logs without extra config.
+func newFormatter() logrus.Formatter {
+	if os.Getenv(logFormatEnv) == "text" {
+		return &logrus.TextFormatter{
+			FullTimestamp:   true,
+			TimestampFormat: "2006-01-02 15:04:05",
+			DisableQuote:    true,
+		}
+	}
+	return &logrus.JSONFormatter{
+		TimestampFormat: "2006-01-02T15:04:05.000Z07:00",
+		FieldMap: logrus.FieldMap{
+			logrus.FieldKeyTime:  "ts",
+			logrus.FieldKeyLevel: "level",
+			logrus.FieldKeyMsg:   "msg",
+		},
+	}
+}
+
+// newLevel resolves the default log level from LOG_LEVEL, falling back to Info
+// when unset or unparseable.
+func newLevel() logrus.Level {
+	if lvl, err := logrus.ParseLevel(os.Getenv(logLevelEnv)); err == nil {
+		return lvl
+	}
+	return logrus.InfoLevel
+}
 
 // NewLogger creates a new logger instance with standard configuration
 func NewLogger() Logger {
 	l := logrus.New()
-	// Set default formatter with timestamps and full log level names
-	l.SetFormatter(&logrus.TextFormatter{
-		FullTimestamp:   true,
-		TimestampFormat: logTimestampFormat,
-		DisableQuote:    true,
-	})
+	l.SetFormatter(newFormatter())
+	l.SetLevel(newLevel())
 	return &appLogger{
 		prefix: "",
 		logger: l,
@@ -99,11 +186,8 @@ func NewLogger() Logger {
 
 func NewLoggerWithPrefix(ctx context.Context, prefix string) Logger {
 	l := logrus.New()
-	l.SetFormatter(&logrus.TextFormatter{
-		FullTimestamp:   true,
-		TimestampFormat: logTimestampFormat,
-		DisableQuote:    true,
-	})
+	l.SetFormatter(newFormatter())
+	l.SetLevel(newLevel())
 	return &appLogger{
 		prefix: prefix,
 		logger: l,
@@ -113,11 +197,7 @@ func NewLoggerWithPrefix(ctx context.Context, prefix string) Logger {
 func NewLoggerWithDebug(ctx context.Context) Logger {
 	l := logrus.New()
 	l.SetLevel(logrus.DebugLevel)
-	l.SetFormatter(&logrus.TextFormatter{
-		FullTimestamp:   true,
-		TimestampFormat: logTimestampFormat,
-		DisableQuote:    true,
-	})
+	l.SetFormatter(newFormatter())
 	return &appLogger{
 		debug:  true,
 		prefix: "",
@@ -125,17 +205,58 @@ func NewLoggerWithDebug(ctx context.Context) Logger {
 	}
 }
 
-// withFields adds consistent fields to all log entries
-func (l *appLogger) withFields(ctx context.Context) *logrus.Entry {
+// baseFields returns the fields attached to every entry regardless of context:
+// the component prefix plus any fields bound via WithField/WithFields.
+func (l *appLogger) baseFields() logrus.Fields {
 	fields := logrus.Fields{}
 	if l.prefix != "" {
-		fields[componentField] = l.prefix
+		fields[FieldComponent] = l.prefix
 	}
-	// You can add more context-based fields here, like:
-	// - Request ID from context
-	// - Correlation ID
-	// - User info
+	for k, v := range l.fields {
+		fields[k] = v
+	}
+	return fields
+}
+
+// withFields merges the base fields with correlation values carried on the
+// context (request/user/org/cluster IDs) for a single log entry.
+func (l *appLogger) withFields(ctx context.Context) *logrus.Entry {
+	fields := l.baseFields()
+	if ctx != nil {
+		if v, ok := ctx.Value(requestIDKey).(string); ok && v != "" {
+			fields[FieldRequestID] = v
+		}
+		if v, ok := ctx.Value(userIDKey).(string); ok && v != "" {
+			fields[FieldUserID] = v
+		}
+		if v, ok := ctx.Value(orgIDKey).(string); ok && v != "" {
+			fields[FieldOrgID] = v
+		}
+		if v, ok := ctx.Value(clusterIDKey).(string); ok && v != "" {
+			fields[FieldClusterID] = v
+		}
+	}
 	return l.logger.WithFields(fields)
+}
+
+func (l *appLogger) WithField(key string, value interface{}) Logger {
+	return l.WithFields(map[string]interface{}{key: value})
+}
+
+func (l *appLogger) WithFields(fields map[string]interface{}) Logger {
+	merged := logrus.Fields{}
+	for k, v := range l.fields {
+		merged[k] = v
+	}
+	for k, v := range fields {
+		merged[k] = v
+	}
+	return &appLogger{
+		debug:  l.debug,
+		prefix: l.prefix,
+		fields: merged,
+		logger: l.logger,
+	}
 }
 
 func (l *appLogger) SetLevel(level logrus.Level) Logger {
@@ -170,37 +291,23 @@ func (l *appLogger) Debug(ctx context.Context, format string, args ...interface{
 }
 
 func (l *appLogger) Infof(format string, args ...interface{}) {
-	// For backwards compatibility with methods that don't have context
-	l.logger.WithFields(logrus.Fields{
-		componentField: l.prefix,
-	}).Infof(format, args...)
+	l.logger.WithFields(l.baseFields()).Infof(format, args...)
 }
 
 func (l *appLogger) Warnf(format string, args ...interface{}) {
-	// For backwards compatibility with methods that don't have context
-	l.logger.WithFields(logrus.Fields{
-		componentField: l.prefix,
-	}).Warnf(format, args...)
+	l.logger.WithFields(l.baseFields()).Warnf(format, args...)
 }
 
 func (l *appLogger) Errorf(format string, args ...interface{}) {
-	// For backwards compatibility with methods that don't have context
-	l.logger.WithFields(logrus.Fields{
-		componentField: l.prefix,
-	}).Errorf(format, args...)
+	l.logger.WithFields(l.baseFields()).Errorf(format, args...)
 }
 
 func (l *appLogger) Debugf(format string, args ...interface{}) {
-	// For backwards compatibility with methods that don't have context
-	l.logger.WithFields(logrus.Fields{
-		componentField: l.prefix,
-	}).Debugf(format, args...)
+	l.logger.WithFields(l.baseFields()).Debugf(format, args...)
 }
 
 func (l *appLogger) Fatalf(format string, args ...interface{}) {
-	l.logger.WithFields(logrus.Fields{
-		componentField: l.prefix,
-	}).Fatalf(format, args...)
+	l.logger.WithFields(l.baseFields()).Fatalf(format, args...)
 }
 
 func (l *appLogger) Info(ctx context.Context, format string, args ...interface{}) {

--- a/pkg/mocks/mock_logger.go
+++ b/pkg/mocks/mock_logger.go
@@ -295,3 +295,31 @@ func (mr *MockLoggerMockRecorder) Warnf(format any, args ...any) *gomock.Call {
 	varargs := append([]any{format}, args...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Warnf", reflect.TypeOf((*MockLogger)(nil).Warnf), varargs...)
 }
+
+// WithField mocks base method.
+func (m *MockLogger) WithField(key string, value any) logger.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithField", key, value)
+	ret0, _ := ret[0].(logger.Logger)
+	return ret0
+}
+
+// WithField indicates an expected call of WithField.
+func (mr *MockLoggerMockRecorder) WithField(key, value any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithField", reflect.TypeOf((*MockLogger)(nil).WithField), key, value)
+}
+
+// WithFields mocks base method.
+func (m *MockLogger) WithFields(fields map[string]any) logger.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithFields", fields)
+	ret0, _ := ret[0].(logger.Logger)
+	return ret0
+}
+
+// WithFields indicates an expected call of WithFields.
+func (mr *MockLoggerMockRecorder) WithFields(fields any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithFields", reflect.TypeOf((*MockLogger)(nil).WithFields), fields)
+}

--- a/pkg/services/api_token_service.go
+++ b/pkg/services/api_token_service.go
@@ -148,7 +148,7 @@ func (s *apiTokenService) ValidateToken(ctx context.Context, rawToken string) (*
 	go func() {
 		bgCtx := context.Background()
 		if err := s.store.UpdateLastUsed(bgCtx, token.ID); err != nil {
-			s.logger.Errorf("failed to update token last used: %s", err.Error())
+			s.logger.Error(ctx, "failed to update token last used: %s", err.Error())
 		}
 	}()
 

--- a/pkg/services/cluster_service.go
+++ b/pkg/services/cluster_service.go
@@ -81,12 +81,12 @@ func (s *clusterService) InjectClusterManager(clusterManager clustermanager.Clus
 func (s *clusterService) InternalListAllClusters(ctx context.Context) ([]*models.Cluster, *errors.ServiceError) {
 	clusters, err := s.clusterStore.ListAll(ctx)
 	if err != nil {
-		s.logger.Errorf("failed to list all clusters: %v", err)
+		s.logger.Error(ctx, "failed to list all clusters: %v", err)
 		return nil, err
 	}
 	for _, cluster := range clusters {
 		if decErr := s.decryptClusterCredentials(cluster); decErr != nil {
-			s.logger.Errorf("failed to decrypt cluster credentials for cluster %s: %v", cluster.ID, decErr)
+			s.logger.Error(ctx, "failed to decrypt cluster credentials for cluster %s: %v", cluster.ID, decErr)
 			return nil, decErr
 		}
 	}
@@ -100,7 +100,7 @@ func (s *clusterService) AddCluster(ctx context.Context, cluster *models.Cluster
 	// Check if the cluster already exists for the org
 	existingCluster, err := s.clusterStore.GetClusterForOrg(ctx, cluster.OrganisationID)
 	if err != nil && err.Code != errors.ErrorNotFound {
-		s.logger.Errorf("failed to get existing cluster for org: %v", err)
+		s.logger.Error(ctx, "failed to get existing cluster for org: %v", err)
 		return nil, err
 	}
 	if existingCluster != nil {
@@ -114,12 +114,12 @@ func (s *clusterService) AddCluster(ctx context.Context, cluster *models.Cluster
 	// Validate the cluster
 	err = s.validateCluster(cluster)
 	if err != nil {
-		s.logger.Errorf("failed to validate cluster: %v", err)
+		s.logger.Error(ctx, "failed to validate cluster: %v", err)
 		return nil, err
 	}
 
 	if encErr := s.encryptClusterCredentials(cluster); encErr != nil {
-		s.logger.Errorf("failed to encrypt cluster credentials: %v", encErr)
+		s.logger.Error(ctx, "failed to encrypt cluster credentials: %v", encErr)
 		return nil, encErr
 	}
 
@@ -140,7 +140,7 @@ func (s *clusterService) AddCluster(ctx context.Context, cluster *models.Cluster
 			registry.OrganisationID = createdCluster.OrganisationID
 			createdRegistry, err := s.imageRegistryService.CreateWithTx(ctx, registry)
 			if err != nil {
-				s.logger.Errorf("failed to create image registry: %v", err)
+				s.logger.Error(ctx, "failed to create image registry: %v", err)
 				return err
 			}
 			createdCluster.ImageRegistries = []*models.ClusterImageRegistry{createdRegistry}
@@ -148,12 +148,12 @@ func (s *clusterService) AddCluster(ctx context.Context, cluster *models.Cluster
 		return nil
 	})
 	if cerr != nil {
-		s.logger.Errorf("failed to create cluster: %v", cerr)
+		s.logger.Error(ctx, "failed to create cluster: %v", cerr)
 		return nil, cerr
 	}
 
 	if err := s.ensureClusterIssuer(ctx, createdCluster); err != nil {
-		s.logger.Errorf("failed to create ClusterIssuer on cluster %s: %v", createdCluster.ID, err)
+		s.logger.Error(ctx, "failed to create ClusterIssuer on cluster %s: %v", createdCluster.ID, err)
 	}
 
 	return createdCluster, nil
@@ -162,7 +162,7 @@ func (s *clusterService) AddCluster(ctx context.Context, cluster *models.Cluster
 func (s *clusterService) Delete(ctx context.Context, ID string) *errors.ServiceError {
 	cluster, err := s.clusterStore.Get(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster: %v", err)
+		s.logger.Error(ctx, "failed to get cluster: %v", err)
 		return err
 	}
 	if permErr := s.permissions.Check(ctx, cluster.OrganisationID, auth.ResourceClusters, ID, auth.ActionDelete); permErr != nil {
@@ -179,13 +179,13 @@ func (s *clusterService) Delete(ctx context.Context, ID string) *errors.ServiceE
 		for _, registry := range cluster.ImageRegistries {
 			// Delete the image registry from the cluster
 			if registry == nil {
-				s.logger.Errorf("image registry is nil")
+				s.logger.Error(ctx, "image registry is nil")
 				return errors.GeneralError("image registry is nil")
 			}
-			s.logger.Infof("Deleting image registry %s", registry.ID)
+			s.logger.Info(ctx, "Deleting image registry %s", registry.ID)
 			err := s.imageRegistryService.Delete(ctx, cluster.OrganisationID, registry.ID)
 			if err != nil {
-				s.logger.Errorf("failed to delete image registry: %v", err)
+				s.logger.Error(ctx, "failed to delete image registry: %v", err)
 				return err
 			}
 		}
@@ -194,7 +194,7 @@ func (s *clusterService) Delete(ctx context.Context, ID string) *errors.ServiceE
 	// Delete the cluster from the database
 	err = s.clusterStore.Delete(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to delete cluster: %v", err)
+		s.logger.Error(ctx, "failed to delete cluster: %v", err)
 		return err
 	}
 	return nil
@@ -290,11 +290,11 @@ func (s *clusterService) GetClusterForOrg(ctx context.Context, orgID string) (*m
 	}
 	cluster, err := s.clusterStore.GetClusterForOrg(ctx, orgID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster for org: %v", err)
+		s.logger.Error(ctx, "failed to get cluster for org: %v", err)
 		return nil, err
 	}
 	if decErr := s.decryptClusterCredentials(cluster); decErr != nil {
-		s.logger.Errorf("failed to decrypt cluster credentials: %v", decErr)
+		s.logger.Error(ctx, "failed to decrypt cluster credentials: %v", decErr)
 		return nil, decErr
 	}
 	return cluster, nil
@@ -303,11 +303,11 @@ func (s *clusterService) GetClusterForOrg(ctx context.Context, orgID string) (*m
 func (s *clusterService) GetDefaultCluster(ctx context.Context) (*models.Cluster, *errors.ServiceError) {
 	cluster, err := s.clusterStore.GetDefaultCluster(ctx)
 	if err != nil {
-		s.logger.Errorf("failed to get default cluster: %v", err)
+		s.logger.Error(ctx, "failed to get default cluster: %v", err)
 		return nil, err
 	}
 	if decErr := s.decryptClusterCredentials(cluster); decErr != nil {
-		s.logger.Errorf("failed to decrypt cluster credentials: %v", decErr)
+		s.logger.Error(ctx, "failed to decrypt cluster credentials: %v", decErr)
 		return nil, decErr
 	}
 	return cluster, nil
@@ -316,14 +316,14 @@ func (s *clusterService) GetDefaultCluster(ctx context.Context) (*models.Cluster
 func (s *clusterService) Get(ctx context.Context, ID string) (*models.Cluster, *errors.ServiceError) {
 	cluster, err := s.clusterStore.Get(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster: %v", err)
+		s.logger.Error(ctx, "failed to get cluster: %v", err)
 		return nil, err
 	}
 	if permErr := s.permissions.Check(ctx, cluster.OrganisationID, auth.ResourceClusters, ID, auth.ActionRead); permErr != nil {
 		return nil, permErr
 	}
 	if decErr := s.decryptClusterCredentials(cluster); decErr != nil {
-		s.logger.Errorf("failed to decrypt cluster credentials: %v", decErr)
+		s.logger.Error(ctx, "failed to decrypt cluster credentials: %v", decErr)
 		return nil, decErr
 	}
 	return cluster, nil
@@ -417,11 +417,11 @@ func (s *clusterService) ensureClusterIssuer(ctx context.Context, cluster *model
 		if cerr := k8sClient.Create(ctx, issuer); cerr != nil {
 			return fmt.Errorf("creating ClusterIssuer: %w", cerr)
 		}
-		s.logger.Infof("created ClusterIssuer %s on cluster %s", models.DefaultClusterIssuerName, cluster.ID)
+		s.logger.Info(ctx, "created ClusterIssuer %s on cluster %s", models.DefaultClusterIssuerName, cluster.ID)
 		return nil
 	}
 
-	s.logger.Infof("ClusterIssuer %s already exists on cluster %s, skipping", models.DefaultClusterIssuerName, cluster.ID)
+	s.logger.Info(ctx, "ClusterIssuer %s already exists on cluster %s, skipping", models.DefaultClusterIssuerName, cluster.ID)
 	return nil
 }
 

--- a/pkg/services/clusterresource/cluster_registry_service.go
+++ b/pkg/services/clusterresource/cluster_registry_service.go
@@ -44,14 +44,14 @@ func (s *clusterImageRegistryService) CreateImageRegistryInCluster(ctx context.C
 	}
 	clusterClient, clientGetErr := s.clusterManager.GetClient(cluster.ID)
 	if clientGetErr != nil {
-		s.logger.Errorf("failed to get cluster client: %v", clientGetErr)
+		s.logger.Error(ctx, "failed to get cluster client: %v", clientGetErr)
 		return newError("failed to get cluster client", clientGetErr)
 	}
 
 	desiredObjectInCluster := s.desiredObjectInCluster(registry)
 
 	if err := clusterClient.Create(ctx, desiredObjectInCluster); err != nil {
-		s.logger.Errorf("failed to create imageregistry in cluster: %v", err)
+		s.logger.Error(ctx, "failed to create imageregistry in cluster: %v", err)
 		return newError("failed to create image registry in cluster", err)
 	}
 	return nil
@@ -64,7 +64,7 @@ func (s *clusterImageRegistryService) DeleteImageRegistryInCluster(ctx context.C
 	}
 	clusterClient, clientGetErr := s.clusterManager.GetClient(cluster.ID)
 	if clientGetErr != nil {
-		s.logger.Errorf("failed to get cluster client: %v", clientGetErr)
+		s.logger.Error(ctx, "failed to get cluster client: %v", clientGetErr)
 		return newError("failed to get cluster client", clientGetErr)
 	}
 
@@ -75,7 +75,7 @@ func (s *clusterImageRegistryService) DeleteImageRegistryInCluster(ctx context.C
 			s.logger.Warn(ctx, "image registry '%s' not found in cluster", registry.ID)
 			return nil
 		}
-		s.logger.Errorf("failed to delete imageregistry in cluster: %v", err)
+		s.logger.Error(ctx, "failed to delete imageregistry in cluster: %v", err)
 		return newError("failed to delete image registry in cluster", err)
 	}
 	return nil

--- a/pkg/services/clusterresource/logging_service.go
+++ b/pkg/services/clusterresource/logging_service.go
@@ -106,7 +106,7 @@ func (s *loggingService) GetLogsForResources(ctx context.Context, orgID string, 
 
 	resourcePodMap, errors := s.resolveResourcePods(ctx, k8sclient, readyResources)
 	if len(errors) > 0 {
-		s.logger.Warnf("resource pod resolution failures: %v", errors)
+		s.logger.Warn(ctx, "resource pod resolution failures: %v", errors)
 	}
 
 	if len(resourcePodMap) == 0 {
@@ -141,7 +141,7 @@ func (s *loggingService) resolveResourcePods(ctx context.Context, k8sclient clie
 				ResourceName: resource.Name,
 				Error:        err,
 			})
-			s.logger.Errorf("failed to get pod for resource %s: %v", resource.Name, err)
+			s.logger.Error(ctx, "failed to get pod for resource %s: %v", resource.Name, err)
 			continue
 		}
 		if pod != nil {
@@ -247,11 +247,11 @@ func (s *LogStreamer) safeWriteToChannel(ctx context.Context, ch chan<- interfac
 		return
 	default:
 		// Channel full
-		s.Logger.Infof("log stream channel is full, applying rate limiting..")
+		s.Logger.Info(ctx, "log stream channel is full, applying rate limiting..")
 	}
 
 	if err := s.streamConfig.rateLimiter.Wait(ctx); err != nil {
-		s.Logger.Errorf("rate limiter wait failed: %v", err)
+		s.Logger.Error(ctx, "rate limiter wait failed: %v", err)
 		return
 	}
 	// Try again after waiting for the rate limiter.
@@ -262,6 +262,6 @@ func (s *LogStreamer) safeWriteToChannel(ctx context.Context, ch chan<- interfac
 		return
 	default:
 		// Channel is stil full, drop the message
-		s.Logger.Warnf("log stream channel is full, dropping message")
+		s.Logger.Warn(ctx, "log stream channel is full, dropping message")
 	}
 }

--- a/pkg/services/clusterresource/metrics_service.go
+++ b/pkg/services/clusterresource/metrics_service.go
@@ -111,13 +111,13 @@ func (s *clusterMetricsService) GetMetricsForResource(ctx context.Context, orgID
 
 	clusterClient, cErr := s.clusterManager.GetClient(cluster.ID)
 	if cErr != nil {
-		s.logger.Errorf("failed to get cluster client: %v", cErr)
+		s.logger.Error(ctx, "failed to get cluster client: %v", cErr)
 		return nil, newError("failed to get cluster client", cErr)
 	}
 
 	restConfig, cErr := s.clusterManager.GetRestConfig(cluster.ID)
 	if cErr != nil {
-		s.logger.Errorf("failed to get cluster rest config: %v", cErr)
+		s.logger.Error(ctx, "failed to get cluster rest config: %v", cErr)
 		return nil, newError("failed to get cluster rest config", cErr)
 	}
 
@@ -163,13 +163,13 @@ func (s *clusterMetricsService) GetMetricsForStack(ctx context.Context, orgID st
 
 	clusterClient, cErr := s.clusterManager.GetClient(cluster.ID)
 	if cErr != nil {
-		s.logger.Errorf("failed to get cluster client: %v", cErr)
+		s.logger.Error(ctx, "failed to get cluster client: %v", cErr)
 		return nil, newError("failed to get cluster client", cErr)
 	}
 
 	restConfig, cErr := s.clusterManager.GetRestConfig(cluster.ID)
 	if cErr != nil {
-		s.logger.Errorf("failed to get cluster rest config: %v", cErr)
+		s.logger.Error(ctx, "failed to get cluster rest config: %v", cErr)
 		return nil, newError("failed to get cluster rest config", cErr)
 	}
 
@@ -207,13 +207,13 @@ func (s *clusterMetricsService) StreamMetricsForResource(ctx context.Context, or
 
 	clusterClient, cErr := s.clusterManager.GetClient(cluster.ID)
 	if cErr != nil {
-		s.logger.Errorf("failed to get cluster client: %v", cErr)
+		s.logger.Error(ctx, "failed to get cluster client: %v", cErr)
 		return nil, newError("failed to get cluster client", cErr)
 	}
 
 	restConfig, cErr := s.clusterManager.GetRestConfig(cluster.ID)
 	if cErr != nil {
-		s.logger.Errorf("failed to get cluster rest config: %v", cErr)
+		s.logger.Error(ctx, "failed to get cluster rest config: %v", cErr)
 		return nil, newError("failed to get cluster rest config", cErr)
 	}
 
@@ -249,13 +249,13 @@ func (s *clusterMetricsService) StreamMetricsForStack(ctx context.Context, orgID
 
 	clusterClient, cErr := s.clusterManager.GetClient(cluster.ID)
 	if cErr != nil {
-		s.logger.Errorf("failed to get cluster client: %v", cErr)
+		s.logger.Error(ctx, "failed to get cluster client: %v", cErr)
 		return nil, newError("failed to get cluster client", cErr)
 	}
 
 	restConfig, cErr := s.clusterManager.GetRestConfig(cluster.ID)
 	if cErr != nil {
-		s.logger.Errorf("failed to get cluster rest config: %v", cErr)
+		s.logger.Error(ctx, "failed to get cluster rest config: %v", cErr)
 		return nil, newError("failed to get cluster rest config", cErr)
 	}
 
@@ -328,7 +328,7 @@ func (s *clusterMetricsStreamer) streamStackResourceMetrics(ctx context.Context)
 				apiObj := presenters.PresentResourceMetrics(metrics)
 				data, err := json.Marshal(apiObj)
 				if err != nil {
-					s.logger.Errorf("failed to marshal metrics object: %v", err)
+					s.logger.Error(ctx, "failed to marshal metrics object: %v", err)
 					continue
 				}
 				s.safeWriteToChannel(ctx, streamerChan, &StreamedMetrics{data: data})
@@ -373,7 +373,7 @@ func (s *clusterMetricsStreamer) streamStackMetrics(ctx context.Context) (<-chan
 				apiObj := presenters.PresentResourceMetrics(metrics)
 				data, err := json.Marshal(apiObj)
 				if err != nil {
-					s.logger.Errorf("failed to marshal metrics object: %v", err)
+					s.logger.Error(ctx, "failed to marshal metrics object: %v", err)
 					continue
 				}
 				s.safeWriteToChannel(ctx, streamerChan, &StreamedMetrics{data: data})
@@ -397,10 +397,10 @@ func (s *clusterMetricsStreamer) safeWriteToChannel(ctx context.Context, ch chan
 		return
 	default:
 		// Channel full
-		s.logger.Infof("log stream channel is full, applying rate limiting..")
+		s.logger.Info(ctx, "log stream channel is full, applying rate limiting..")
 	}
 	if err := s.config.rateLimiter.Wait(ctx); err != nil {
-		s.logger.Errorf("rate limiter wait failed: %v", err)
+		s.logger.Error(ctx, "rate limiter wait failed: %v", err)
 		return
 	}
 
@@ -412,7 +412,7 @@ func (s *clusterMetricsStreamer) safeWriteToChannel(ctx context.Context, ch chan
 		return
 	default:
 		// Channel is stil full, drop the message
-		s.logger.Warnf("log stream channel is full, dropping message")
+		s.logger.Warn(ctx, "log stream channel is full, dropping message")
 	}
 }
 

--- a/pkg/services/clusterresource/namespace_service.go
+++ b/pkg/services/clusterresource/namespace_service.go
@@ -57,7 +57,7 @@ func annotationsToMap(annotations models.Annotations) map[string]string {
 func (s *namespaceClusterResourceService) CreateNamespaceInCluster(ctx context.Context, ns *models.Namespace) *ClusterResourceError {
 	cluster, err := s.clusterService.GetClusterForOrg(ctx, ns.OrganisationID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster for org: %v", err)
+		s.logger.Error(ctx, "failed to get cluster for org: %v", err)
 		return newError("failed to get cluster for org", err)
 	}
 
@@ -76,7 +76,7 @@ func (s *namespaceClusterResourceService) CreateNamespaceInCluster(ctx context.C
 
 	createErr := client.Create(ctx, desiredObject)
 	if createErr != nil {
-		s.logger.Errorf("failed to create namespace in cluster: %v", createErr)
+		s.logger.Error(ctx, "failed to create namespace in cluster: %v", createErr)
 		return newError("failed to create namespace in cluster", createErr)
 	}
 
@@ -87,7 +87,7 @@ func (s *namespaceClusterResourceService) CreateNamespaceInCluster(ctx context.C
 func (s *namespaceClusterResourceService) DeleteNamespaceInCluster(ctx context.Context, ns *models.Namespace) *ClusterResourceError {
 	cluster, err := s.clusterService.GetClusterForOrg(ctx, ns.OrganisationID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster for org: %v", err)
+		s.logger.Error(ctx, "failed to get cluster for org: %v", err)
 		return newError("failed to get cluster for org", err)
 	}
 
@@ -104,7 +104,7 @@ func (s *namespaceClusterResourceService) DeleteNamespaceInCluster(ctx context.C
 
 	deleteErr := client.Delete(ctx, desiredObject)
 	if deleteErr != nil {
-		s.logger.Errorf("failed to delete namespace in cluster: %v", deleteErr)
+		s.logger.Error(ctx, "failed to delete namespace in cluster: %v", deleteErr)
 		return newError("failed to delete namespace in cluster", deleteErr)
 	}
 

--- a/pkg/services/clusterresource/volume_service.go
+++ b/pkg/services/clusterresource/volume_service.go
@@ -51,30 +51,30 @@ func NewVolumeClusterResourceService(spec VolumeClusterResourceServiceSpec) Volu
 
 func (w *volumeClusterService) CreateVolumeInCluster(ctx context.Context, volume *models.Volume) *ClusterResourceError {
 	if err := w.resolveGitRevision(ctx, volume); err != nil {
-		w.logger.Errorf("failed to resolve git revision for volume '%s': %v", volume.ID, err)
+		w.logger.Error(ctx, "failed to resolve git revision for volume '%s': %v", volume.ID, err)
 		return newError("failed to resolve git revision", err)
 	}
 
 	cluster, err := w.clusterService.GetClusterForOrg(ctx, volume.OrganisationID)
 	if err != nil {
-		w.logger.Errorf("failed to get cluster for org: %v", err)
+		w.logger.Error(ctx, "failed to get cluster for org: %v", err)
 		return newError("failed to get cluster for org", err)
 	}
 
 	volumeCR, cerr := w.desiredObjectInCluster(volume)
 	if cerr != nil {
-		w.logger.Errorf("failed to create desired volume object in cluster: %v", cerr)
+		w.logger.Error(ctx, "failed to create desired volume object in cluster: %v", cerr)
 		return newError("failed to create desired volume object in cluster", cerr)
 	}
 
 	clusterClient, clientGetErr := w.clusterManager.GetClient(cluster.ID)
 	if clientGetErr != nil {
-		w.logger.Errorf("failed to get cluster client: %v", clientGetErr)
+		w.logger.Error(ctx, "failed to get cluster client: %v", clientGetErr)
 		return newError("failed to get cluster client", clientGetErr)
 	}
 
 	if err := clusterClient.Create(ctx, volumeCR); err != nil {
-		w.logger.Errorf("failed to create volume  in cluster: %v", err)
+		w.logger.Error(ctx, "failed to create volume  in cluster: %v", err)
 		return newError("failed to create volume  in cluster", err)
 	}
 
@@ -88,13 +88,13 @@ func (w *volumeClusterService) UpdateVolumeRemoteDirRevisionInCluster(ctx contex
 
 	cluster, err := w.clusterService.GetClusterForOrg(ctx, volume.OrganisationID)
 	if err != nil {
-		w.logger.Errorf("failed to get cluster for org: %v", err)
+		w.logger.Error(ctx, "failed to get cluster for org: %v", err)
 		return newError("failed to get cluster for org", err)
 	}
 
 	clusterClient, clientGetErr := w.clusterManager.GetClient(cluster.ID)
 	if clientGetErr != nil {
-		w.logger.Errorf("failed to get cluster client: %v", clientGetErr)
+		w.logger.Error(ctx, "failed to get cluster client: %v", clientGetErr)
 		return newError("failed to get cluster client", clientGetErr)
 	}
 
@@ -104,7 +104,7 @@ func (w *volumeClusterService) UpdateVolumeRemoteDirRevisionInCluster(ctx contex
 		Namespace: volume.Namespace,
 	}, existingVolumeCR); err != nil {
 		if k8sapierrors.IsNotFound(err) {
-			w.logger.Errorf("volume missing in cluster: %v", err)
+			w.logger.Error(ctx, "volume missing in cluster: %v", err)
 			return newError("volume missing in cluster", err)
 		}
 		return newError("failed to get volume from cluster", err)
@@ -112,7 +112,7 @@ func (w *volumeClusterService) UpdateVolumeRemoteDirRevisionInCluster(ctx contex
 
 	existingVolumeCR.Spec.Source.RemoteDir.CurrentDirectoryHash = volume.VolumeSource.RemoteDirSource.CurrentDirectoryHash
 	if err := clusterClient.Update(ctx, existingVolumeCR); err != nil {
-		w.logger.Errorf("failed to update volume in cluster: %v", err)
+		w.logger.Error(ctx, "failed to update volume in cluster: %v", err)
 		return newError("failed to update volume in cluster", err)
 	}
 	return nil
@@ -124,19 +124,19 @@ func (w *volumeClusterService) UpdateVolumeGitRevisionInCluster(ctx context.Cont
 	}
 
 	if err := w.resolveGitRevision(ctx, volume); err != nil {
-		w.logger.Errorf("failed to resolve git revision for volume '%s': %v", volume.ID, err)
+		w.logger.Error(ctx, "failed to resolve git revision for volume '%s': %v", volume.ID, err)
 		return newError("failed to resolve git revision", err)
 	}
 
 	cluster, err := w.clusterService.GetClusterForOrg(ctx, volume.OrganisationID)
 	if err != nil {
-		w.logger.Errorf("failed to get cluster for org: %v", err)
+		w.logger.Error(ctx, "failed to get cluster for org: %v", err)
 		return newError("failed to get cluster for org", err)
 	}
 
 	clusterClient, clientGetErr := w.clusterManager.GetClient(cluster.ID)
 	if clientGetErr != nil {
-		w.logger.Errorf("failed to get cluster client: %v", clientGetErr)
+		w.logger.Error(ctx, "failed to get cluster client: %v", clientGetErr)
 		return newError("failed to get cluster client", clientGetErr)
 	}
 
@@ -146,7 +146,7 @@ func (w *volumeClusterService) UpdateVolumeGitRevisionInCluster(ctx context.Cont
 		Namespace: volume.Namespace,
 	}, existingVolumeCR); err != nil {
 		if k8sapierrors.IsNotFound(err) {
-			w.logger.Errorf("volume missing in cluster: %v", err)
+			w.logger.Error(ctx, "volume missing in cluster: %v", err)
 			return newError("volume missing in cluster", err)
 		}
 		return newError("failed to get volume from cluster", err)
@@ -167,7 +167,7 @@ func (w *volumeClusterService) UpdateVolumeGitRevisionInCluster(ctx context.Cont
 
 	existingVolumeCR.Spec.Source.GitRepo.Revision = updatedRevision
 	if err := clusterClient.Update(ctx, existingVolumeCR); err != nil {
-		w.logger.Errorf("failed to update volume in cluster: %v", err)
+		w.logger.Error(ctx, "failed to update volume in cluster: %v", err)
 		return newError("failed to update volume in cluster", err)
 	}
 	return nil
@@ -176,13 +176,13 @@ func (w *volumeClusterService) UpdateVolumeGitRevisionInCluster(ctx context.Cont
 func (w *volumeClusterService) DeleteVolumeInCluster(ctx context.Context, volume *models.Volume) *ClusterResourceError {
 	cluster, err := w.clusterService.GetClusterForOrg(ctx, volume.OrganisationID)
 	if err != nil {
-		w.logger.Errorf("failed to get cluster for org: %v", err)
+		w.logger.Error(ctx, "failed to get cluster for org: %v", err)
 		return newError("failed to get cluster for org", err)
 	}
 
 	clusterClient, clientGetErr := w.clusterManager.GetClient(cluster.ID)
 	if clientGetErr != nil {
-		w.logger.Errorf("failed to get cluster client: %v", clientGetErr)
+		w.logger.Error(ctx, "failed to get cluster client: %v", clientGetErr)
 		return newError("failed to get cluster client", clientGetErr)
 	}
 
@@ -192,7 +192,7 @@ func (w *volumeClusterService) DeleteVolumeInCluster(ctx context.Context, volume
 		Namespace: volume.Namespace,
 	}, existingVolumeCR); err != nil {
 		if k8sapierrors.IsNotFound(err) {
-			w.logger.Errorf("volume missing in cluster: %v", err)
+			w.logger.Error(ctx, "volume missing in cluster: %v", err)
 			return newError("volume missing in cluster", err)
 		}
 		return newError("failed to get volume from cluster", err)
@@ -203,7 +203,7 @@ func (w *volumeClusterService) DeleteVolumeInCluster(ctx context.Context, volume
 			w.logger.Warn(ctx, "volume '%s' not found in cluster", volume.ID)
 			return nil
 		}
-		w.logger.Errorf("failed to delete  volume in cluster: %v", err)
+		w.logger.Error(ctx, "failed to delete  volume in cluster: %v", err)
 		return newError("failed to delete  volume in cluster", err)
 	}
 	return nil

--- a/pkg/services/clusterresource/workspace_user_service.go
+++ b/pkg/services/clusterresource/workspace_user_service.go
@@ -48,13 +48,13 @@ func NewWorkspaceUserClusterResourceService(spec WorkspaceUserClusterResourceSer
 func (s *workspaceUserClusterResourceService) CreateWorkspaceUserInCluster(ctx context.Context, workspaceUser *models.WorkspaceUser) *ClusterResourceError {
 	cluster, err := s.clusterService.GetClusterForOrg(ctx, workspaceUser.OrganisationID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster for org: %v", err)
+		s.logger.Error(ctx, "failed to get cluster for org: %v", err)
 		return newError("failed to get cluster for org", err)
 	}
 
 	user, err := s.userService.Get(ctx, workspaceUser.UserID)
 	if err != nil {
-		s.logger.Errorf("failed to get user: %v", err)
+		s.logger.Error(ctx, "failed to get user: %v", err)
 		return newError("failed to get user", err)
 	}
 
@@ -70,7 +70,7 @@ func (s *workspaceUserClusterResourceService) CreateWorkspaceUserInCluster(ctx c
 	// Create the user in the cluster
 	createErr := client.Create(ctx, desiredObject)
 	if createErr != nil {
-		s.logger.Errorf("failed to create workspaceuser in cluster: %v", err)
+		s.logger.Error(ctx, "failed to create workspaceuser in cluster: %v", err)
 		return newError("failed to create workspaceuser in cluster", createErr)
 	}
 
@@ -81,12 +81,12 @@ func (s *workspaceUserClusterResourceService) CreateWorkspaceUserInCluster(ctx c
 func (s *workspaceUserClusterResourceService) DeleteWorkspaceUserInCluster(ctx context.Context, workspaceUser *models.WorkspaceUser) *ClusterResourceError {
 	cluster, err := s.clusterService.GetClusterForOrg(ctx, workspaceUser.OrganisationID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster for org: %v", err)
+		s.logger.Error(ctx, "failed to get cluster for org: %v", err)
 		return newError("failed to get cluster for org", err)
 	}
 	user, err := s.userService.Get(ctx, workspaceUser.UserID)
 	if err != nil {
-		s.logger.Errorf("failed to get user: %v", err)
+		s.logger.Error(ctx, "failed to get user: %v", err)
 		return newError("failed to get user from db", err)
 	}
 
@@ -104,7 +104,7 @@ func (s *workspaceUserClusterResourceService) DeleteWorkspaceUserInCluster(ctx c
 	// Delete the user in the cluster
 	deleteErr := client.Delete(ctx, desiredObject)
 	if deleteErr != nil {
-		s.logger.Errorf("failed to delete workspaceuser in cluster: %v", deleteErr)
+		s.logger.Error(ctx, "failed to delete workspaceuser in cluster: %v", deleteErr)
 		return newError("failed to delete workspaceuser in cluster", deleteErr)
 	}
 
@@ -115,13 +115,13 @@ func (s *workspaceUserClusterResourceService) DeleteWorkspaceUserInCluster(ctx c
 func (s *workspaceUserClusterResourceService) UpdateWorkspaceUserInCluster(ctx context.Context, workspaceUser *models.WorkspaceUser) *ClusterResourceError {
 	cluster, err := s.clusterService.GetClusterForOrg(ctx, workspaceUser.OrganisationID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster for org: %v", err)
+		s.logger.Error(ctx, "failed to get cluster for org: %v", err)
 		return newError("failed to get cluster for org", err)
 	}
 
 	user, err := s.userService.Get(ctx, workspaceUser.UserID)
 	if err != nil {
-		s.logger.Errorf("failed to get user: %v", err)
+		s.logger.Error(ctx, "failed to get user: %v", err)
 		return newError("failed to get user from db", err)
 	}
 
@@ -143,7 +143,7 @@ func (s *workspaceUserClusterResourceService) UpdateWorkspaceUserInCluster(ctx c
 	desiredObject.ResourceVersion = existingObject.ResourceVersion
 	updateErr := client.Update(ctx, desiredObject)
 	if updateErr != nil {
-		s.logger.Errorf("failed to update workspaceuser in cluster: %v", err)
+		s.logger.Error(ctx, "failed to update workspaceuser in cluster: %v", err)
 		return newError("failed to update workspaceuser in cluster", updateErr)
 	}
 

--- a/pkg/services/delete_protection_test.go
+++ b/pkg/services/delete_protection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/mocks"
 	"github.com/Stackdome/stackdome/pkg/models"
 	"go.uber.org/mock/gomock"
@@ -27,6 +28,7 @@ func TestSecretDeleteBlockedReturns409(t *testing.T) {
 		secretStore:      secretStore,
 		referenceService: refs,
 		permissions:      permissions,
+		logger:           logger.NewLogger(),
 	}
 
 	err := svc.Delete(context.Background(), "sec-1")
@@ -54,6 +56,7 @@ func TestSecretDeleteAllowedWhenNotReferenced(t *testing.T) {
 		secretStore:      secretStore,
 		referenceService: refs,
 		permissions:      permissions,
+		logger:           logger.NewLogger(),
 	}
 
 	if err := svc.Delete(context.Background(), "sec-1"); err != nil {
@@ -79,6 +82,7 @@ func TestPostgresAddonDeleteBlockedReturns409(t *testing.T) {
 		postgresAddonStore: addonStore,
 		referenceService:   refs,
 		permissions:        permissions,
+		logger:             logger.NewLogger(),
 	}
 
 	_, err := svc.DeletePostgresAddon(context.Background(), "pg-1")
@@ -105,6 +109,7 @@ func TestVolumeDeleteBlockedReturns409(t *testing.T) {
 		volumeStore:      volumeStore,
 		referenceService: refs,
 		permissions:      permissions,
+		logger:           logger.NewLogger(),
 	}
 
 	err := svc.Delete(context.Background(), "vol-1")

--- a/pkg/services/image_registry_service.go
+++ b/pkg/services/image_registry_service.go
@@ -64,7 +64,7 @@ func (s *clusterImageRegistryService) Get(ctx context.Context, ID string) (*mode
 	}
 	registry, err := s.clusterImageRegistryStore.GetByID(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster image registry: %v", err)
+		s.logger.Error(ctx, "failed to get cluster image registry: %v", err)
 		return nil, err
 	}
 	return registry, nil
@@ -80,7 +80,7 @@ func (s *clusterImageRegistryService) ListByClusterID(ctx context.Context, orgID
 	}
 	registries, err := s.clusterImageRegistryStore.ListByClusterID(ctx, clusterID)
 	if err != nil {
-		s.logger.Errorf("failed to list cluster image registries: %v", err)
+		s.logger.Error(ctx, "failed to list cluster image registries: %v", err)
 		return nil, err
 	}
 	return registries, nil
@@ -106,7 +106,7 @@ func (s *clusterImageRegistryService) PopulateInClusterRegistryUrlForResource(ct
 func (s *clusterImageRegistryService) GetForOrg(ctx context.Context, orgID string) (*models.ClusterImageRegistry, *errors.ServiceError) {
 	registry, err := s.clusterImageRegistryStore.GetForOrg(ctx, orgID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster image registry for org: %v", err)
+		s.logger.Error(ctx, "failed to get cluster image registry for org: %v", err)
 		return nil, err
 	}
 	return registry, nil
@@ -147,14 +147,14 @@ func (s *clusterImageRegistryService) Create(ctx context.Context, spec *models.C
 		// Create registry in database
 		createdRegistry, err = s.clusterImageRegistryStore.CreateWithTx(ctx, spec)
 		if err != nil {
-			s.logger.Errorf("failed to create cluster image registry: %v", err)
+			s.logger.Error(ctx, "failed to create cluster image registry: %v", err)
 			return err
 		}
 
 		// Create registry in cluster
 		cerr := s.clusterResourceService.CreateImageRegistryInCluster(ctx, createdRegistry)
 		if cerr != nil {
-			s.logger.Errorf("failed to create cluster image registry in cluster: %v", cerr)
+			s.logger.Error(ctx, "failed to create cluster image registry in cluster: %v", cerr)
 			return errors.GeneralError("failed to create cluster image registry in cluster: %s", cerr.Error())
 		}
 		return nil
@@ -196,14 +196,14 @@ func (s *clusterImageRegistryService) CreateWithTx(ctx context.Context, spec *mo
 	// Create registry in database
 	createdRegistry, err = s.clusterImageRegistryStore.CreateWithTx(ctx, spec)
 	if err != nil {
-		s.logger.Errorf("failed to create cluster image registry: %v", err)
+		s.logger.Error(ctx, "failed to create cluster image registry: %v", err)
 		return nil, err
 	}
 
 	// Create registry in cluster
 	cerr := s.clusterResourceService.CreateImageRegistryInCluster(ctx, createdRegistry)
 	if cerr != nil {
-		s.logger.Errorf("failed to create cluster image registry in cluster: %v", cerr)
+		s.logger.Error(ctx, "failed to create cluster image registry in cluster: %v", cerr)
 		return nil, errors.GeneralError("failed to create cluster image registry in cluster: %s", cerr.Error())
 	}
 
@@ -223,7 +223,7 @@ func (s *clusterImageRegistryService) validateBackendStorageSize(size string) *e
 func (s *clusterImageRegistryService) UpdateStatus(ctx context.Context, ID string, status *models.ClusterImageRegistryStatus) *errors.ServiceError {
 	err := s.clusterImageRegistryStore.UpdateStatus(ctx, ID, status)
 	if err != nil {
-		s.logger.Errorf("failed to update cluster image registry status: %v", err)
+		s.logger.Error(ctx, "failed to update cluster image registry status: %v", err)
 		return err
 	}
 	return nil
@@ -236,7 +236,7 @@ func (s *clusterImageRegistryService) Delete(ctx context.Context, orgID, ID stri
 
 	registry, err := s.clusterImageRegistryStore.GetByID(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to get cluster image registry for deletion: %v", err)
+		s.logger.Error(ctx, "failed to get cluster image registry for deletion: %v", err)
 		return err
 	}
 
@@ -244,21 +244,21 @@ func (s *clusterImageRegistryService) Delete(ctx context.Context, orgID, ID stri
 		// Delete from cluster first
 		cErr := s.clusterResourceService.DeleteImageRegistryInCluster(ctx, registry)
 		if cErr != nil {
-			s.logger.Errorf("failed to delete cluster image registry in cluster: %v", cErr)
+			s.logger.Error(ctx, "failed to delete cluster image registry in cluster: %v", cErr)
 			return errors.GeneralError("failed to delete cluster image registry in cluster: %s", cErr.Error())
 		}
 
 		// Then delete from database
 		err = s.clusterImageRegistryStore.DeleteWithTx(ctx, ID)
 		if err != nil {
-			s.logger.Errorf("failed to delete cluster image registry: %v", err)
+			s.logger.Error(ctx, "failed to delete cluster image registry: %v", err)
 			return err
 		}
 		return nil
 	})
 
 	if deleteErr != nil {
-		s.logger.Errorf("failed to delete cluster image registry: %v", deleteErr)
+		s.logger.Error(ctx, "failed to delete cluster image registry: %v", deleteErr)
 		return deleteErr
 	}
 	return nil

--- a/pkg/services/metrics_service.go
+++ b/pkg/services/metrics_service.go
@@ -44,7 +44,7 @@ func NewMetricsService(spec MetricsServiceSpec) MetricsService {
 func (s *metricsService) GetMetricsForStackResource(ctx context.Context, orgID string, stackID string, stackResourceName string) (*models.ResourceMetrics, error) {
 	resource, err := s.stackResourceService.GetByStackIDAndResourceName(ctx, stackID, stackResourceName)
 	if err != nil {
-		s.logger.Errorf("failed to get stack resource: %v", err)
+		s.logger.Error(ctx, "failed to get stack resource: %v", err)
 		return nil, err
 	}
 	if resource.Status != nil && resource.Status.State != models.StackResourcePhaseReady {
@@ -61,7 +61,7 @@ func (s *metricsService) GetMetricsForStackResource(ctx context.Context, orgID s
 func (s *metricsService) GetMetricsForStack(ctx context.Context, orgID string, stackID string) (*models.ResourceMetrics, error) {
 	stack, err := s.stackService.GetStack(ctx, stackID)
 	if err != nil {
-		s.logger.Errorf("failed to get stack: %v", err)
+		s.logger.Error(ctx, "failed to get stack: %v", err)
 		return nil, err
 	}
 
@@ -71,7 +71,7 @@ func (s *metricsService) GetMetricsForStack(ctx context.Context, orgID string, s
 
 	res, cerr := s.ClusterMetricsService.GetMetricsForStack(ctx, orgID, stack)
 	if cerr != nil {
-		s.logger.Errorf("failed to get metrics for stack: %v", cerr)
+		s.logger.Error(ctx, "failed to get metrics for stack: %v", cerr)
 		return nil, cerr
 	}
 	return res, nil
@@ -80,7 +80,7 @@ func (s *metricsService) GetMetricsForStack(ctx context.Context, orgID string, s
 func (s *metricsService) StreamMetricsForStackResource(ctx context.Context, orgID string, stackID string, stackResourceName string) (interfaces.ServerSideStreamable, error) {
 	resource, err := s.stackResourceService.GetByStackIDAndResourceName(ctx, stackID, stackResourceName)
 	if err != nil {
-		s.logger.Errorf("failed to get stack resource: %v", err)
+		s.logger.Error(ctx, "failed to get stack resource: %v", err)
 		return nil, err
 	}
 	if resource.Status != nil && resource.Status.State != models.StackResourcePhaseReady {
@@ -88,7 +88,7 @@ func (s *metricsService) StreamMetricsForStackResource(ctx context.Context, orgI
 	}
 	streamer, cerr := s.ClusterMetricsService.StreamMetricsForResource(ctx, orgID, resource)
 	if cerr != nil {
-		s.logger.Errorf("failed to stream metrics for resource: %v", cerr)
+		s.logger.Error(ctx, "failed to stream metrics for resource: %v", cerr)
 		return nil, cerr
 	}
 	return streamer, nil
@@ -96,7 +96,7 @@ func (s *metricsService) StreamMetricsForStackResource(ctx context.Context, orgI
 func (s *metricsService) StreamMetricsForStack(ctx context.Context, orgID string, stackID string) (interfaces.ServerSideStreamable, error) {
 	stack, err := s.stackService.GetStack(ctx, stackID)
 	if err != nil {
-		s.logger.Errorf("failed to get stack: %v", err)
+		s.logger.Error(ctx, "failed to get stack: %v", err)
 		return nil, err
 	}
 
@@ -105,7 +105,7 @@ func (s *metricsService) StreamMetricsForStack(ctx context.Context, orgID string
 	}
 	streamer, cerr := s.ClusterMetricsService.StreamMetricsForStack(ctx, orgID, stack)
 	if cerr != nil {
-		s.logger.Errorf("failed to stream metrics for stack: %v", cerr)
+		s.logger.Error(ctx, "failed to stream metrics for stack: %v", cerr)
 		return nil, cerr
 	}
 	return streamer, nil

--- a/pkg/services/object_store_service.go
+++ b/pkg/services/object_store_service.go
@@ -229,7 +229,7 @@ func (s *objectStoreService) Delete(ctx context.Context, ID string) *errors.Serv
 func (s *objectStoreService) cleanupFromCluster(ctx context.Context, objectStore *models.ObjectStore, deployed models.DeployedClusterInfo) {
 	clusterClient, clientErr := s.clusterManager.GetClient(deployed.ClusterID)
 	if clientErr != nil {
-		s.logger.Errorf("failed to get client for cluster %s during ObjectStore cleanup: %v", deployed.ClusterID, clientErr)
+		s.logger.Error(ctx, "failed to get client for cluster %s during ObjectStore cleanup: %v", deployed.ClusterID, clientErr)
 		return
 	}
 
@@ -240,7 +240,7 @@ func (s *objectStoreService) cleanupFromCluster(ctx context.Context, objectStore
 		},
 	}
 	if deleteErr := clusterClient.Delete(ctx, osCR); deleteErr != nil && !k8sapierrors.IsNotFound(deleteErr) {
-		s.logger.Errorf("failed to delete ObjectStore CR %s from cluster %s: %v", objectStore.Name, deployed.ClusterID, deleteErr)
+		s.logger.Error(ctx, "failed to delete ObjectStore CR %s from cluster %s: %v", objectStore.Name, deployed.ClusterID, deleteErr)
 	}
 
 	credSecret := &corev1.Secret{
@@ -250,7 +250,7 @@ func (s *objectStoreService) cleanupFromCluster(ctx context.Context, objectStore
 		},
 	}
 	if deleteErr := clusterClient.Delete(ctx, credSecret, client.PropagationPolicy(metav1.DeletePropagationBackground)); deleteErr != nil && !k8sapierrors.IsNotFound(deleteErr) {
-		s.logger.Errorf("failed to delete credential secret for ObjectStore %s from cluster %s: %v", objectStore.Name, deployed.ClusterID, deleteErr)
+		s.logger.Error(ctx, "failed to delete credential secret for ObjectStore %s from cluster %s: %v", objectStore.Name, deployed.ClusterID, deleteErr)
 	}
 }
 

--- a/pkg/services/org_invite_service.go
+++ b/pkg/services/org_invite_service.go
@@ -150,7 +150,7 @@ func (s *orgInviteService) Create(ctx context.Context, email, teamName string, r
 
 	if s.BackgroundJobEnqueuer != nil {
 		if err := s.BackgroundJobEnqueuer.Enqueue(&models.OrgInvite{ID: created.ID}); err != nil {
-			s.logger.Errorf("failed to enqueue invite email job: %s", err.Error())
+			s.logger.Error(ctx, "failed to enqueue invite email job: %s", err.Error())
 		}
 	}
 
@@ -218,7 +218,7 @@ func (s *orgInviteService) Resend(ctx context.Context, orgID, id string) *errors
 
 	if s.BackgroundJobEnqueuer != nil {
 		if err := s.BackgroundJobEnqueuer.Enqueue(&models.OrgInvite{ID: id}); err != nil {
-			s.logger.Errorf("failed to enqueue invite email job for resend: %s", err.Error())
+			s.logger.Error(ctx, "failed to enqueue invite email job for resend: %s", err.Error())
 		}
 	}
 	return nil

--- a/pkg/services/organisation_domain_service.go
+++ b/pkg/services/organisation_domain_service.go
@@ -60,7 +60,7 @@ func (s *organisationDomainService) InternalCreateWithTx(ctx context.Context, sp
 	// Verify no duplicate domain exists
 	domains, err := s.organisationDomainStore.ListByOrganisationID(ctx, spec.OrganisationID)
 	if err != nil {
-		s.logger.Errorf("failed to list domains for organisation %s: %v", spec.OrganisationID, err)
+		s.logger.Error(ctx, "failed to list domains for organisation %s: %v", spec.OrganisationID, err)
 		return nil, err
 	}
 
@@ -72,7 +72,7 @@ func (s *organisationDomainService) InternalCreateWithTx(ctx context.Context, sp
 
 	createdDomain, err := s.organisationDomainStore.CreateWithTx(ctx, spec)
 	if err != nil {
-		s.logger.Errorf("failed to create organisation domain: %v", err)
+		s.logger.Error(ctx, "failed to create organisation domain: %v", err)
 		return nil, err
 	}
 	return createdDomain, nil
@@ -106,7 +106,7 @@ func (s *organisationDomainService) Create(ctx context.Context, spec *models.Org
 
 	domains, err := s.organisationDomainStore.ListByOrganisationID(ctx, spec.OrganisationID)
 	if err != nil {
-		s.logger.Errorf("failed to list domains for organisation %s: %v", spec.OrganisationID, err)
+		s.logger.Error(ctx, "failed to list domains for organisation %s: %v", spec.OrganisationID, err)
 		return nil, err
 	}
 
@@ -157,7 +157,7 @@ func (s *organisationDomainService) Update(ctx context.Context, id string, spec 
 	if existingDomain.Domain != spec.Domain {
 		domains, err := s.organisationDomainStore.ListByOrganisationID(ctx, existingDomain.OrganisationID)
 		if err != nil {
-			s.logger.Errorf("failed to list domains for organisation %s: %v", existingDomain.OrganisationID, err)
+			s.logger.Error(ctx, "failed to list domains for organisation %s: %v", existingDomain.OrganisationID, err)
 			return nil, err
 		}
 
@@ -189,7 +189,7 @@ func (s *organisationDomainService) GetDefaultDomainForOrganisation(ctx context.
 
 	domains, err := s.organisationDomainStore.ListByOrganisationID(ctx, organisationID)
 	if err != nil {
-		s.logger.Errorf("failed to list domains for organisation %s: %v", organisationID, err)
+		s.logger.Error(ctx, "failed to list domains for organisation %s: %v", organisationID, err)
 		return nil, err
 	}
 

--- a/pkg/services/organisation_service.go
+++ b/pkg/services/organisation_service.go
@@ -71,7 +71,7 @@ func (s *organisationService) InternalCreate(ctx context.Context, spec *models.O
 
 	org, err := s.organisationStore.Create(ctx, spec)
 	if err != nil {
-		s.logger.Errorf("failed to create organisation: %v", err)
+		s.logger.Error(ctx, "failed to create organisation: %v", err)
 		return nil, err
 	}
 
@@ -91,7 +91,7 @@ func (s *organisationService) Get(ctx context.Context, ID string) (*models.Organ
 	}
 	org, err := s.organisationStore.Get(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to get organisation: %v", err)
+		s.logger.Error(ctx, "failed to get organisation: %v", err)
 		return nil, err
 	}
 	return org, nil
@@ -111,7 +111,7 @@ func (s *organisationService) Delete(ctx context.Context, ID string) *errors.Ser
 	}
 	err = s.organisationStore.Delete(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to delete organisation: %v", err)
+		s.logger.Error(ctx, "failed to delete organisation: %v", err)
 		return err
 	}
 	return nil
@@ -130,7 +130,7 @@ func (s *organisationService) Update(ctx context.Context, ID string, spec *model
 	if spec.Name != "" && existing.Name != spec.Name {
 		nameExists, err := s.organisationStore.OrganisationNameExists(ctx, spec.Name)
 		if err != nil {
-			s.logger.Errorf("failed to check if organisation name exists: %v", err)
+			s.logger.Error(ctx, "failed to check if organisation name exists: %v", err)
 			return nil, errors.GeneralError("failed to update organisation")
 		}
 		if nameExists {
@@ -143,7 +143,7 @@ func (s *organisationService) Update(ctx context.Context, ID string, spec *model
 	}
 	org, err := s.organisationStore.Update(ctx, ID, spec)
 	if err != nil {
-		s.logger.Errorf("failed to update organisation: %v", err)
+		s.logger.Error(ctx, "failed to update organisation: %v", err)
 		return nil, err
 	}
 
@@ -204,7 +204,7 @@ func (s *organisationService) PromoteToOrgAdmin(ctx context.Context, orgID, user
 	}
 
 	if err := s.policyMgr.AddGroupingPolicy(userID, string(models.OrgAdminRole), orgID); err != nil {
-		s.logger.Errorf("failed to add OrgAdmin grouping: %s", err.Error())
+		s.logger.Error(ctx, "failed to add OrgAdmin grouping: %s", err.Error())
 		return errors.InternalServerError("failed to add OrgAdmin grouping")
 	}
 
@@ -244,12 +244,12 @@ func (s *organisationService) DemoteOrgAdmin(ctx context.Context, orgID, userID,
 		}
 
 		if _, serr := s.teamService.InternalAddMember(txCtx, teamID, userID, role); serr != nil {
-			s.logger.Errorf("failed to add demoted user to team: %s", serr.Error())
+			s.logger.Error(ctx, "failed to add demoted user to team: %s", serr.Error())
 			return serr
 		}
 
 		if err := s.policyMgr.RemoveGroupingPolicy(userID, string(models.OrgAdminRole), orgID); err != nil {
-			s.logger.Errorf("failed to remove OrgAdmin grouping: %s", err.Error())
+			s.logger.Error(ctx, "failed to remove OrgAdmin grouping: %s", err.Error())
 			return errors.InternalServerError("failed to remove OrgAdmin grouping")
 		}
 

--- a/pkg/services/postgres_addon_service.go
+++ b/pkg/services/postgres_addon_service.go
@@ -254,6 +254,11 @@ func (s *postgresAddonService) CreatePostgresAddon(ctx context.Context, postgres
 		return nil, errors.GeneralError("failed to enqueue background job for postgres addon '%s': %s", createdPostgresAddon.Name, err.Error())
 	}
 
+	s.logger.WithFields(map[string]interface{}{
+		"addon_id":            createdPostgresAddon.ID,
+		logger.FieldClusterID: createdPostgresAddon.ClusterID,
+		"databases":           len(createdPostgresAddon.Databases),
+	}).Info(ctx, "created postgres addon")
 	return createdPostgresAddon, nil
 }
 
@@ -334,6 +339,7 @@ func (s *postgresAddonService) UpdatePostgresAddon(ctx context.Context, id strin
 		return nil, errors.GeneralError("failed to enqueue background job for postgres addon '%s': %s", updatedPostgresAddon.Name, err.Error())
 	}
 
+	s.logger.WithField("addon_id", updatedPostgresAddon.ID).Info(ctx, "updated postgres addon")
 	return updatedPostgresAddon, nil
 }
 
@@ -440,6 +446,7 @@ func (s *postgresAddonService) DeletePostgresAddon(ctx context.Context, id strin
 		return nil, errors.GeneralError("failed to enqueue background job for postgres addon '%s': %s", postgresAddon.Name, err.Error())
 	}
 
+	s.logger.WithField("addon_id", id).Info(ctx, "marked postgres addon for deletion")
 	return postgresAddon, nil
 }
 

--- a/pkg/services/postgres_addon_service_test.go
+++ b/pkg/services/postgres_addon_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	apperrors "github.com/Stackdome/stackdome/pkg/errors"
+	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/mocks"
 	"github.com/Stackdome/stackdome/pkg/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -33,6 +34,7 @@ var _ = Describe("PostgresAddonService DeletePostgresAddon", func() {
 		ctx = context.Background()
 
 		svc = &postgresAddonService{
+			logger:             logger.NewLogger(),
 			postgresAddonStore: addonStore,
 			referenceService:   refs,
 			permissions:        permissions,

--- a/pkg/services/secret_service.go
+++ b/pkg/services/secret_service.go
@@ -103,6 +103,11 @@ func (s *secretService) Create(ctx context.Context, secret *models.Secret) (*mod
 		return nil, err
 	}
 
+	s.logger.WithFields(map[string]interface{}{
+		"secret_id": createdSecret.ID,
+		"team_id":   createdSecret.TeamID,
+		"key_count": len(createdSecret.Keys),
+	}).Info(ctx, "created secret")
 	return createdSecret, nil
 }
 
@@ -182,6 +187,7 @@ func (s *secretService) Update(ctx context.Context, id string, secret *models.Se
 		return nil, err
 	}
 
+	s.logger.WithField("secret_id", updatedSecret.ID).Info(ctx, "updated secret")
 	return updatedSecret, nil
 }
 
@@ -206,6 +212,7 @@ func (s *secretService) Delete(ctx context.Context, ID string) *errors.ServiceEr
 		return err
 	}
 
+	s.logger.WithField("secret_id", ID).Info(ctx, "deleted secret")
 	return nil
 }
 

--- a/pkg/services/signup_service.go
+++ b/pkg/services/signup_service.go
@@ -61,7 +61,7 @@ func NewSignupService(spec SignupServiceSpec) SignupService {
 }
 
 func (s *signupService) Signup(ctx context.Context, user *models.User, inviteToken string) (*openapi.UserSignupResponse, *errors.ServiceError) {
-	s.logger.Infof("Creating user with email: %s", user.Email)
+	s.logger.Info(ctx, "Creating user with email: %s", user.Email)
 	if len(user.Password) < 8 {
 		return nil, errors.BadRequest("password must be at least 8 characters")
 	}
@@ -78,7 +78,7 @@ func (s *signupService) Signup(ctx context.Context, user *models.User, inviteTok
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
 	if err != nil {
-		s.logger.Errorf("failed to hash password, %s", err.Error())
+		s.logger.Error(ctx, "failed to hash password, %s", err.Error())
 		return nil, errors.GeneralError("failed to create user")
 	}
 	user.Password = string(hashedPassword)
@@ -102,14 +102,14 @@ func (s *signupService) Signup(ctx context.Context, user *models.User, inviteTok
 	}
 	createdOrganisation, orgErr := s.organisationService.InternalCreate(ctx, user.Organisation)
 	if orgErr != nil {
-		s.logger.Errorf("failed to create organisation, %s", orgErr.Error())
+		s.logger.Error(ctx, "failed to create organisation, %s", orgErr.Error())
 		return nil, errors.GeneralError("failed to create user")
 	}
 	user.OrganisationID = createdOrganisation.ID
 	user.Role = models.OrgAdminRole
 
 	if _, teamErr := s.teamService.InternalCreateDefaultTeam(ctx, createdOrganisation.ID); teamErr != nil {
-		s.logger.Errorf("failed to create default team: %s", teamErr.Error())
+		s.logger.Error(ctx, "failed to create default team: %s", teamErr.Error())
 		return nil, errors.GeneralError("failed to create default team")
 	}
 
@@ -123,7 +123,7 @@ func (s *signupService) Signup(ctx context.Context, user *models.User, inviteTok
 		string(models.OrgAdminRole),
 		createdUser.OrganisationID,
 	); policyAddErr != nil {
-		s.logger.Errorf("failed to add OrgAdmin policy for user: %s", policyAddErr.Error())
+		s.logger.Error(ctx, "failed to add OrgAdmin policy for user: %s", policyAddErr.Error())
 		return nil, errors.GeneralError("failed to create user")
 	}
 
@@ -132,7 +132,7 @@ func (s *signupService) Signup(ctx context.Context, user *models.User, inviteTok
 		string(models.OrgMemberRole),
 		createdUser.OrganisationID,
 	); policyAddErr != nil {
-		s.logger.Errorf("failed to add OrgMember policy for user: %s", policyAddErr.Error())
+		s.logger.Error(ctx, "failed to add OrgMember policy for user: %s", policyAddErr.Error())
 	}
 
 	return s.buildSignupResponse(ctx, createdUser)
@@ -148,7 +148,7 @@ func (s *signupService) buildSignupResponse(ctx context.Context, createdUser *mo
 	}
 	refreshToken, refreshErr := auth.CreateRefreshToken(ctx, s.refreshTokenStore, createdUser.ID)
 	if refreshErr != nil {
-		s.logger.Errorf("failed to create refresh token: %s", refreshErr.Error())
+		s.logger.Error(ctx, "failed to create refresh token: %s", refreshErr.Error())
 		return nil, errors.GeneralError("failed to generate refresh token")
 	}
 	return &openapi.UserSignupResponse{

--- a/pkg/services/stack_domain_service.go
+++ b/pkg/services/stack_domain_service.go
@@ -61,7 +61,7 @@ func (s *stackDomainService) InternalCreateWithTx(ctx context.Context, spec *mod
 	}
 	existing, err := s.domainsStore.GetByFqdn(ctx, spec.Fqdn)
 	if err != nil && err.Code != errors.ErrorNotFound {
-		s.logger.Errorf("failed to check if domain exists: %v", err)
+		s.logger.Error(ctx, "failed to check if domain exists: %v", err)
 		return nil, err
 	}
 	if existing != nil {
@@ -84,7 +84,7 @@ func (s *stackDomainService) InternalCreateWithTx(ctx context.Context, spec *mod
 	}
 	createdDomain, err := s.domainsStore.CreateWithTx(ctx, spec)
 	if err != nil {
-		s.logger.Errorf("failed to create domain: %v", err)
+		s.logger.Error(ctx, "failed to create domain: %v", err)
 		return nil, err
 	}
 	return createdDomain, nil
@@ -97,7 +97,7 @@ func (s *stackDomainService) InternalDeleteWithTx(ctx context.Context, id string
 func (s *stackDomainService) DomainToUseForStack(ctx context.Context, stack *models.Stack) (*models.OrganisationDomain, *errors.ServiceError) {
 	domains, err := s.organisationDomainStore.ListByOrganisationID(ctx, stack.OrganisationID)
 	if err != nil {
-		s.logger.Errorf("failed to list domains for organisation %s: %v", stack.OrganisationID, err)
+		s.logger.Error(ctx, "failed to list domains for organisation %s: %v", stack.OrganisationID, err)
 		return nil, err
 	}
 	if len(domains) == 0 {
@@ -210,7 +210,7 @@ func (s *stackDomainService) Create(ctx context.Context, spec *models.StackDomai
 	}
 	existing, err := s.domainsStore.GetByFqdn(ctx, spec.Fqdn)
 	if err != nil && err.Code != errors.ErrorNotFound {
-		s.logger.Errorf("failed to check if domain exists: %v", err)
+		s.logger.Error(ctx, "failed to check if domain exists: %v", err)
 		return nil, err
 	}
 	if !isValidDomain(spec.Fqdn) {

--- a/pkg/services/stack_release_service.go
+++ b/pkg/services/stack_release_service.go
@@ -182,6 +182,12 @@ func (s *stackReleaseService) createReleaseForStack(ctx context.Context, stack *
 	if err := s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, &models.StackRelease{ID: created.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue release: %s", err.Error())
 	}
+	s.logger.WithFields(map[string]interface{}{
+		logger.FieldStackID:   stack.ID,
+		logger.FieldReleaseID: created.ID,
+		"sequence":            created.Sequence,
+		"cause":               cause.Kind,
+	}).Info(ctx, "created release")
 	return created, nil
 }
 
@@ -258,6 +264,12 @@ func (s *stackReleaseService) RollbackRelease(ctx context.Context, stackID, from
 	if err := s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, &models.StackRelease{ID: created.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue release: %s", err.Error())
 	}
+	s.logger.WithFields(map[string]interface{}{
+		logger.FieldStackID:   stackID,
+		logger.FieldReleaseID: created.ID,
+		"sequence":            created.Sequence,
+		"rollback_from":       src.Sequence,
+	}).Info(ctx, "created rollback release")
 	return created, nil
 }
 
@@ -492,7 +504,7 @@ func (s *stackReleaseService) CancelRelease(ctx context.Context, releaseID strin
 	// The CAS win already persisted the cancellation; recording is best-effort.
 	rel.State = models.ReleaseStateCancelled
 	if recErr := s.eventRecorder.RecordReleaseTerminal(ctx, rel, models.ReleaseStateCancelled, releaseCancelledMessage); recErr != nil {
-		s.logger.Errorf("release %s: failed to record release_cancelled event: %v", rel.ID, recErr)
+		s.logger.Error(ctx, "release %s: failed to record release_cancelled event: %v", rel.ID, recErr)
 	}
 	return nil
 }
@@ -562,16 +574,16 @@ func (s *stackReleaseService) MarkFailedWithValidationErrors(ctx context.Context
 	}
 	rel, getErr := s.store.GetByID(ctx, id)
 	if getErr != nil {
-		s.logger.Errorf("release %s: failed to load release for failure events: %v", id, getErr)
+		s.logger.Error(ctx, "release %s: failed to load release for failure events: %v", id, getErr)
 		return true, nil
 	}
 	for _, verr := range verrs {
 		if recErr := s.eventRecorder.RecordReleaseCheckFailed(ctx, rel, verr.ResourceName, validationCheckKey(verr), verr.Message); recErr != nil {
-			s.logger.Errorf("release %s: failed to record release_check_failed event: %v", id, recErr)
+			s.logger.Error(ctx, "release %s: failed to record release_check_failed event: %v", id, recErr)
 		}
 	}
 	if recErr := s.eventRecorder.RecordReleaseTerminal(ctx, rel, models.ReleaseStateFailed, message); recErr != nil {
-		s.logger.Errorf("release %s: failed to record release_failed event: %v", id, recErr)
+		s.logger.Error(ctx, "release %s: failed to record release_failed event: %v", id, recErr)
 	}
 	return true, nil
 }
@@ -582,11 +594,11 @@ func (s *stackReleaseService) MarkFailedWithValidationErrors(ctx context.Context
 func (s *stackReleaseService) recordTerminalEvent(ctx context.Context, id string, state models.StackReleaseState, message string) {
 	rel, serr := s.store.GetByID(ctx, id)
 	if serr != nil {
-		s.logger.Errorf("release %s: failed to load release for %s event: %v", id, state, serr)
+		s.logger.Error(ctx, "release %s: failed to load release for %s event: %v", id, state, serr)
 		return
 	}
 	if recErr := s.eventRecorder.RecordReleaseTerminal(ctx, rel, state, message); recErr != nil {
-		s.logger.Errorf("release %s: failed to record %s event: %v", id, state, recErr)
+		s.logger.Error(ctx, "release %s: failed to record %s event: %v", id, state, recErr)
 	}
 }
 

--- a/pkg/services/stack_release_service_test.go
+++ b/pkg/services/stack_release_service_test.go
@@ -60,6 +60,7 @@ var _ = Describe("stackReleaseService.resolvePins", func() {
 		gitClients = NewMocksourceGitClientProvider(ctrl)
 		gitClient = mocks.NewMockGitClient(ctrl)
 		svc = &stackReleaseService{
+			logger:             logger.NewLogger(),
 			credentialResolver: credResolver,
 			gitClients:         gitClients,
 		}
@@ -211,6 +212,7 @@ var _ = Describe("stackReleaseService release creation records release_created",
 		recorder = NewMockReleaseEventRecorder(ctrl)
 		enqueuer = mocks.NewMockBackgroundJobEnqueuer(ctrl)
 		svc = &stackReleaseService{
+			logger:           logger.NewLogger(),
 			store:            releaseStore,
 			stackQuery:       stackSvc,
 			permissions:      perms,
@@ -399,6 +401,7 @@ var _ = Describe("stackReleaseService.ListReleaseEvents", func() {
 		perms = mocks.NewMockPermissionService(ctrl)
 		eventStore = mocks.NewMockReleaseEventStore(ctrl)
 		svc = &stackReleaseService{
+			logger:      logger.NewLogger(),
 			store:       releaseStore,
 			stackQuery:  stackSvc,
 			permissions: perms,
@@ -746,6 +749,7 @@ var _ = Describe("stackReleaseService.GetReleaseDetail", func() {
 		stackSvc = NewMockStackService(ctrl)
 		perms = mocks.NewMockPermissionService(ctrl)
 		svc = &stackReleaseService{
+			logger:      logger.NewLogger(),
 			store:       releaseStore,
 			stackQuery:  stackSvc,
 			permissions: perms,
@@ -809,7 +813,8 @@ var _ = Describe("stackReleaseService.InternalGetReleaseRefs", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		releaseStore = mocks.NewMockStackReleaseStore(ctrl)
 		svc = &stackReleaseService{
-			store: releaseStore,
+			logger: logger.NewLogger(),
+			store:  releaseStore,
 		}
 		ctx = context.Background()
 	})
@@ -876,6 +881,7 @@ var _ = Describe("stackReleaseService.StreamReleaseEvents", func() {
 		perms = mocks.NewMockPermissionService(ctrl)
 		eventStore = mocks.NewMockReleaseEventStore(ctrl)
 		svc = &stackReleaseService{
+			logger:      logger.NewLogger(),
 			store:       releaseStore,
 			stackQuery:  stackSvc,
 			permissions: perms,

--- a/pkg/services/stack_service.go
+++ b/pkg/services/stack_service.go
@@ -197,11 +197,11 @@ func (s *stackService) InternalCreateStack(ctx context.Context, spec *models.Sta
 		return nil, errors.Conflict("stack with name '%s' already exists", spec.Name)
 	}
 
-	s.logger.Infof("running validation for stack creation: %s", spec.Name)
+	s.logger.Info(ctx, "running validation for stack creation: %s", spec.Name)
 	if err := s.stackValidator.ValidateForCreate(ctx, spec); err != nil {
 		return nil, err
 	}
-	s.logger.Infof("validation passed for stack creation: %s", spec.Name)
+	s.logger.Info(ctx, "validation passed for stack creation: %s", spec.Name)
 
 	spec, _ = s.defaultingService.PopulateDefaultValues(spec)
 
@@ -240,6 +240,11 @@ func (s *stackService) InternalCreateStack(ctx context.Context, spec *models.Sta
 	for _, v := range createdStack.Volumes {
 		_ = s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, &models.Volume{ID: v.ID})
 	}
+	s.logger.WithFields(map[string]interface{}{
+		logger.FieldStackID:   createdStack.ID,
+		logger.FieldClusterID: createdStack.ClusterID,
+		"name":                createdStack.Name,
+	}).Info(ctx, "created stack")
 	return createdStack, nil
 }
 
@@ -343,6 +348,7 @@ func (s *stackService) InternalUpdateStack(ctx context.Context, ID string, spec 
 		}
 	}
 
+	s.logger.WithField(logger.FieldStackID, updatedStack.ID).Info(ctx, "updated stack")
 	return updatedStack, nil
 }
 
@@ -728,7 +734,7 @@ func (s *stackService) InternalDeleteStack(ctx context.Context, stack *models.St
 	if s.releaseService != nil {
 		if active, _ := s.releaseService.InternalGetActiveByStackID(ctx, stack.ID); active != nil {
 			if _, markErr := s.releaseService.MarkFailed(ctx, active.ID, "stack deleted", nil); markErr != nil {
-				s.logger.Errorf("failed to mark release '%s' failed for deleted stack '%s': %s", active.ID, stack.Name, markErr.Error())
+				s.logger.Error(ctx, "failed to mark release '%s' failed for deleted stack '%s': %s", active.ID, stack.Name, markErr.Error())
 			}
 		}
 	}
@@ -744,6 +750,7 @@ func (s *stackService) InternalDeleteStack(ctx context.Context, stack *models.St
 	}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue background job for stack '%s': %s", stack.Name, err.Error())
 	}
+	s.logger.WithField(logger.FieldStackID, stack.ID).Info(ctx, "marked stack for deletion")
 	return stackMarkedForDelete, nil
 }
 

--- a/pkg/services/stack_topology.go
+++ b/pkg/services/stack_topology.go
@@ -146,7 +146,7 @@ func (s *stackService) enrichExternalNodes(ctx context.Context, nodes map[string
 			addon, err := s.postgresAddonService.InternalGetPostgresAddon(ctx, node.Ref.Id)
 			if err != nil {
 				if err.Is404() {
-					s.logger.Warnf("postgres addon '%s' not found for topology, marking as missing", node.Ref.Id)
+					s.logger.Warn(ctx, "postgres addon '%s' not found for topology, marking as missing", node.Ref.Id)
 					node.State = "missing"
 					nodes[key] = node
 					continue
@@ -164,7 +164,7 @@ func (s *stackService) enrichExternalNodes(ctx context.Context, nodes map[string
 			secret, err := s.secretService.InternalGetByID(ctx, node.Ref.Id)
 			if err != nil {
 				if err.Is404() {
-					s.logger.Warnf("secret '%s' not found for topology, marking as missing", node.Ref.Id)
+					s.logger.Warn(ctx, "secret '%s' not found for topology, marking as missing", node.Ref.Id)
 					node.State = "missing"
 					nodes[key] = node
 					continue

--- a/pkg/services/team_service.go
+++ b/pkg/services/team_service.go
@@ -200,7 +200,7 @@ func (s *teamService) DeleteTeam(ctx context.Context, id string) *errors.Service
 	// Clean up Casbin policies using pre-fetched membership data
 	for _, membership := range memberships {
 		if rmErr := s.policyMgr.RemoveGroupingPolicy(membership.UserID, string(membership.Role), membership.TeamID); rmErr != nil {
-			s.logger.Errorf("failed to remove team role grouping: %s", rmErr.Error())
+			s.logger.Error(ctx, "failed to remove team role grouping: %s", rmErr.Error())
 		}
 	}
 
@@ -209,7 +209,7 @@ func (s *teamService) DeleteTeam(ctx context.Context, id string) *errors.Service
 	// If not, remove the OrgMember grouping for that user.
 	for _, membership := range memberships {
 		if err := s.cleanupOrgMemberGrouping(ctx, membership.UserID, team.OrganisationID); err != nil {
-			s.logger.Errorf("failed to cleanup org member grouping for user %s: %s", membership.UserID, err.Error())
+			s.logger.Error(ctx, "failed to cleanup org member grouping for user %s: %s", membership.UserID, err.Error())
 		}
 	}
 
@@ -306,12 +306,12 @@ func (s *teamService) InternalAddMember(ctx context.Context, teamID, userID stri
 	}
 
 	if err := s.policyMgr.AddGroupingPolicy(userID, string(role), teamID); err != nil {
-		s.logger.Errorf("failed to add team role grouping: %s", err.Error())
+		s.logger.Error(ctx, "failed to add team role grouping: %s", err.Error())
 		return nil, errors.InternalServerError("failed to add team role grouping")
 	}
 
 	if err := s.ensureOrgMemberGrouping(ctx, userID, team.OrganisationID); err != nil {
-		s.logger.Errorf("failed to ensure org member grouping: %s", err.Error())
+		s.logger.Error(ctx, "failed to ensure org member grouping: %s", err.Error())
 		return nil, err
 	}
 
@@ -364,12 +364,12 @@ func (s *teamService) AddMember(ctx context.Context, teamID, userID string, role
 	}
 
 	if err := s.policyMgr.AddGroupingPolicy(userID, string(role), teamID); err != nil {
-		s.logger.Errorf("failed to add team role grouping: %s", err.Error())
+		s.logger.Error(ctx, "failed to add team role grouping: %s", err.Error())
 		return nil, errors.InternalServerError("failed to add team role grouping")
 	}
 
 	if err := s.ensureOrgMemberGrouping(ctx, userID, team.OrganisationID); err != nil {
-		s.logger.Errorf("failed to ensure org member grouping: %s", err.Error())
+		s.logger.Error(ctx, "failed to ensure org member grouping: %s", err.Error())
 		return nil, err
 	}
 
@@ -394,12 +394,12 @@ func (s *teamService) RemoveMember(ctx context.Context, membershipID string) *er
 	}
 
 	if rmErr := s.policyMgr.RemoveGroupingPolicy(membership.UserID, string(membership.Role), membership.TeamID); rmErr != nil {
-		s.logger.Errorf("failed to remove team role grouping: %s", rmErr.Error())
+		s.logger.Error(ctx, "failed to remove team role grouping: %s", rmErr.Error())
 		return errors.InternalServerError("failed to remove team role grouping: %s", rmErr.Error())
 	}
 
 	if err := s.cleanupOrgMemberGrouping(ctx, membership.UserID, team.OrganisationID); err != nil {
-		s.logger.Errorf("failed to cleanup org member grouping: %s", err.Error())
+		s.logger.Error(ctx, "failed to cleanup org member grouping: %s", err.Error())
 		return errors.InternalServerError("failed to cleanup org member grouping")
 	}
 
@@ -429,12 +429,12 @@ func (s *teamService) UpdateMemberRole(ctx context.Context, membershipID string,
 	// Remove old grouping policy and add new one
 	err := s.policyMgr.RemoveGroupingPolicy(existing.UserID, string(existing.Role), existing.TeamID)
 	if err != nil {
-		s.logger.Errorf("failed to remove team role grouping: %s", err.Error())
+		s.logger.Error(ctx, "failed to remove team role grouping: %s", err.Error())
 		return nil, errors.InternalServerError("failed to remove team role grouping")
 	}
 
 	if err := s.policyMgr.AddGroupingPolicy(existing.UserID, string(role), existing.TeamID); err != nil {
-		s.logger.Errorf("failed to update team role grouping: %s", err.Error())
+		s.logger.Error(ctx, "failed to update team role grouping: %s", err.Error())
 		return nil, errors.InternalServerError("failed to update team role grouping")
 	}
 	return res, nil

--- a/pkg/services/user_service.go
+++ b/pkg/services/user_service.go
@@ -115,7 +115,7 @@ func (u usersService) GetUserFromContext(ctx context.Context) (*models.User, []*
 	}
 	memberships, membErr := u.teamService.InternalListUserTeams(ctx, user.ID, user.OrganisationID)
 	if membErr != nil {
-		u.logger.Errorf("failed to list user teams: %s", membErr.Error())
+		u.logger.Error(ctx, "failed to list user teams: %s", membErr.Error())
 	}
 	return user, memberships, nil
 }
@@ -172,7 +172,7 @@ func (u usersService) InternalCreateOAuthUser(ctx context.Context, email, name, 
 		string(models.OrgAdminRole),
 		createdUser.OrganisationID,
 	); policyErr != nil {
-		u.logger.Errorf("failed to add OrgAdmin policy for oauth user: %s", policyErr.Error())
+		u.logger.Error(ctx, "failed to add OrgAdmin policy for oauth user: %s", policyErr.Error())
 		return nil, fmt.Errorf("failed to add access policy: %w", policyErr)
 	}
 
@@ -181,7 +181,7 @@ func (u usersService) InternalCreateOAuthUser(ctx context.Context, email, name, 
 		string(models.OrgMemberRole),
 		createdUser.OrganisationID,
 	); policyErr != nil {
-		u.logger.Errorf("failed to add OrgMember policy for oauth user: %s", policyErr.Error())
+		u.logger.Error(ctx, "failed to add OrgMember policy for oauth user: %s", policyErr.Error())
 	}
 
 	return createdUser, nil
@@ -197,7 +197,7 @@ func (u usersService) InternalCreateInvitedUser(ctx context.Context, user *model
 	}
 
 	if _, teamErr := u.teamService.InternalAddMember(ctx, invite.TeamID, createdUser.ID, invite.TeamRole); teamErr != nil {
-		u.logger.Errorf("failed to add invited user to team: %s", teamErr.Error())
+		u.logger.Error(ctx, "failed to add invited user to team: %s", teamErr.Error())
 		return nil, errors.GeneralError("failed to add user to team")
 	}
 
@@ -220,7 +220,7 @@ func (u usersService) InternalCreateInvitedOAuthUser(ctx context.Context, email,
 	}
 
 	if _, teamErr := u.teamService.InternalAddMember(ctx, invite.TeamID, createdUser.ID, invite.TeamRole); teamErr != nil {
-		u.logger.Errorf("failed to add invited oauth user to team: %s", teamErr.Error())
+		u.logger.Error(ctx, "failed to add invited oauth user to team: %s", teamErr.Error())
 		return nil, fmt.Errorf("failed to add user to team: %w", teamErr)
 	}
 
@@ -237,7 +237,7 @@ func (u usersService) Login(ctx context.Context, loginRequest *openapi.LoginRequ
 		if stderrors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
 			return nil, errors.BadRequest("invalid email or password")
 		}
-		u.logger.Errorf("failed to login: %s", err.Error())
+		u.logger.Error(ctx, "failed to login: %s", err.Error())
 		return nil, errors.GeneralError("failed to login")
 	}
 	expirationTime := time.Now().UTC().Add(auth.JwtTokenExpiry)
@@ -250,13 +250,13 @@ func (u usersService) Login(ctx context.Context, loginRequest *openapi.LoginRequ
 
 	refreshToken, refreshErr := auth.CreateRefreshToken(ctx, u.refreshTokenStore, userInDB.ID)
 	if refreshErr != nil {
-		u.logger.Errorf("failed to create refresh token: %s", refreshErr.Error())
+		u.logger.Error(ctx, "failed to create refresh token: %s", refreshErr.Error())
 		return nil, errors.GeneralError("failed to generate refresh token")
 	}
 
 	memberships, membErr := u.teamService.InternalListUserTeams(ctx, userInDB.ID, userInDB.OrganisationID)
 	if membErr != nil {
-		u.logger.Errorf("failed to list user teams: %s", membErr.Error())
+		u.logger.Error(ctx, "failed to list user teams: %s", membErr.Error())
 		return nil, errors.GeneralError("failed to list user teams")
 	}
 

--- a/pkg/services/volume_service.go
+++ b/pkg/services/volume_service.go
@@ -76,7 +76,7 @@ func (s *volumeService) InjectClusterResourceService(volumeClusterService cluste
 func (s *volumeService) Get(ctx context.Context, ID string) (*models.Volume, *errors.ServiceError) {
 	volume, err := s.volumeStore.GetByID(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to get volume: %v", err)
+		s.logger.Error(ctx, "failed to get volume: %v", err)
 		return nil, err
 	}
 	if permErr := s.permissions.Check(ctx, volume.TeamID, auth.ResourceVolumes, ID, auth.ActionRead); permErr != nil {
@@ -92,7 +92,7 @@ func (s *volumeService) InternalGet(ctx context.Context, ID string) (*models.Vol
 func (s *volumeService) ListVolumesUsedByStack(ctx context.Context, stackID string) ([]*models.Volume, *errors.ServiceError) {
 	volumes, err := s.stackVolumeStore.ListVolumesByStackID(ctx, stackID)
 	if err != nil {
-		s.logger.Errorf("failed to list volumes used by stack: %v", err)
+		s.logger.Error(ctx, "failed to list volumes used by stack: %v", err)
 		return nil, err
 	}
 	return volumes, nil
@@ -138,7 +138,7 @@ func (s *volumeService) associateVolumeWithStackWithTx(ctx context.Context, volu
 func (s *volumeService) GetByVolumeNameAndNamespace(ctx context.Context, volumeName, namespace string) (*models.Volume, *errors.ServiceError) {
 	volume, err := s.volumeStore.GetByVolumeNameAndNamespace(ctx, volumeName, namespace)
 	if err != nil {
-		s.logger.Errorf("failed to get volume by name and namespace: %v", err)
+		s.logger.Error(ctx, "failed to get volume by name and namespace: %v", err)
 		return nil, err
 	}
 	if volume == nil {
@@ -153,7 +153,7 @@ func (s *volumeService) ListByUserID(ctx context.Context, teamID, userID string)
 	}
 	volumes, err := s.volumeStore.GetByUserID(ctx, userID)
 	if err != nil {
-		s.logger.Errorf("failed to list volumes by user ID: %v", err)
+		s.logger.Error(ctx, "failed to list volumes by user ID: %v", err)
 		return nil, err
 	}
 	return volumes, nil
@@ -162,7 +162,7 @@ func (s *volumeService) ListByUserID(ctx context.Context, teamID, userID string)
 func (s *volumeService) InternalList(ctx context.Context, ids []string) ([]*models.Volume, *errors.ServiceError) {
 	volumes, err := s.volumeStore.InternalList(ctx, ids)
 	if err != nil {
-		s.logger.Errorf("failed to list volumes: %v", err)
+		s.logger.Error(ctx, "failed to list volumes: %v", err)
 		return nil, err
 	}
 	return volumes, nil
@@ -171,7 +171,7 @@ func (s *volumeService) InternalList(ctx context.Context, ids []string) ([]*mode
 func (s *volumeService) InternalListNotReady(ctx context.Context) ([]*models.Volume, *errors.ServiceError) {
 	volumes, err := s.volumeStore.InternalListNotReady(ctx)
 	if err != nil {
-		s.logger.Errorf("failed to list not-ready volumes: %v", err)
+		s.logger.Error(ctx, "failed to list not-ready volumes: %v", err)
 		return nil, err
 	}
 	return volumes, nil
@@ -187,12 +187,12 @@ func (s *volumeService) UpdateGitRepoSourceRevision(ctx context.Context, ID stri
 	updateErr := s.volumeStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
 		updatedVolume, err = s.volumeStore.UpdateGitRepoSourceRevisionWithTx(ctx, ID, revision)
 		if err != nil {
-			s.logger.Errorf("failed to update volume git repo source revision: %v", err)
+			s.logger.Error(ctx, "failed to update volume git repo source revision: %v", err)
 			return err
 		}
 		cErr := s.clusterResourceService.UpdateVolumeGitRevisionInCluster(ctx, updatedVolume)
 		if cErr != nil {
-			s.logger.Errorf("failed to update volume git revision in cluster: %v", cErr)
+			s.logger.Error(ctx, "failed to update volume git revision in cluster: %v", cErr)
 			return errors.GeneralError("failed to update volume git revision in cluster: %s", cErr.Error())
 		}
 		return nil
@@ -213,13 +213,13 @@ func (s *volumeService) UpdateRemoteSourceRevision(ctx context.Context, ID strin
 	updateErr := s.volumeStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
 		updatedVolume, err = s.volumeStore.UpdateRemoteDirSourceHashWithTx(ctx, ID, revision.CurrentDirectoryHash)
 		if err != nil {
-			s.logger.Errorf("failed to update volume remote source revision: %v", err)
+			s.logger.Error(ctx, "failed to update volume remote source revision: %v", err)
 			return err
 		}
 
 		cErr := s.clusterResourceService.UpdateVolumeGitRevisionInCluster(ctx, updatedVolume)
 		if cErr != nil {
-			s.logger.Errorf("failed to update volume git revision in cluster: %v", cErr)
+			s.logger.Error(ctx, "failed to update volume git revision in cluster: %v", cErr)
 			return errors.GeneralError("failed to update volume git revision in cluster: %s", cErr.Error())
 		}
 		return nil
@@ -240,12 +240,12 @@ func (s *volumeService) Create(ctx context.Context, spec *models.Volume) (*model
 	createErr := s.volumeStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
 		createdVolume, err = s.volumeStore.CreateWithTx(ctx, spec)
 		if err != nil {
-			s.logger.Errorf("failed to create volume: %v", err)
+			s.logger.Error(ctx, "failed to create volume: %v", err)
 			return err
 		}
 		cerr := s.clusterResourceService.CreateVolumeInCluster(ctx, createdVolume)
 		if cerr != nil {
-			s.logger.Errorf("failed to create volume in cluster: %v", cerr)
+			s.logger.Error(ctx, "failed to create volume in cluster: %v", cerr)
 			return errors.GeneralError("failed to create volume in cluster: %s", cerr.Error())
 		}
 		return nil
@@ -263,12 +263,12 @@ func (s *volumeService) CreateWithTx(ctx context.Context, spec *models.Volume) (
 	var err *errors.ServiceError
 	createdVolume, err = s.volumeStore.CreateWithTx(ctx, spec)
 	if err != nil {
-		s.logger.Errorf("failed to create volume: %v", err)
+		s.logger.Error(ctx, "failed to create volume: %v", err)
 		return nil, err
 	}
 	cerr := s.clusterResourceService.CreateVolumeInCluster(ctx, createdVolume)
 	if cerr != nil {
-		s.logger.Errorf("failed to create volume in cluster: %v", cerr)
+		s.logger.Error(ctx, "failed to create volume in cluster: %v", cerr)
 		return nil, errors.GeneralError("failed to create volume in cluster: %s", cerr.Error())
 	}
 	return createdVolume, nil
@@ -277,16 +277,16 @@ func (s *volumeService) CreateWithTx(ctx context.Context, spec *models.Volume) (
 func (s *volumeService) CreateInCluster(ctx context.Context, spec *models.Volume) *errors.ServiceError {
 	volume, err := s.volumeStore.GetByID(ctx, spec.ID)
 	if err != nil {
-		s.logger.Errorf("failed to get volume for creation in cluster: %v", err)
+		s.logger.Error(ctx, "failed to get volume for creation in cluster: %v", err)
 		return err
 	}
 	if volume == nil {
-		s.logger.Errorf("volume not found for creation in cluster: %v", spec.ID)
+		s.logger.Error(ctx, "volume not found for creation in cluster: %v", spec.ID)
 		return errors.NotFound("volume not found")
 	}
 	cErr := s.clusterResourceService.CreateVolumeInCluster(ctx, volume)
 	if cErr != nil {
-		s.logger.Errorf("failed to create volume in cluster: %v", cErr)
+		s.logger.Error(ctx, "failed to create volume in cluster: %v", cErr)
 		return errors.GeneralError("failed to create volume in cluster: %s", cErr.Error())
 	}
 	return nil
@@ -297,7 +297,7 @@ func (s *volumeService) CreateInDbWithTx(ctx context.Context, spec *models.Volum
 	var err *errors.ServiceError
 	createdVolume, err = s.volumeStore.CreateWithTx(ctx, spec)
 	if err != nil {
-		s.logger.Errorf("failed to create volume: %v", err)
+		s.logger.Error(ctx, "failed to create volume: %v", err)
 		return nil, err
 	}
 	return createdVolume, nil
@@ -306,7 +306,7 @@ func (s *volumeService) CreateInDbWithTx(ctx context.Context, spec *models.Volum
 func (s *volumeService) UpdateStatus(ctx context.Context, ID string, status *models.VolumeStatus) *errors.ServiceError {
 	err := s.volumeStore.UpdateStatus(ctx, ID, status)
 	if err != nil {
-		s.logger.Errorf("failed to update volume status: %v", err)
+		s.logger.Error(ctx, "failed to update volume status: %v", err)
 		return err
 	}
 	return nil
@@ -315,7 +315,7 @@ func (s *volumeService) UpdateStatus(ctx context.Context, ID string, status *mod
 func (s *volumeService) Delete(ctx context.Context, ID string) *errors.ServiceError {
 	volume, err := s.volumeStore.GetByID(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to get volume for deletion: %v", err)
+		s.logger.Error(ctx, "failed to get volume for deletion: %v", err)
 		return err
 	}
 
@@ -333,18 +333,18 @@ func (s *volumeService) Delete(ctx context.Context, ID string) *errors.ServiceEr
 	deleteErr := s.volumeStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
 		cErr := s.clusterResourceService.DeleteVolumeInCluster(ctx, volume)
 		if cErr != nil {
-			s.logger.Errorf("failed to delete volume in cluster: %v", cErr)
+			s.logger.Error(ctx, "failed to delete volume in cluster: %v", cErr)
 			return errors.GeneralError("failed to delete volume in cluster: %s", cErr.Error())
 		}
 		err = s.volumeStore.DeleteWithTx(ctx, ID)
 		if err != nil {
-			s.logger.Errorf("failed to delete volume: %v", err)
+			s.logger.Error(ctx, "failed to delete volume: %v", err)
 			return err
 		}
 		return nil
 	})
 	if deleteErr != nil {
-		s.logger.Errorf("failed to delete volume: %v", deleteErr)
+		s.logger.Error(ctx, "failed to delete volume: %v", deleteErr)
 		return deleteErr
 	}
 
@@ -388,7 +388,7 @@ func (s *volumeService) InternalDeleteVolumesUsedByStackFromDB(ctx context.Conte
 func (s *volumeService) DeleteWithTx(ctx context.Context, ID string) *errors.ServiceError {
 	volume, err := s.volumeStore.GetByID(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to get volume for deletion: %v", err)
+		s.logger.Error(ctx, "failed to get volume for deletion: %v", err)
 		return err
 	}
 	inUse, refs, refErr := s.referenceService.IsReferentInUse(ctx, models.ReferentVolume, volume.ID)
@@ -401,12 +401,12 @@ func (s *volumeService) DeleteWithTx(ctx context.Context, ID string) *errors.Ser
 
 	cErr := s.clusterResourceService.DeleteVolumeInCluster(ctx, volume)
 	if cErr != nil {
-		s.logger.Errorf("failed to delete volume in cluster: %v", cErr)
+		s.logger.Error(ctx, "failed to delete volume in cluster: %v", cErr)
 		return errors.GeneralError("failed to delete volume in cluster: %s", cErr.Error())
 	}
 	err = s.volumeStore.DeleteWithTx(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to delete volume: %v", err)
+		s.logger.Error(ctx, "failed to delete volume: %v", err)
 		return err
 	}
 	return nil

--- a/pkg/services/workspace_user_service.go
+++ b/pkg/services/workspace_user_service.go
@@ -73,7 +73,7 @@ func (s *workspaceUserService) InjectClusterResourceService(clusterResourceServi
 func (s *workspaceUserService) GetByID(ctx context.Context, ID string) (*models.WorkspaceUser, *errors.ServiceError) {
 	request, err := s.workspaceUserStore.GetByID(ctx, ID)
 	if err != nil {
-		s.logger.Errorf("failed to get workspace user: %v", err)
+		s.logger.Error(ctx, "failed to get workspace user: %v", err)
 		return nil, err
 	}
 	if permErr := s.permissions.Check(ctx, request.TeamID, auth.ResourceWorkspaceUsers, ID, auth.ActionRead); permErr != nil {
@@ -89,7 +89,7 @@ func (s *workspaceUserService) InternalGetByID(ctx context.Context, ID string) (
 func (s *workspaceUserService) GetWorkspaceUser(ctx context.Context, userID string) (*models.WorkspaceUser, *errors.ServiceError) {
 	request, err := s.workspaceUserStore.GetByUserID(ctx, userID)
 	if err != nil {
-		s.logger.Errorf("failed to get workspace user: %v", err)
+		s.logger.Error(ctx, "failed to get workspace user: %v", err)
 		return nil, err
 	}
 	if permErr := s.permissions.Check(ctx, request.TeamID, auth.ResourceWorkspaceUsers, request.ID, auth.ActionRead); permErr != nil {
@@ -101,7 +101,7 @@ func (s *workspaceUserService) GetWorkspaceUser(ctx context.Context, userID stri
 func (s *workspaceUserService) InternalList(ctx context.Context, query string, args ...any) ([]*models.WorkspaceUser, *errors.ServiceError) {
 	requests, err := s.workspaceUserStore.InternalList(ctx, query, args...)
 	if err != nil {
-		s.logger.Errorf("failed to internal list workspace users: %v", err)
+		s.logger.Error(ctx, "failed to internal list workspace users: %v", err)
 		return nil, err
 	}
 	return requests, nil
@@ -116,7 +116,7 @@ func (s *workspaceUserService) Create(ctx context.Context, spec *models.Workspac
 	s.setNamespacesForCreate(spec, user)
 	cluster, serr := s.dbClusterService.GetClusterForOrg(ctx, user.OrganisationID)
 	if serr != nil {
-		s.logger.Errorf("failed to get cluster for org: %v", serr)
+		s.logger.Error(ctx, "failed to get cluster for org: %v", serr)
 		return nil, serr
 	}
 	spec.ClusterID = cluster.ID
@@ -140,7 +140,7 @@ func (s *workspaceUserService) Create(ctx context.Context, spec *models.Workspac
 func (s *workspaceUserService) Update(ctx context.Context, id string, spec *models.WorkspaceUser, user *models.User) (*models.WorkspaceUser, *errors.ServiceError) {
 	current, err := s.workspaceUserStore.GetByID(ctx, id)
 	if err != nil {
-		s.logger.Errorf("failed to get workspace user: %v", err)
+		s.logger.Error(ctx, "failed to get workspace user: %v", err)
 		return nil, err
 	}
 	if permErr := s.permissions.Check(ctx, current.TeamID, auth.ResourceWorkspaceUsers, id, auth.ActionWrite); permErr != nil {
@@ -149,7 +149,7 @@ func (s *workspaceUserService) Update(ctx context.Context, id string, spec *mode
 	s.setNamespacesForUpdate(spec, current, user)
 	cluster, serr := s.dbClusterService.GetClusterForOrg(ctx, user.OrganisationID)
 	if serr != nil {
-		s.logger.Errorf("failed to get cluster for org: %v", serr)
+		s.logger.Error(ctx, "failed to get cluster for org: %v", serr)
 		return nil, serr
 	}
 	spec.ClusterID = cluster.ID
@@ -158,10 +158,10 @@ func (s *workspaceUserService) Update(ctx context.Context, id string, spec *mode
 	updateErr := s.workspaceUserStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
 		updatedWorkspaceUser, serr = s.workspaceUserStore.UpdateWithTx(ctx, id, spec)
 		if serr != nil {
-			s.logger.Errorf("failed to update workspace user: %v", serr)
+			s.logger.Error(ctx, "failed to update workspace user: %v", serr)
 			return serr
 		}
-		s.logger.Infof("updated workspace user: %s", updatedWorkspaceUser.ID)
+		s.logger.Info(ctx, "updated workspace user: %s", updatedWorkspaceUser.ID)
 		if err := s.clusterResourceService.UpdateWorkspaceUserInCluster(ctx, updatedWorkspaceUser); err != nil {
 			return errors.GeneralError("failed to update workspace user in cluster: %s", err.Error())
 		}
@@ -173,7 +173,7 @@ func (s *workspaceUserService) Update(ctx context.Context, id string, spec *mode
 func (s *workspaceUserService) UpdateStatus(ctx context.Context, id string, WorkspaceUser *models.WorkspaceUser) *errors.ServiceError {
 	_, err := s.workspaceUserStore.PatchStatus(ctx, id, WorkspaceUser.Status)
 	if err != nil {
-		s.logger.Errorf("failed to update workspace user: %v", err)
+		s.logger.Error(ctx, "failed to update workspace user: %v", err)
 		return err
 	}
 	return nil
@@ -182,7 +182,7 @@ func (s *workspaceUserService) UpdateStatus(ctx context.Context, id string, Work
 func (s *workspaceUserService) InternalUpdate(ctx context.Context, id string, spec *models.WorkspaceUser) *errors.ServiceError {
 	_, err := s.workspaceUserStore.Update(ctx, id, spec)
 	if err != nil {
-		s.logger.Errorf("failed to update workspace user: %v", err)
+		s.logger.Error(ctx, "failed to update workspace user: %v", err)
 		return err
 	}
 	return nil
@@ -191,7 +191,7 @@ func (s *workspaceUserService) InternalUpdate(ctx context.Context, id string, sp
 func (s *workspaceUserService) InternalDelete(ctx context.Context, id string) *errors.ServiceError {
 	err := s.workspaceUserStore.Delete(ctx, id)
 	if err != nil {
-		s.logger.Errorf("failed to delete workspace user: %v", err)
+		s.logger.Error(ctx, "failed to delete workspace user: %v", err)
 		return err
 	}
 	return nil

--- a/pkg/stores/pgstore/workspace_user.go
+++ b/pkg/stores/pgstore/workspace_user.go
@@ -3,7 +3,6 @@ package pgstore
 import (
 	"context"
 	stderrors "errors"
-	"fmt"
 
 	"github.com/Stackdome/stackdome/pkg/db"
 	"github.com/Stackdome/stackdome/pkg/errors"
@@ -46,8 +45,6 @@ func (w *workspaceUserStore) CreateWithTx(ctx context.Context, spec *models.Work
 	for _, wn := range spec.WorkspaceNamespaces {
 		wn.UserID = spec.UserID
 		wn.WorkspaceUserID = spec.ID
-		fmt.Printf("setting workspace user id %s\n", wn.WorkspaceUserID)
-		fmt.Printf("setting user id %s\n", wn.UserID)
 	}
 	if _, err := w.workspaceNamespaceStore.CreateBatchWithTx(ctx, spec.WorkspaceNamespaces); err != nil {
 		return nil, err
@@ -226,7 +223,6 @@ func (w *workspaceUserStore) UpdateWithTx(ctx context.Context, id string, spec *
 	for _, currentWS := range spec.WorkspaceNamespaces {
 		if _, ok := existingWorkspaceMap[currentWS.Workspace]; !ok {
 			// New workspaces.
-			fmt.Printf("creating new workspace %s\n", currentWS.Workspace)
 			currentWS.UserID = existingObj.UserID
 			currentWS.WorkspaceUserID = existingObj.ID
 			if _, err := w.workspaceNamespaceStore.Create(ctx, currentWS); err != nil {
@@ -235,7 +231,6 @@ func (w *workspaceUserStore) UpdateWithTx(ctx context.Context, id string, spec *
 		} else {
 			existingWS := existingWorkspaceMap[currentWS.Workspace]
 			// Enable workspace namespace objects in the current patch.
-			fmt.Printf("enabling workspace %s\n", currentWS.Workspace)
 			currentWS.Enabled = true
 			if _, err := w.workspaceNamespaceStore.UpdateWithTx(ctx, existingWS.Workspace, existingWS.UserID, currentWS); err != nil {
 				return nil, err
@@ -247,7 +242,6 @@ func (w *workspaceUserStore) UpdateWithTx(ctx context.Context, id string, spec *
 	for workspaceName, existingWN := range existingWorkspaceMap {
 		if _, ok := currentWorkspaceMap[workspaceName]; !ok {
 			// Disable workspace namespace objects not in the current patch.
-			fmt.Printf("disabling workspace %s\n", workspaceName)
 			existingWN.Enabled = false
 			if _, err := w.workspaceNamespaceStore.UpdateWithTx(ctx, existingWN.Workspace, existingWN.UserID, existingWN); err != nil {
 				return nil, err

--- a/pkg/worker/invite/invite_cleanup_worker.go
+++ b/pkg/worker/invite/invite_cleanup_worker.go
@@ -44,7 +44,7 @@ func (w *inviteCleanupWorker) Interval() time.Duration {
 
 func (w *inviteCleanupWorker) GetInput(ctx context.Context) ([]worker.Operand, *errors.ServiceError) {
 	if w.leadershipFlag != nil && !w.leadershipFlag.Raised() {
-		w.Logger().Infof("Not the leader, invite cleanup worker will not run")
+		w.Logger().Info(ctx, "Not the leader, invite cleanup worker will not run")
 		return nil, nil
 	}
 
@@ -68,13 +68,13 @@ func (w *inviteCleanupWorker) Execute(ctx context.Context, operand worker.Operan
 	}
 	invites := batch.Items
 
-	w.Logger().Infof("Cleaning up %d expired invites", len(invites))
+	w.Logger().Info(ctx, "Cleaning up %d expired invites", len(invites))
 
 	if serr := w.inviteService.InternalMarkExpiredAndDelete(ctx, invites); serr != nil {
-		w.Logger().Errorf("failed to clean up expired invites: %s", serr.Error())
+		w.Logger().Error(ctx, "failed to clean up expired invites: %s", serr.Error())
 		return worker.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
 
-	w.Logger().Infof("Cleaned up %d expired invites", len(invites))
+	w.Logger().Info(ctx, "Cleaned up %d expired invites", len(invites))
 	return worker.Result{}, nil
 }

--- a/pkg/worker/invite/invite_worker.go
+++ b/pkg/worker/invite/invite_worker.go
@@ -44,7 +44,7 @@ func (w *inviteWorker) Interval() time.Duration {
 
 func (w *inviteWorker) GetInput(ctx context.Context) ([]worker.Operand, *errors.ServiceError) {
 	if w.leadershipFlag != nil && !w.leadershipFlag.Raised() {
-		w.Logger().Infof("Not the leader, invite email worker will not send emails")
+		w.Logger().Info(ctx, "Not the leader, invite email worker will not send emails")
 		return nil, nil
 	}
 
@@ -70,7 +70,7 @@ func (w *inviteWorker) Execute(ctx context.Context, operand worker.Operand) (wor
 	invite, serr := w.inviteService.InternalGetByID(ctx, id.ID)
 	if serr != nil {
 		if serr.Is404() {
-			w.Logger().Infof("Invite %s not found, skipping", id.ID)
+			w.Logger().Info(ctx, "Invite %s not found, skipping", id.ID)
 			return worker.Result{}, nil
 		}
 		return worker.Result{}, serr
@@ -82,9 +82,9 @@ func (w *inviteWorker) Execute(ctx context.Context, operand worker.Operand) (wor
 
 	rawToken, decErr := w.inviteService.InternalDecryptToken(ctx, invite.EncryptedToken)
 	if decErr != nil {
-		w.Logger().Errorf("failed to decrypt token for invite %s: %s", invite.ID, decErr.Error())
+		w.Logger().Error(ctx, "failed to decrypt token for invite %s: %s", invite.ID, decErr.Error())
 		if markErr := w.inviteService.InternalMarkEmailError(ctx, invite.ID, "failed to decrypt token"); markErr != nil {
-			w.Logger().Errorf("failed to mark email error for invite %s: %s", invite.ID, markErr.Error())
+			w.Logger().Error(ctx, "failed to mark email error for invite %s: %s", invite.ID, markErr.Error())
 		}
 		return worker.Result{}, nil
 	}
@@ -102,7 +102,7 @@ func (w *inviteWorker) Execute(ctx context.Context, operand worker.Operand) (wor
 		inviterName = invite.InvitedBy.Name
 	}
 
-	w.Logger().Infof("Sending invite email to %s for org %s", invite.Email, orgName)
+	w.Logger().Info(ctx, "Sending invite email to %s for org %s", invite.Email, orgName)
 
 	txErr := w.inviteService.InternalWithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
 		if markErr := w.inviteService.InternalMarkEmailSent(txCtx, invite.ID); markErr != nil {
@@ -121,13 +121,13 @@ func (w *inviteWorker) Execute(ctx context.Context, operand worker.Operand) (wor
 		return nil
 	})
 	if txErr != nil {
-		w.Logger().Errorf("failed to send invite email to %s: %s", invite.Email, txErr.Error())
+		w.Logger().Error(ctx, "failed to send invite email to %s: %s", invite.Email, txErr.Error())
 		if markErr := w.inviteService.InternalMarkEmailError(ctx, invite.ID, txErr.Error()); markErr != nil {
-			w.Logger().Errorf("failed to mark email error for invite %s: %s", invite.ID, markErr.Error())
+			w.Logger().Error(ctx, "failed to mark email error for invite %s: %s", invite.ID, markErr.Error())
 		}
 		return worker.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
 
-	w.Logger().Infof("Invite email sent to %s", invite.Email)
+	w.Logger().Info(ctx, "Invite email sent to %s", invite.Email)
 	return worker.Result{}, nil
 }

--- a/pkg/worker/postgresaddon/deprovision_reconciler.go
+++ b/pkg/worker/postgresaddon/deprovision_reconciler.go
@@ -41,11 +41,11 @@ func (r *deprovisionReconciler) Reconcile(ctx context.Context, addon *models.Pos
 		return resultNil, fmt.Errorf("failed to check addon usage: %w", err)
 	}
 	if inUse {
-		r.logger.Infof("Postgres addon '%s' is still in use by stacks, requeueing", addon.Name)
+		r.logger.Info(ctx, "Postgres addon '%s' is still in use by stacks, requeueing", addon.Name)
 		return resultRequeueAfter(30 * time.Second), nil
 	}
 
-	r.logger.Infof("Deprovisioning postgres addon '%s' in namespace '%s'", addon.Name, addon.Namespace)
+	r.logger.Info(ctx, "Deprovisioning postgres addon '%s' in namespace '%s'", addon.Name, addon.Namespace)
 
 	clusterClient, cerr := r.clusterManager.GetClient(addon.ClusterID)
 	if cerr != nil {
@@ -68,6 +68,6 @@ func (r *deprovisionReconciler) Reconcile(ctx context.Context, addon *models.Pos
 		return resultNil, fmt.Errorf("failed to delete postgres addon from DB: %w", serr)
 	}
 
-	r.logger.Infof("Successfully deprovisioned postgres addon '%s'", addon.Name)
+	r.logger.Info(ctx, "Successfully deprovisioned postgres addon '%s'", addon.Name)
 	return resultStop, nil
 }

--- a/pkg/worker/postgresaddon/image_catalog_reconciler.go
+++ b/pkg/worker/postgresaddon/image_catalog_reconciler.go
@@ -38,7 +38,7 @@ func (r *imageCatalogReconciler) Reconcile(ctx context.Context, addon *models.Po
 	key := client.ObjectKey{Name: builders.DefaultImageCatalogName, Namespace: addon.Namespace}
 	if err := clusterClient.Get(ctx, key, existing); err != nil {
 		if k8sapierrors.IsNotFound(err) {
-			r.logger.Infof("Creating ImageCatalog '%s' in namespace '%s'", builders.DefaultImageCatalogName, addon.Namespace)
+			r.logger.Info(ctx, "Creating ImageCatalog '%s' in namespace '%s'", builders.DefaultImageCatalogName, addon.Namespace)
 			catalog := &cnpgv1.ImageCatalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      builders.DefaultImageCatalogName,

--- a/pkg/worker/postgresaddon/namespace_reconciler.go
+++ b/pkg/worker/postgresaddon/namespace_reconciler.go
@@ -43,7 +43,7 @@ func (r *namespaceReconciler) Reconcile(ctx context.Context, addon *models.Postg
 	existingNamespace := &corev1.Namespace{}
 	if err := clusterClient.Get(ctx, client.ObjectKey{Name: namespace.Name}, existingNamespace); err != nil {
 		if k8sapierrors.IsNotFound(err) {
-			r.logger.Infof("Creating namespace '%s' in cluster", namespace.Name)
+			r.logger.Info(ctx, "Creating namespace '%s' in cluster", namespace.Name)
 			return resultNil, clusterClient.Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: namespace.Name},
 			})

--- a/pkg/worker/postgresaddon/objectstore_dependency_reconciler.go
+++ b/pkg/worker/postgresaddon/objectstore_dependency_reconciler.go
@@ -55,7 +55,7 @@ func (r *objectStoreDependencyReconciler) Reconcile(ctx context.Context, addon *
 		}
 	}
 
-	r.logger.Infof("Deploying ObjectStore '%s' to namespace '%s'", objectStore.Name, addon.Namespace)
+	r.logger.Info(ctx, "Deploying ObjectStore '%s' to namespace '%s'", objectStore.Name, addon.Namespace)
 
 	if err := r.ensureCredentialSecret(ctx, clusterClient, objectStore, addon.Namespace); err != nil {
 		return resultNil, fmt.Errorf("failed to ensure credential secret: %w", err)

--- a/pkg/worker/postgresaddon/postgres_addon_worker.go
+++ b/pkg/worker/postgresaddon/postgres_addon_worker.go
@@ -60,17 +60,17 @@ func (w *postgresAddonWorker) Execute(ctx context.Context, operand worker.Operan
 	addon, err := w.postgresAddonService.InternalGetPostgresAddon(ctx, addonRef.ID)
 	if err != nil {
 		if err.Is404() {
-			w.Logger().Infof("PostgresAddon %s not found, skipping", addonRef.ID)
+			w.Logger().Info(ctx, "PostgresAddon %s not found, skipping", addonRef.ID)
 			return worker.Result{}, nil
 		}
 		return worker.Result{}, err
 	}
 
-	w.Logger().Infof("Processing postgres addon: %s (%s)", addon.Name, addon.ID)
+	w.Logger().Info(ctx, "Processing postgres addon: %s (%s)", addon.Name, addon.ID)
 
 	res, reconcileErr := w.reconcile(ctx, addon)
 	if reconcileErr != nil {
-		w.Logger().Errorf("Failed to reconcile postgres addon %s: %v", addon.ID, reconcileErr)
+		w.Logger().Error(ctx, "Failed to reconcile postgres addon %s: %v", addon.ID, reconcileErr)
 		return worker.Result{}, w.WorkerError.NewError("failed to reconcile postgres addon %s: %v", addon.ID, reconcileErr)
 	}
 	return res, nil
@@ -78,7 +78,7 @@ func (w *postgresAddonWorker) Execute(ctx context.Context, operand worker.Operan
 
 func (w *postgresAddonWorker) reconcile(ctx context.Context, addon *models.PostgresAddon) (worker.Result, error) {
 	for _, sr := range w.subReconcilers {
-		w.Logger().Infof("Running sub-reconciler: %s for addon: %s", sr.Name(), addon.ID)
+		w.Logger().Info(ctx, "Running sub-reconciler: %s for addon: %s", sr.Name(), addon.ID)
 		result, err := sr.Reconcile(ctx, addon)
 		switch {
 		case err != nil:

--- a/pkg/worker/postgresaddon/postgres_cluster_reconciler.go
+++ b/pkg/worker/postgresaddon/postgres_cluster_reconciler.go
@@ -53,14 +53,14 @@ func (r *postgresClusterReconciler) Reconcile(ctx context.Context, addon *models
 	existingCR := &addonsv1alpha1.PostgresCluster{}
 	if err := clusterClient.Get(ctx, client.ObjectKeyFromObject(desiredCR), existingCR); err != nil {
 		if k8sapierrors.IsNotFound(err) {
-			r.logger.Infof("Creating PostgresCluster CR '%s' in namespace '%s'", desiredCR.Name, desiredCR.Namespace)
+			r.logger.Info(ctx, "Creating PostgresCluster CR '%s' in namespace '%s'", desiredCR.Name, desiredCR.Namespace)
 			return resultNil, clusterClient.Create(ctx, desiredCR)
 		}
 		return resultNil, fmt.Errorf("failed to get PostgresCluster CR: %w", err)
 	}
 
 	if !equality.Semantic.DeepEqual(existingCR.Spec, desiredCR.Spec) {
-		r.logger.Infof("Updating PostgresCluster CR '%s'", desiredCR.Name)
+		r.logger.Info(ctx, "Updating PostgresCluster CR '%s'", desiredCR.Name)
 		desiredCR.ResourceVersion = existingCR.ResourceVersion
 		return resultNil, clusterClient.Update(ctx, desiredCR)
 	}

--- a/pkg/worker/postgresaddon/secret_reconciler.go
+++ b/pkg/worker/postgresaddon/secret_reconciler.go
@@ -76,7 +76,7 @@ func (r *secretReconciler) Reconcile(ctx context.Context, addon *models.Postgres
 		Namespace: addon.Namespace,
 	}, existing); err != nil {
 		if k8sapierrors.IsNotFound(err) {
-			r.logger.Infof("Creating import password secret '%s'", secretName)
+			r.logger.Info(ctx, "Creating import password secret '%s'", secretName)
 			return resultNil, clusterClient.Create(ctx, k8sSecret)
 		}
 		return resultNil, fmt.Errorf("failed to get secret '%s': %w", secretName, err)

--- a/pkg/worker/preview/converge_reconciler.go
+++ b/pkg/worker/preview/converge_reconciler.go
@@ -55,7 +55,7 @@ func (r *convergeReconciler) Reconcile(ctx context.Context, preview *models.Prev
 		if _, sErr := r.previewStackStore.Update(ctx, preview); sErr != nil {
 			return resultNil, fmt.Errorf("failed to update preview status: %w", sErr)
 		}
-		r.logger.Infof("preview %s is ready", preview.ID)
+		r.logger.Info(ctx, "preview %s is ready", preview.ID)
 		return resultStop, nil
 
 	case models.ReleaseStateSuperseded:
@@ -72,7 +72,7 @@ func (r *convergeReconciler) Reconcile(ctx context.Context, preview *models.Prev
 		if _, sErr := r.previewStackStore.Update(ctx, preview); sErr != nil {
 			return resultNil, fmt.Errorf("failed to update preview status: %w", sErr)
 		}
-		r.logger.Infof("preview %s failed: %s", preview.ID, release.Message)
+		r.logger.Info(ctx, "preview %s failed: %s", preview.ID, release.Message)
 		return resultStop, nil
 
 	case models.ReleaseStateCancelled:
@@ -84,7 +84,7 @@ func (r *convergeReconciler) Reconcile(ctx context.Context, preview *models.Prev
 		if _, sErr := r.previewStackStore.Update(ctx, preview); sErr != nil {
 			return resultNil, fmt.Errorf("failed to update preview status: %w", sErr)
 		}
-		r.logger.Infof("preview %s cancelled", preview.ID)
+		r.logger.Info(ctx, "preview %s cancelled", preview.ID)
 		return resultStop, nil
 
 	default:

--- a/pkg/worker/preview/deprovision_reconciler.go
+++ b/pkg/worker/preview/deprovision_reconciler.go
@@ -64,10 +64,10 @@ func (r *deprovisionReconciler) deletePreviewRecord(ctx context.Context, preview
 	if key, ok := r.previewCacheKeys.LoadAndDelete(preview.ID); ok {
 		r.stackfileCache.Delete(key.(string))
 	}
-	r.logger.Infof("preview %s: cleaning up record", preview.ID)
+	r.logger.Info(ctx, "preview %s: cleaning up record", preview.ID)
 	if sErr := r.previewStackStore.Delete(ctx, preview.ID); sErr != nil {
 		return resultNil, fmt.Errorf("failed to delete preview record %s: %w", preview.ID, sErr)
 	}
-	r.logger.Infof("preview %s deprovisioned", preview.ID)
+	r.logger.Info(ctx, "preview %s deprovisioned", preview.ID)
 	return resultStop, nil
 }

--- a/pkg/worker/preview/preview_worker.go
+++ b/pkg/worker/preview/preview_worker.go
@@ -56,7 +56,7 @@ func (w *previewWorker) Execute(ctx context.Context, operand worker.Operand) (wo
 	preview, serr := w.previewStackStore.GetByID(ctx, previewRef.ID)
 	if serr != nil {
 		if serr.Is404() {
-			w.Logger().Infof("preview %s not found, skipping", previewRef.ID)
+			w.Logger().Info(ctx, "preview %s not found, skipping", previewRef.ID)
 			return worker.Result{}, nil
 		}
 		return worker.Result{}, serr
@@ -66,11 +66,11 @@ func (w *previewWorker) Execute(ctx context.Context, operand worker.Operand) (wo
 		return worker.Result{}, nil
 	}
 
-	w.Logger().Infof("processing preview %s (phase=%s)", preview.ID, preview.Status.Phase)
+	w.Logger().Info(ctx, "processing preview %s (phase=%s)", preview.ID, preview.Status.Phase)
 
 	res, reconcileErr := w.reconcile(ctx, preview)
 	if reconcileErr != nil {
-		w.Logger().Errorf("failed to reconcile preview %s: %v", preview.ID, reconcileErr)
+		w.Logger().Error(ctx, "failed to reconcile preview %s: %v", preview.ID, reconcileErr)
 		return worker.Result{}, w.WorkerError.NewError("failed to reconcile preview %s: %v", preview.ID, reconcileErr)
 	}
 
@@ -79,7 +79,7 @@ func (w *previewWorker) Execute(ctx context.Context, operand worker.Operand) (wo
 
 func (w *previewWorker) reconcile(ctx context.Context, preview *models.PreviewStack) (worker.Result, error) {
 	for _, sr := range w.subReconcilers {
-		w.Logger().Infof("running sub-reconciler: %s for preview: %s", sr.Name(), preview.ID)
+		w.Logger().Info(ctx, "running sub-reconciler: %s for preview: %s", sr.Name(), preview.ID)
 		result, err := sr.Reconcile(ctx, preview)
 		switch {
 		case err != nil:

--- a/pkg/worker/preview/provision_reconciler.go
+++ b/pkg/worker/preview/provision_reconciler.go
@@ -161,7 +161,7 @@ func (r *provisionReconciler) Reconcile(ctx context.Context, preview *models.Pre
 		return resultNil, fmt.Errorf("provision transaction failed: %w", txErr)
 	}
 
-	r.logger.Infof("preview %s provisioned, stack %s created", preview.ID, created.ID)
+	r.logger.Info(ctx, "preview %s provisioned, stack %s created", preview.ID, created.ID)
 	return resultRequeueAfter(convergePollInterval), nil
 }
 
@@ -226,6 +226,6 @@ func (r *provisionReconciler) fail(ctx context.Context, preview *models.PreviewS
 	if _, sErr := r.previewStackStore.Update(ctx, preview); sErr != nil {
 		return resultNil, fmt.Errorf("failed to mark preview %s as failed: %w", preview.ID, sErr)
 	}
-	r.logger.Errorf("preview %s failed: %s: %s", preview.ID, reason, message)
+	r.logger.Error(ctx, "preview %s failed: %s: %s", preview.ID, reason, message)
 	return resultStop, nil
 }

--- a/pkg/worker/release/apply.go
+++ b/pkg/worker/release/apply.go
@@ -112,7 +112,7 @@ func (r *applyReconciler) Reconcile(ctx context.Context, release *models.StackRe
 
 	if err := r.syncHubSecrets(ctx, clusterClient, effectiveStack); err != nil {
 		if isTransientClusterError(err) {
-			r.logger.Warnf("release %s: transient error syncing hub secrets, requeueing: %v", release.ID, err)
+			r.logger.Warn(ctx, "release %s: transient error syncing hub secrets, requeueing: %v", release.ID, err)
 			return resultRequeueAfter(convergencePollInterval), nil
 		}
 		return resultNil, fmt.Errorf("failed to sync hub secrets: %w", err)
@@ -120,7 +120,7 @@ func (r *applyReconciler) Reconcile(ctx context.Context, release *models.StackRe
 
 	if err := r.syncPostgresCredentialSecrets(ctx, clusterClient, effectiveStack); err != nil {
 		if isTransientClusterError(err) {
-			r.logger.Warnf("release %s: transient error syncing postgres secrets, requeueing: %v", release.ID, err)
+			r.logger.Warn(ctx, "release %s: transient error syncing postgres secrets, requeueing: %v", release.ID, err)
 			return resultRequeueAfter(convergencePollInterval), nil
 		}
 		return resultNil, fmt.Errorf("failed to sync postgres credential secrets: %w", err)
@@ -128,7 +128,7 @@ func (r *applyReconciler) Reconcile(ctx context.Context, release *models.StackRe
 
 	if err := r.syncGenericSecrets(ctx, clusterClient, effectiveStack); err != nil {
 		if isTransientClusterError(err) {
-			r.logger.Warnf("release %s: transient error syncing generic secrets, requeueing: %v", release.ID, err)
+			r.logger.Warn(ctx, "release %s: transient error syncing generic secrets, requeueing: %v", release.ID, err)
 			return resultRequeueAfter(convergencePollInterval), nil
 		}
 		return resultNil, fmt.Errorf("failed to sync generic secrets: %w", err)
@@ -149,7 +149,7 @@ func (r *applyReconciler) Reconcile(ctx context.Context, release *models.StackRe
 			return resultStop, nil
 		}
 		if isTransient(err) {
-			r.logger.Warnf("release %s: transient error applying stack CR, requeueing: %v", release.ID, err)
+			r.logger.Warn(ctx, "release %s: transient error applying stack CR, requeueing: %v", release.ID, err)
 			return resultRequeueAfter(convergencePollInterval), nil
 		}
 		failRelease(ctx, r.releaseService, r.logger, release, fmt.Sprintf("failed to apply stack CR: %v", err))
@@ -157,7 +157,7 @@ func (r *applyReconciler) Reconcile(ctx context.Context, release *models.StackRe
 	}
 	if err := r.applyStackResourceCRs(ctx, clusterClient, release, stackCR); err != nil {
 		if isTransient(err) {
-			r.logger.Warnf("release %s: transient error applying resource CRs, requeueing: %v", release.ID, err)
+			r.logger.Warn(ctx, "release %s: transient error applying resource CRs, requeueing: %v", release.ID, err)
 			return resultRequeueAfter(convergencePollInterval), nil
 		}
 		failRelease(ctx, r.releaseService, r.logger, release, fmt.Sprintf("failed to apply stack resource CRs: %v", err))
@@ -165,7 +165,7 @@ func (r *applyReconciler) Reconcile(ctx context.Context, release *models.StackRe
 	}
 
 	if err := r.pruneStackResources(ctx, clusterClient, stack, release.Manifest.ResourceNames); err != nil {
-		r.logger.Errorf("release %s: prune error (non-fatal): %v", release.ID, err)
+		r.logger.Error(ctx, "release %s: prune error (non-fatal): %v", release.ID, err)
 	}
 
 	return resultNil, nil
@@ -193,7 +193,7 @@ func (r *applyReconciler) supersededByClusterCR(ctx context.Context, existing *c
 	if _, err := r.releaseService.MarkSuperseded(ctx, release.ID, reason); err != nil {
 		return false, fmt.Errorf("failed to mark release superseded: %w", err)
 	}
-	r.logger.Infof("release %s: %s", release.ID, reason)
+	r.logger.Info(ctx, "release %s: %s", release.ID, reason)
 	return true, nil
 }
 
@@ -233,7 +233,7 @@ func (r *applyReconciler) applyStackCR(ctx context.Context, clusterClient client
 		return desired, nil
 	}
 
-	r.logger.Infof("stack CR '%s': updating", desired.Name)
+	r.logger.Info(ctx, "stack CR '%s': updating", desired.Name)
 	desired.ResourceVersion = existing.ResourceVersion
 	if err := clusterClient.Update(ctx, desired); err != nil {
 		return nil, wrapIfTransient(fmt.Errorf("failed to update stack CR: %w", err))
@@ -275,7 +275,7 @@ func (r *applyReconciler) applyStackResourceCRs(ctx context.Context, clusterClie
 				if err := clusterClient.Create(ctx, desired); err != nil {
 					return wrapIfTransient(fmt.Errorf("failed to create StackResource CR '%s': %w", name, err))
 				}
-				r.logger.Infof("resource '%s': created", name)
+				r.logger.Info(ctx, "resource '%s': created", name)
 				continue
 			}
 			return wrapIfTransient(fmt.Errorf("failed to get StackResource CR '%s': %w", name, err))
@@ -287,7 +287,7 @@ func (r *applyReconciler) applyStackResourceCRs(ctx context.Context, clusterClie
 			continue
 		}
 
-		r.logger.Infof("resource '%s': updating", name)
+		r.logger.Info(ctx, "resource '%s': updating", name)
 		desired.ResourceVersion = existing.ResourceVersion
 		if err := clusterClient.Update(ctx, desired); err != nil {
 			return wrapIfTransient(fmt.Errorf("failed to update StackResource CR '%s': %w", name, err))
@@ -312,7 +312,7 @@ func (r *applyReconciler) pruneStackResources(ctx context.Context, clusterClient
 	for i := range srList.Items {
 		resourceName := srList.Items[i].Labels[corev1alpha1.LabelResourceName]
 		if _, keep := activeSet[resourceName]; !keep {
-			r.logger.Infof("pruning orphaned StackResource CR '%s'", srList.Items[i].Name)
+			r.logger.Info(ctx, "pruning orphaned StackResource CR '%s'", srList.Items[i].Name)
 			if err := clusterClient.Delete(ctx, &srList.Items[i], client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
 				if k8sapierrors.IsNotFound(err) {
 					continue

--- a/pkg/worker/release/apply_secrets.go
+++ b/pkg/worker/release/apply_secrets.go
@@ -335,8 +335,8 @@ func createOrUpdateSecret(ctx context.Context, clusterClient client.Client, desi
 }
 
 func failRelease(ctx context.Context, svc releaseService, log logger.Logger, release *models.StackRelease, msg string) {
-	log.Errorf("release %s failed: %s", release.ID, msg)
+	log.Error(ctx, "release %s failed: %s", release.ID, msg)
 	if _, err := svc.MarkFailed(ctx, release.ID, msg, nil); err != nil {
-		log.Errorf("failed to mark release %s as failed: %v", release.ID, err)
+		log.Error(ctx, "failed to mark release %s as failed: %v", release.ID, err)
 	}
 }

--- a/pkg/worker/release/converge.go
+++ b/pkg/worker/release/converge.go
@@ -48,7 +48,7 @@ func (r *convergeReconciler) Reconcile(ctx context.Context, release *models.Stac
 				return resultNil, fmt.Errorf("failed to mark released: %w", markErr)
 			}
 			if ok {
-				r.logger.Infof("release %s converged", release.ID)
+				r.logger.Info(ctx, "release %s converged", release.ID)
 			}
 			return resultStop, nil
 		}
@@ -61,7 +61,7 @@ func (r *convergeReconciler) Reconcile(ctx context.Context, release *models.Stac
 		if _, markErr := r.releaseService.MarkFailed(ctx, release.ID, msg, &outcome); markErr != nil {
 			return resultNil, fmt.Errorf("failed to mark failed: %w", markErr)
 		}
-		r.logger.Errorf("release %s: %s", release.ID, msg)
+		r.logger.Error(ctx, "release %s: %s", release.ID, msg)
 		return resultStop, nil
 	}
 

--- a/pkg/worker/release/gatekeeper_reconciler.go
+++ b/pkg/worker/release/gatekeeper_reconciler.go
@@ -38,7 +38,7 @@ func (r *gatekeeperReconciler) Reconcile(ctx context.Context, release *models.St
 		if _, err := r.releaseService.MarkSuperseded(ctx, release.ID, reason); err != nil {
 			return resultNil, fmt.Errorf("failed to mark release superseded: %w", err)
 		}
-		r.logger.Infof("release %s: %s", release.ID, reason)
+		r.logger.Info(ctx, "release %s: %s", release.ID, reason)
 		return resultStop, nil
 	}
 
@@ -48,12 +48,12 @@ func (r *gatekeeperReconciler) Reconcile(ctx context.Context, release *models.St
 			return resultNil, fmt.Errorf("failed to mark in progress: %w", serr)
 		}
 		if !ok {
-			r.logger.Infof("release %s: CAS Pending→InProgress failed", release.ID)
+			r.logger.Info(ctx, "release %s: CAS Pending→InProgress failed", release.ID)
 			return resultStop, nil
 		}
 		release.State = models.ReleaseStateInProgress
 		if recErr := r.eventRecorder.RecordReleaseStarted(ctx, release); recErr != nil {
-			r.logger.Errorf("release %s: failed to record release_started event: %v", release.ID, recErr)
+			r.logger.Error(ctx, "release %s: failed to record release_started event: %v", release.ID, recErr)
 		}
 	}
 

--- a/pkg/worker/release/release_worker.go
+++ b/pkg/worker/release/release_worker.go
@@ -77,7 +77,7 @@ func (w *releaseWorker) Execute(ctx context.Context, operand worker.Operand) (wo
 	release, serr := w.releaseService.InternalGet(ctx, releaseRef.ID)
 	if serr != nil {
 		if serr.Is404() {
-			w.Logger().Infof("release %s not found, skipping", releaseRef.ID)
+			w.Logger().Info(ctx, "release %s not found, skipping", releaseRef.ID)
 			return worker.Result{}, nil
 		}
 		return worker.Result{}, serr
@@ -87,11 +87,11 @@ func (w *releaseWorker) Execute(ctx context.Context, operand worker.Operand) (wo
 		return worker.Result{}, nil
 	}
 
-	w.Logger().Infof("processing release %s (stack=%s, state=%s)", release.ID, release.StackID, release.State)
+	w.Logger().Info(ctx, "processing release %s (stack=%s, state=%s)", release.ID, release.StackID, release.State)
 
 	res, reconcileErr := w.reconcile(ctx, release)
 	if reconcileErr != nil {
-		w.Logger().Errorf("failed to reconcile release %s: %v", release.ID, reconcileErr)
+		w.Logger().Error(ctx, "failed to reconcile release %s: %v", release.ID, reconcileErr)
 		return worker.Result{}, w.WorkerError.NewError("failed to reconcile release %s: %v", release.ID, reconcileErr)
 	}
 
@@ -99,7 +99,7 @@ func (w *releaseWorker) Execute(ctx context.Context, operand worker.Operand) (wo
 		updated, _ := w.releaseService.InternalGet(ctx, releaseRef.ID)
 		if updated != nil && updated.State.Terminal() {
 			if err := w.releaseWorkerEnqueuer.Enqueue(&releasegc.ReleaseGCRequest{StackID: updated.StackID}); err != nil {
-				w.Logger().Errorf("failed to enqueue release GC for stack %s: %v", updated.StackID, err)
+				w.Logger().Error(ctx, "failed to enqueue release GC for stack %s: %v", updated.StackID, err)
 			}
 		}
 	}
@@ -109,7 +109,7 @@ func (w *releaseWorker) Execute(ctx context.Context, operand worker.Operand) (wo
 
 func (w *releaseWorker) reconcile(ctx context.Context, release *models.StackRelease) (worker.Result, error) {
 	for _, sr := range w.subReconcilers {
-		w.Logger().Infof("running sub-reconciler: %s for release: %s", sr.Name(), release.ID)
+		w.Logger().Info(ctx, "running sub-reconciler: %s for release: %s", sr.Name(), release.ID)
 		result, err := sr.Reconcile(ctx, release)
 		switch {
 		case err != nil:

--- a/pkg/worker/release/render.go
+++ b/pkg/worker/release/render.go
@@ -44,7 +44,7 @@ func (r *renderReconciler) Reconcile(ctx context.Context, release *models.StackR
 	if err != nil {
 		var depErr stackdeploy.DependencyNotReadyError
 		if isNotReady(err, &depErr) {
-			r.logger.Infof("release %s: dependency not ready, requeueing: %s", release.ID, depErr.Message)
+			r.logger.Info(ctx, "release %s: dependency not ready, requeueing: %s", release.ID, depErr.Message)
 			return resultRequeueAfter(convergencePollInterval), nil
 		}
 		failRelease(ctx, r.releaseService, r.logger, release, fmt.Sprintf("render failed: %v", err))
@@ -107,12 +107,12 @@ func (r *renderReconciler) Reconcile(ctx context.Context, release *models.StackR
 		return resultNil, fmt.Errorf("failed to save manifest: %w", serr)
 	}
 	if !ok {
-		r.logger.Infof("release %s: SaveManifest CAS failed", release.ID)
+		r.logger.Info(ctx, "release %s: SaveManifest CAS failed", release.ID)
 		return resultStop, nil
 	}
 
 	if sErr := r.stackService.UpdateStackCrRevision(ctx, release.StackID, manifestRevision); sErr != nil {
-		r.logger.Errorf("failed to update stack CrRevision: %v", sErr)
+		r.logger.Error(ctx, "failed to update stack CrRevision: %v", sErr)
 	}
 
 	return resultRequeue, nil

--- a/pkg/worker/release/simulator_reconciler.go
+++ b/pkg/worker/release/simulator_reconciler.go
@@ -32,7 +32,7 @@ func (r *simulatorReconciler) Reconcile(ctx context.Context, release *models.Sta
 	}
 
 	if r.env != config.EnvironmentTest {
-		r.logger.Errorf("release %s: simulation annotations are only allowed in test environments, ignoring", release.ID)
+		r.logger.Error(ctx, "release %s: simulation annotations are only allowed in test environments, ignoring", release.ID)
 		return resultNil, nil
 	}
 
@@ -58,6 +58,6 @@ func (r *simulatorReconciler) Reconcile(ctx context.Context, release *models.Sta
 		return resultNil, fmt.Errorf("unsupported simulated release state: %s", targetState)
 	}
 
-	r.logger.Infof("simulated release %s → %s (skip-cluster-provisioning)", release.ID, targetState)
+	r.logger.Info(ctx, "simulated release %s → %s (skip-cluster-provisioning)", release.ID, targetState)
 	return resultStop, nil
 }

--- a/pkg/worker/release/validation_reconciler.go
+++ b/pkg/worker/release/validation_reconciler.go
@@ -62,7 +62,7 @@ func (r *validationReconciler) Reconcile(ctx context.Context, release *models.St
 	// requeue that re-enters here re-calls harmlessly. Log-only on error: the
 	// validation outcome is authoritative, not the event trail.
 	if recErr := r.eventRecorder.RecordReleaseChecksStarted(ctx, release); recErr != nil {
-		r.logger.Errorf("release %s: failed to record release_checks_started event: %v", release.ID, recErr)
+		r.logger.Error(ctx, "release %s: failed to record release_checks_started event: %v", release.ID, recErr)
 	}
 
 	var verrs models.ReleaseValidationErrors
@@ -92,7 +92,7 @@ func (r *validationReconciler) Reconcile(ctx context.Context, release *models.St
 	// checks_passed until a later re-entry verifies it.
 	if !anyRateLimited {
 		if recErr := r.eventRecorder.RecordReleaseChecksPassed(ctx, release); recErr != nil {
-			r.logger.Errorf("release %s: failed to record release_checks_passed event: %v", release.ID, recErr)
+			r.logger.Error(ctx, "release %s: failed to record release_checks_passed event: %v", release.ID, recErr)
 		}
 	}
 	return resultNil, nil
@@ -159,7 +159,7 @@ func (r *validationReconciler) checkImagePull(ctx context.Context, release *mode
 		// most likely deploy fine. Warn and skip the check so the release
 		// proceeds; no success fingerprint is recorded since nothing was
 		// verified. The skip is reported so checks_passed is withheld.
-		r.logger.Warnf("release %s: resource %s: registry rate limited while checking image '%s'; skipping check", release.ID, res.Name, imageRef)
+		r.logger.Warn(ctx, "release %s: resource %s: registry rate limited while checking image '%s'; skipping check", release.ID, res.Name, imageRef)
 		return nil, true, nil
 	case stderrors.Is(err, clients.ErrAuthFailed) && resolved.Source == credentials.SourceAnonymous:
 		// No credentials were resolved for this registry and it rejects
@@ -223,7 +223,7 @@ func (r *validationReconciler) checkPushAccess(ctx context.Context, release *mod
 		// Same rationale as checkImagePull: skip instead of requeueing so a
 		// registry rate limit cannot hang the release to deploy timeout. The
 		// skip is reported so checks_passed is withheld.
-		r.logger.Warnf("release %s: resource %s: registry rate limited while checking push access to '%s'; skipping check", release.ID, res.Name, pushRef)
+		r.logger.Warn(ctx, "release %s: resource %s: registry rate limited while checking push access to '%s'; skipping check", release.ID, res.Name, pushRef)
 		return nil, true, nil
 	case stderrors.Is(err, clients.ErrAuthFailed) && resolved.Source == credentials.SourceAnonymous:
 		// Same distinction as checkImagePull: pushing without any resolved
@@ -259,7 +259,7 @@ func (r *validationReconciler) rememberSuccess(ctx context.Context, stackID, res
 		StackID: stackID, ResourceName: resourceName, CheckKind: kind,
 		Fingerprint: fingerprint, ValidatedAt: time.Now().UTC(),
 	}); serr != nil {
-		r.logger.Warnf("failed to record validation success for %s/%s: %v", stackID, resourceName, serr)
+		r.logger.Warn(ctx, "failed to record validation success for %s/%s: %v", stackID, resourceName, serr)
 	}
 }
 

--- a/pkg/worker/releasegc/release_gc_worker.go
+++ b/pkg/worker/releasegc/release_gc_worker.go
@@ -84,7 +84,7 @@ func (w *releaseGCWorker) Execute(ctx context.Context, operand worker.Operand) (
 		return worker.Result{}, w.WorkerError.NewError("failed to delete releases for stack %s: %v", req.StackID, err)
 	}
 
-	w.Logger().Infof("GC completed for stack %s: deleted %d of %d terminal releases", req.StackID, len(toDelete), len(candidates))
+	w.Logger().Info(ctx, "GC completed for stack %s: deleted %d of %d terminal releases", req.StackID, len(toDelete), len(candidates))
 	return worker.Result{}, nil
 }
 

--- a/pkg/worker/stack/deprovision_reconciler.go
+++ b/pkg/worker/stack/deprovision_reconciler.go
@@ -58,15 +58,20 @@ func (r *deprovisionReconciler) Reconcile(ctx context.Context, stack *models.Sta
 		return resultNil, nil
 	}
 
-	r.logger.Infof("deprovisioning stack '%s' in namespace '%s'", stack.Name, stack.Namespace)
+	log := r.logger.WithFields(map[string]interface{}{
+		logger.FieldStackID:   stack.ID,
+		logger.FieldClusterID: stack.ClusterID,
+	})
+
+	log.Info(ctx, "deprovisioning stack '%s' in namespace '%s'", stack.Name, stack.Namespace)
 	if err := r.deleteClusterResources(ctx, stack); err != nil {
 		return resultNil, fmt.Errorf("failed to delete cluster resources for stack '%s': %w", stack.Name, err)
 	}
-	r.logger.Infof("deleted cluster resources for stack '%s' in namespace '%s'", stack.Name, stack.Namespace)
+	log.Info(ctx, "deleted cluster resources for stack '%s' in namespace '%s'", stack.Name, stack.Namespace)
 	if err := r.deleteResourcesFromDB(ctx, stack); err != nil {
 		return resultNil, fmt.Errorf("failed to delete resources from db for stack '%s': %w", stack.Name, err)
 	}
-	r.logger.Infof("deleted resources from db for stack '%s' in namespace '%s'", stack.Name, stack.Namespace)
+	log.Info(ctx, "deleted resources from db for stack '%s' in namespace '%s'", stack.Name, stack.Namespace)
 	return resultStop, nil
 }
 
@@ -86,6 +91,8 @@ func (r *deprovisionReconciler) deleteResourcesFromDB(ctx context.Context, stack
 }
 
 func (r *deprovisionReconciler) deleteClusterResources(ctx context.Context, stack *models.Stack) error {
+	log := r.logger.WithField(logger.FieldStackID, stack.ID)
+
 	clusterClient, cerr := r.clusterManager.GetClient(stack.ClusterID)
 	if cerr != nil {
 		return cerr
@@ -98,6 +105,7 @@ func (r *deprovisionReconciler) deleteClusterResources(ctx context.Context, stac
 			Namespace: stack.Namespace,
 		},
 	}
+	log.Debug(ctx, "deleting stack CR '%s' in namespace '%s'", stack.Name, stack.Namespace)
 	if err := clusterClient.Delete(
 		ctx, stackCR,
 		&client.DeleteOptions{
@@ -138,7 +146,7 @@ func (r *deprovisionReconciler) deleteClusterResources(ctx context.Context, stac
 				Namespace: stack.Namespace,
 			},
 		}
-		r.logger.Infof("deleting secret '%s' in namespace '%s'", secretObj.Name, stack.Namespace)
+		log.Debug(ctx, "deleting secret '%s' in namespace '%s'", secretObj.Name, stack.Namespace)
 		if err := clusterClient.Delete(
 			ctx, secretObj,
 			&client.DeleteOptions{
@@ -154,6 +162,7 @@ func (r *deprovisionReconciler) deleteClusterResources(ctx context.Context, stac
 			Name: stack.Namespace,
 		},
 	}
+	log.Debug(ctx, "deleting namespace '%s'", stack.Namespace)
 	if err := clusterClient.Delete(
 		ctx, namespace,
 		&client.DeleteOptions{

--- a/pkg/worker/stack/namespace_reconciler.go
+++ b/pkg/worker/stack/namespace_reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Stackdome/stackdome/pkg/clustermanager"
+	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/models"
 	corev1 "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,21 +16,29 @@ import (
 type namespaceReconciler struct {
 	clusterManager   clustermanager.ClusterManager
 	namespaceService namespaceService
+	logger           logger.Logger
 }
 
 type NamespaceReconcilerSpec struct {
 	ClusterManager   clustermanager.ClusterManager
 	NamespaceService namespaceService
+	Logger           logger.Logger
 }
 
 func NewNamespaceReconciler(spec NamespaceReconcilerSpec) *namespaceReconciler {
 	return &namespaceReconciler{
 		clusterManager:   spec.ClusterManager,
 		namespaceService: spec.NamespaceService,
+		logger:           spec.Logger,
 	}
 }
 
 func (r *namespaceReconciler) Reconcile(ctx context.Context, stack *models.Stack) (subReconcilerResult, error) {
+	log := r.logger.WithFields(map[string]interface{}{
+		logger.FieldStackID:   stack.ID,
+		logger.FieldClusterID: stack.ClusterID,
+	})
+
 	clusterClient, cerr := r.clusterManager.GetClient(stack.ClusterID)
 	if cerr != nil {
 		return resultNil, fmt.Errorf("failed to get cluster client for cluster %s: %w", stack.ClusterID, cerr)
@@ -51,11 +60,13 @@ func (r *namespaceReconciler) Reconcile(ctx context.Context, stack *models.Stack
 	existingNamespace := &corev1.Namespace{}
 	if err := clusterClient.Get(ctx, client.ObjectKey{Name: namespace.Name}, existingNamespace); err != nil {
 		if k8sapierrors.IsNotFound(err) {
+			log.Info(ctx, "creating namespace %s in cluster", namespace.Name)
 			return resultNil, clusterClient.Create(ctx, desiredNamespace)
 		}
 		return resultNil, fmt.Errorf("failed to get namespace %s: %w", namespace.Name, err)
 	}
 
+	log.Debug(ctx, "namespace %s already exists in cluster", namespace.Name)
 	return resultNil, nil
 }
 

--- a/pkg/worker/stack/stack_worker.go
+++ b/pkg/worker/stack/stack_worker.go
@@ -48,6 +48,7 @@ func NewStackWorker(spec StackWorkerSpec) worker.Worker {
 			NewNamespaceReconciler(NamespaceReconcilerSpec{
 				ClusterManager:   spec.ClusterManager,
 				NamespaceService: spec.NamespaceService,
+				Logger:           logger.NewLoggerWithPrefix(context.Background(), "stack-namespace-reconciler"),
 			}),
 		},
 	}
@@ -59,34 +60,37 @@ func (w *stackWorker) Execute(ctx context.Context, operand worker.Operand) (work
 		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected *models.Stack")
 	}
 
+	log := w.Logger().WithField(logger.FieldStackID, stackID.ID)
+
 	stack, err := w.stackService.InternalGetStack(ctx, stackID.ID)
 	if err != nil {
 		if err.Is404() {
-			w.Logger().Infof("Stack %s not found, skipping reconciliation", stackID.ID)
+			log.Info(ctx, "stack not found, skipping reconciliation")
 			return worker.Result{}, nil
 		}
 		return worker.Result{}, err
 	}
-	w.Logger().Infof("Processing stack: %s", stack.ID)
+	log.Info(ctx, "processing stack")
 
 	if stack.Annotations.ToMap()[models.SkipClusterProvisioningAnnotation] == "true" && stack.DeletionTimestamp == nil && w.Env == config.EnvironmentTest {
-		w.Logger().Infof("Skipping cluster provisioning for stack %s due to annotation", stack.ID)
+		log.Info(ctx, "skipping cluster provisioning due to annotation")
 		return worker.Result{}, w.markAsReadyForSkippedClusterProvisioning(ctx, stack)
 	}
 
 	res, err := w.reconcile(ctx, stack)
 	if err != nil {
-		w.Logger().Errorf("Failed to reconcile stack %s: %v", stack.ID, err)
+		log.Error(ctx, "failed to reconcile stack: %v", err)
 		return worker.Result{}, err
 	}
 	return res, nil
 }
 
 func (w *stackWorker) reconcile(ctx context.Context, stack *models.Stack) (worker.Result, *errors.ServiceError) {
-	w.Logger().Infof("Reconciling stack: %s", stack.ID)
+	log := w.Logger().WithField(logger.FieldStackID, stack.ID)
+	log.Info(ctx, "reconciling stack")
 
 	for _, subReconciler := range w.subReconcilers {
-		w.Logger().Info(ctx, "reconciling with sub-reconciler: %s", subReconciler.Name())
+		log.Debug(ctx, "reconciling with sub-reconciler: %s", subReconciler.Name())
 		result, err := subReconciler.Reconcile(ctx, stack)
 		switch {
 		case err != nil:

--- a/pkg/worker/volume/volume_worker.go
+++ b/pkg/worker/volume/volume_worker.go
@@ -59,13 +59,13 @@ func (w *volumeWorker) Execute(ctx context.Context, operand worker.Operand) (wor
 	vol, serr := w.volumeService.InternalGet(ctx, volumeRef.ID)
 	if serr != nil {
 		if serr.Is404() {
-			w.Logger().Infof("volume %s not found, skipping", volumeRef.ID)
+			w.Logger().Info(ctx, "volume %s not found, skipping", volumeRef.ID)
 			return worker.Result{}, nil
 		}
 		return worker.Result{}, serr
 	}
 
-	w.Logger().Infof("processing volume: %s", vol.ID)
+	w.Logger().Info(ctx, "processing volume: %s", vol.ID)
 
 	if err := w.resolveGitRevision(ctx, vol); err != nil {
 		return worker.Result{}, w.WorkerError.NewError("failed to resolve git revision for volume '%s': %v", vol.ID, err)

--- a/pkg/worker/workermanager/worker_manager.go
+++ b/pkg/worker/workermanager/worker_manager.go
@@ -44,6 +44,7 @@ type serviceWorkerManager struct {
 	environment       string
 	registeredWorkers map[reflect.Type]workerlib.Worker
 	stopChan          chan struct{}
+	log               logger.Logger
 }
 
 func NewWorkerManager(spec WorkerManagerSpec) *serviceWorkerManager {
@@ -51,6 +52,7 @@ func NewWorkerManager(spec WorkerManagerSpec) *serviceWorkerManager {
 		environment:       spec.Environment,
 		registeredWorkers: make(map[reflect.Type]workerlib.Worker),
 		stopChan:          make(chan struct{}),
+		log:               logger.NewLoggerWithPrefix(context.Background(), "worker-manager"),
 	}
 	return workerMgr
 }
@@ -63,20 +65,19 @@ func (s *serviceWorkerManager) Start(ctx context.Context) error {
 		return errors.New("no workers registered under the worker manager")
 	}
 
-	workerManagerLogger := logger.NewLoggerWithPrefix(context.Background(), "worker-manager")
-
 	for _, worker := range s.registeredWorkers {
 		if worker != nil {
 			go func(w workerlib.Worker) {
 				s.startWorker(ctx, w)
 			}(worker)
-			workerManagerLogger.Infof("%s worker started", worker.Name())
+			s.log.Info(ctx, "%s worker started", worker.Name())
 		}
 	}
 	return nil
 }
 
 func (s *serviceWorkerManager) Stop(drain bool) {
+	s.log.Infof("stopping worker manager (drain=%t)", drain)
 	close(s.stopChan)
 	var wg sync.WaitGroup
 	wg.Add(len(s.registeredWorkers))
@@ -94,6 +95,7 @@ func (s *serviceWorkerManager) Stop(drain bool) {
 		}(worker)
 	}
 	wg.Wait()
+	s.log.Infof("worker manager stopped")
 }
 
 func (s *serviceWorkerManager) Enqueue(operand interface{}) error {
@@ -150,10 +152,10 @@ func (s *serviceWorkerManager) startWorker(ctx context.Context, worker workerlib
 
 func (s *serviceWorkerManager) populateWorkerQueue(ctx context.Context, worker workerlib.Worker) {
 	ctx = withSystemIdentity(ctx)
-	worker.Logger().Infof("populating queue once for worker: %s", worker.Name())
+	worker.Logger().Info(ctx, "populating queue once for worker: %s", worker.Name())
 	operandList, err := worker.GetInput(ctx)
 	if err != nil {
-		worker.Logger().Errorf("failed to populate queue for worker: %v", err)
+		worker.Logger().Error(ctx, "failed to populate queue for worker: %v", err)
 		return
 	}
 	for _, operand := range operandList {
@@ -170,8 +172,12 @@ func (s *serviceWorkerManager) processNextWorkItemForWorker(ctx context.Context,
 	defer worker.WorkQueue().Done(operand)
 	switch {
 	case err != nil:
-		worker.Logger().Errorf("reconcile error: %v", err)
-		if worker.WorkQueue().NumRequeues(operand) <= MaxOperandRequeue {
+		requeues := worker.WorkQueue().NumRequeues(operand)
+		worker.Logger().WithFields(map[string]interface{}{
+			"operand":  fmt.Sprintf("%v", operand),
+			"requeues": requeues,
+		}).Error(ctx, "reconcile error: %v", err)
+		if requeues <= MaxOperandRequeue {
 			worker.WorkQueue().AddRateLimited(operand)
 		}
 	case result.RequeueAfter > 0:
@@ -190,7 +196,7 @@ func (s *serviceWorkerManager) processNextWorkItemForWorker(ctx context.Context,
 // method.
 func (s *serviceWorkerManager) startPeriodicWorkEnqueue(ctx context.Context,
 	worker workerlib.Worker, periodicWorkerConfig workerlib.PeriodicReconcilable) {
-	worker.Logger().Infof("starting PeriodicReconciler for worker: %s", worker.Name())
+	worker.Logger().Info(ctx, "starting PeriodicReconciler for worker: %s", worker.Name())
 	ticker := time.NewTicker(periodicWorkerConfig.Interval())
 	defer ticker.Stop()
 	for {
@@ -200,7 +206,7 @@ func (s *serviceWorkerManager) startPeriodicWorkEnqueue(ctx context.Context,
 		case <-ticker.C:
 			operandList, err := s.getWorkerInput(ctx, worker)
 			if err != nil {
-				worker.Logger().Errorf("failed to perform periodic reconcile: %v", err)
+				worker.Logger().Error(ctx, "failed to perform periodic reconcile: %v", err)
 				continue
 			}
 			for _, operand := range operandList {
@@ -219,7 +225,7 @@ func (s *serviceWorkerManager) getWorkerInput(
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
 			{
-				worker.Logger().Infof("worker %s panicked: %v", worker.Name(), panicErr)
+				worker.Logger().Error(ctx, "worker %s panicked: %v", worker.Name(), panicErr)
 				err = fmt.Errorf("worker %s panicked: %v", worker.Name(), panicErr)
 			}
 		}
@@ -238,7 +244,7 @@ func (s *serviceWorkerManager) workerExecute(
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
 			{
-				worker.Logger().Infof("worker %s panicked: %v", worker.Name(), panicErr)
+				worker.Logger().Error(ctx, "worker %s panicked: %v", worker.Name(), panicErr)
 				err = fmt.Errorf("worker %s panicked: %v", worker.Name(), panicErr)
 			}
 		}


### PR DESCRIPTION
## What

Reworks logging across the API server into structured JSON with request-scoped correlation IDs. Replaces the ad-hoc mix of `glog`, `fmt.Printf`, and inconsistently-leveled loggers.

## Changes

- **Formatter & interface** — logrus `JSONFormatter` (opt out with `LOG_FORMAT=text`). `WithField`/`WithFields` on the `Logger` interface. Context correlation fields: `request_id`, `user_id`, `org_id`, `cluster_id`, `stack_id`, `release_id`. Prefixed loggers now read `LOG_LEVEL`, so workers inherit the configured level (previously stuck at default).
- **Request middleware** — honors or generates `X-Request-Id`, injects a per-request logger into the context, logs `method`/`path`/`status`/`duration_ms`. `statusRecorder` gained `Flush`/`Hijack` passthrough so SSE (`StreamReleaseEvents`) keeps working.
- **Auth** — stamps `user_id`/`org_id` onto the context + logger once identity is resolved.
- **Cleanup** — removed direct `glog` and leftover `fmt.Printf` debug lines; fixed a format-string bug in `handleError`.
- **Controllers** — `cluster_id` threaded to every controller via `ControllerFn`; clustermanager now logs register/leadership/supervisor transitions (was silent).
- **Workers** — worker manager stop/requeue logging, panic bumped Info→Error; namespace and deprovision reconcilers no longer silent.
- **Services** — logging on release / secret / postgres / stack paths. Secrets log `id`/`team`/`key_count` only — never values.
- **Migration** — ~325 legacy `Infof`/`Errorf` calls moved to `Info(ctx, ...)` so correlation IDs propagate.

## Sample output

```json
{"cluster_id":"","level":"info","msg":"created stack","name":"demo","stack_id":"stack-1","ts":"2026-07-11T04:18:57.340+05:30"}
```

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- Unit tests pass (`pkg/services`, `pkg/worker/...`, `pkg/logger`, `pkg/clustermanager`).
- No secret values logged (independent review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)