### PR TITLE
Feature: Release-centric health with condition-driven rollup

### DIFF
--- a/cmd/installer/helm.go
+++ b/cmd/installer/helm.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	chartRepo      = "oci://quay.io/stackdome/charts/stackdome-agent"
-	chartVersion   = "0.6.5-alpha"
+	chartVersion   = "0.6.6-alpha"
 	chartRelease   = "stackdome-agent"
 	chartNamespace = "stackdome-control-plane"
 )

--- a/config/openapi/stackdome_api.yaml
+++ b/config/openapi/stackdome_api.yaml
@@ -4737,7 +4737,7 @@ components:
           $ref: '#/components/schemas/StackSettings'
         lifecycle:
           $ref: '#/components/schemas/StackLifecycle'
-        current_release:
+        converged_release:
           $ref: '#/components/schemas/ReleaseSummary'
         latest_release:
           $ref: '#/components/schemas/ReleaseSummary'
@@ -6941,8 +6941,8 @@ components:
     ReleaseHealth:
       type: string
       description: Computed runtime health rollup of a live/active release.
-      enum: [ok, progressing, degraded, failed]
-      x-enum-varnames: [RELEASE_HEALTH_OK, RELEASE_HEALTH_PROGRESSING, RELEASE_HEALTH_DEGRADED, RELEASE_HEALTH_FAILED]
+      enum: [ok, progressing, degraded, unavailable, failed]
+      x-enum-varnames: [RELEASE_HEALTH_OK, RELEASE_HEALTH_PROGRESSING, RELEASE_HEALTH_DEGRADED, RELEASE_HEALTH_UNAVAILABLE, RELEASE_HEALTH_FAILED]
 
     ReleaseSummary:
       type: object

--- a/frontend/src/api/stacks.ts
+++ b/frontend/src/api/stacks.ts
@@ -25,7 +25,7 @@ export type VolumeUpdateRequest = Omit<Volume,
 >;
 
 export type StackUpdateRequest = Omit<Stack,
-  'id' | 'organisation_id' | 'user_id' | 'namespace' | 'revision' | 'lifecycle' | 'current_release' | 'latest_release' | 'created_at' | 'updated_at'
+  'id' | 'organisation_id' | 'user_id' | 'namespace' | 'revision' | 'lifecycle' | 'converged_release' | 'latest_release' | 'created_at' | 'updated_at'
 > & {
   spec: {
     stack_resources: StackResourceUpdateRequest[];

--- a/frontend/src/api/types/openapi.d.ts
+++ b/frontend/src/api/types/openapi.d.ts
@@ -7734,7 +7734,7 @@ export interface components {
             spec: components["schemas"]["StackSpec"];
             settings?: components["schemas"]["StackSettings"];
             lifecycle?: components["schemas"]["StackLifecycle"];
-            current_release?: components["schemas"]["ReleaseSummary"];
+            converged_release?: components["schemas"]["ReleaseSummary"];
             latest_release?: components["schemas"]["ReleaseSummary"];
             /** Format: date-time */
             readonly created_at?: string;
@@ -8813,7 +8813,7 @@ export interface components {
          * @description Computed runtime health rollup of a live/active release.
          * @enum {string}
          */
-        ReleaseHealth: "ok" | "progressing" | "degraded" | "failed";
+        ReleaseHealth: "ok" | "progressing" | "degraded" | "unavailable" | "failed";
         /** @description Lightweight release reference embedded in the stack for list views. */
         ReleaseSummary: {
             id?: string;

--- a/frontend/src/api/zod-schemas.ts
+++ b/frontend/src/api/zod-schemas.ts
@@ -619,7 +619,13 @@ const StackReleaseState = z.enum([
   "Superseded",
   "Cancelled",
 ]);
-const ReleaseHealth = z.enum(["ok", "progressing", "degraded", "failed"]);
+const ReleaseHealth = z.enum([
+  "ok",
+  "progressing",
+  "degraded",
+  "unavailable",
+  "failed",
+]);
 const ReleaseSummary = z
   .object({
     id: z.string(),
@@ -646,7 +652,7 @@ const Stack = z
     spec: StackSpec,
     settings: StackSettings.optional(),
     lifecycle: StackLifecycle.optional(),
-    current_release: ReleaseSummary.optional(),
+    converged_release: ReleaseSummary.optional(),
     latest_release: ReleaseSummary.optional(),
     created_at: z.string().datetime({ offset: true }).optional(),
     updated_at: z.string().datetime({ offset: true }).optional(),

--- a/frontend/src/components/branded/status-variant.ts
+++ b/frontend/src/components/branded/status-variant.ts
@@ -123,6 +123,7 @@ export function statusVariant(domain: StatusDomain, state?: string | null): Stat
         case "progressing":
         case "degraded":
           return "pending";
+        case "unavailable":
         case "failed":
           return "error";
         default:

--- a/frontend/src/pages/stacks/components/detail/deployments/deployments-tab.tsx
+++ b/frontend/src/pages/stacks/components/detail/deployments/deployments-tab.tsx
@@ -40,7 +40,7 @@ export function DeploymentsTab({ orgId, projectName, stackId, stack, onOpenLogs,
     : undefined;
 
   // Anchor the live release at the top only when it's buried (not already the newest node).
-  const liveReleaseId = stack.current_release?.id;
+  const liveReleaseId = stack.converged_release?.id;
   const liveIdx = liveReleaseId ? releases.findIndex((r) => r.id === liveReleaseId) : -1;
   const liveRelease = liveIdx >= 0 ? releases[liveIdx] : undefined;
   const liverev = liveIdx >= 0 ? releases[liveIdx + 1] : undefined;

--- a/frontend/src/pages/stacks/components/detail/deployments/derive.ts
+++ b/frontend/src/pages/stacks/components/detail/deployments/derive.ts
@@ -22,7 +22,7 @@ export function deriveHeaderHealth(stack: Stack): ReleaseHealth | undefined {
   const latest = stack.latest_release;
   if (!latest) return undefined;
   if (!isTerminal(latest.state)) return "progressing";
-  if (stack.current_release?.health) return stack.current_release.health;
+  if (stack.converged_release?.health) return stack.converged_release.health;
   return latest.state === ReleaseState.Failed ? "failed" : undefined;
 }
 
@@ -55,7 +55,7 @@ export function stripUnpinnedGitRevisions(
 export function latestDeployFailed(stack: Stack): boolean {
   const latest = stack.latest_release;
   if (!latest || latest.state !== ReleaseState.Failed) return false;
-  if (!stack.current_release || latest.id === stack.current_release.id) return false;
+  if (!stack.converged_release || latest.id === stack.converged_release.id) return false;
   return deriveHeaderHealth(stack) !== "failed";
 }
 

--- a/frontend/src/pages/stacks/components/detail/deployments/tests/deployments-tab.test.tsx
+++ b/frontend/src/pages/stacks/components/detail/deployments/tests/deployments-tab.test.tsx
@@ -76,7 +76,7 @@ describe("DeploymentsTab", () => {
   });
 
   it("pins a live anchor when the live release is buried below a newer deploy", () => {
-    const buriedStack = { current_release: { id: "r14" }, spec: { stack_resources: [{ name: "web" }] } } as unknown as Stack;
+    const buriedStack = { converged_release: { id: "r14" }, spec: { stack_resources: [{ name: "web" }] } } as unknown as Stack;
     const buried: StackRelease[] = [
       { id: "r15", sequence: 15, state: "InProgress", cause: { kind: "manual" } } as StackRelease,
       { id: "r14", sequence: 14, state: "Released", cause: { kind: "manual" } } as StackRelease,
@@ -87,7 +87,7 @@ describe("DeploymentsTab", () => {
   });
 
   it("does not pin a live anchor when the live release is already the newest node", () => {
-    const liveTopStack = { current_release: { id: "r14" }, spec: { stack_resources: [] } } as unknown as Stack;
+    const liveTopStack = { converged_release: { id: "r14" }, spec: { stack_resources: [] } } as unknown as Stack;
     const lifecycle: DeployLifecycle = { phase: "clean", nextSeq: 15, vsSeq: 14 };
     renderTab(<DeploymentsTab {...base} stack={liveTopStack} releases={releases} activeRelease={releases[0]} lifecycle={lifecycle} />);
     expect(screen.queryByRole("button", { name: /Live release/ })).not.toBeInTheDocument();

--- a/frontend/src/pages/stacks/components/detail/deployments/tests/derive.test.ts
+++ b/frontend/src/pages/stacks/components/detail/deployments/tests/derive.test.ts
@@ -14,7 +14,7 @@ function liveStatusWith(resources: Record<string, Record<string, unknown>>): Rel
 }
 
 function stackWithReleases(current?: Partial<ReleaseSummary>, latest?: Partial<ReleaseSummary>): Stack {
-  return { current_release: current, latest_release: latest } as unknown as Stack;
+  return { converged_release: current, latest_release: latest } as unknown as Stack;
 }
 
 describe("deriveFailingResources", () => {

--- a/frontend/src/pages/stacks/components/detail/deployments/tests/use-deploy-lifecycle.test.ts
+++ b/frontend/src/pages/stacks/components/detail/deployments/tests/use-deploy-lifecycle.test.ts
@@ -6,7 +6,7 @@ import type { StackRelease, StackReleaseSnapshot } from "@/api/releases";
 const mkStack = (image: string, updatedAt?: string): Stack =>
   ({
     spec: { stack_resources: [{ name: "web", source: { image: { ref: image } } }] },
-    current_release: { id: "live-1" },
+    converged_release: { id: "live-1" },
     updated_at: updatedAt,
   } as unknown as Stack);
 

--- a/frontend/src/pages/stacks/components/detail/deployments/timeline/live-release-summary.tsx
+++ b/frontend/src/pages/stacks/components/detail/deployments/timeline/live-release-summary.tsx
@@ -9,7 +9,7 @@ import { LiveReleaseBody } from "./live-release-body";
 import type { LogContext } from "./resource-row";
 
 export interface LiveReleaseSummaryProps {
-  /** The release currently serving traffic (stack.current_release). */
+  /** The release currently serving traffic (stack.converged_release). */
   release: StackRelease;
   stack: Stack;
   /** Previous release, for the config diff inside the expanded body. */

--- a/frontend/src/pages/stacks/components/detail/deployments/timeline/tests/live-release-summary.test.tsx
+++ b/frontend/src/pages/stacks/components/detail/deployments/timeline/tests/live-release-summary.test.tsx
@@ -26,7 +26,7 @@ const release = {
   live_status: { resources: { web: { state: "Ready" } } },
 } as unknown as StackRelease;
 const stack = {
-  current_release: { id: "r18" },
+  converged_release: { id: "r18" },
   spec: { stack_resources: [{ name: "web" }] },
 } as unknown as Stack;
 const ctx = { orgId: "o", projectName: "t", stackId: "s" };

--- a/frontend/src/pages/stacks/components/detail/deployments/timeline/tests/timeline-rail.test.tsx
+++ b/frontend/src/pages/stacks/components/detail/deployments/timeline/tests/timeline-rail.test.tsx
@@ -50,7 +50,7 @@ describe("TimelineRail", () => {
 
   it("opens the latest deploy by default and tags the live release", () => {
     const r = rels(3);
-    const liveStack = { current_release: { id: "r2" }, spec: { stack_resources: [] } } as unknown as Stack;
+    const liveStack = { converged_release: { id: "r2" }, spec: { stack_resources: [] } } as unknown as Stack;
     renderRail(<TimelineRail releases={r} activeRelease={r[0]} {...base} stack={liveStack} />);
     // #2 is the live release → carries the LIVE chip.
     expect(screen.getByText("Live")).toBeInTheDocument();
@@ -58,7 +58,7 @@ describe("TimelineRail", () => {
 
   it("renders only the live dot solid; every other dot is a hollow ring", () => {
     const r = rels(3);
-    const liveStack = { current_release: { id: "r2" }, spec: { stack_resources: [] } } as unknown as Stack;
+    const liveStack = { converged_release: { id: "r2" }, spec: { stack_resources: [] } } as unknown as Stack;
     renderRail(<TimelineRail releases={r} activeRelease={r[0]} {...base} stack={liveStack} />);
     const dots = screen.getAllByTestId("rail-dot");
     const solid = dots.filter((d) => !d.className.includes("border-2") && !d.className.includes("animate-spin"));

--- a/frontend/src/pages/stacks/components/detail/deployments/timeline/timeline-node.tsx
+++ b/frontend/src/pages/stacks/components/detail/deployments/timeline/timeline-node.tsx
@@ -23,7 +23,7 @@ export interface TimelineNodeProps {
   onCopyId: (id: string) => void;
   /** releases[0] — render LIVE progress from the stack rather than the stored outcome. */
   isActive: boolean;
-  /** This release currently serves traffic (stack.current_release). */
+  /** This release currently serves traffic (stack.converged_release). */
   isLive: boolean;
   stack: Stack;
   logContext?: LogContext;

--- a/frontend/src/pages/stacks/components/detail/deployments/timeline/timeline-rail.tsx
+++ b/frontend/src/pages/stacks/components/detail/deployments/timeline/timeline-rail.tsx
@@ -42,7 +42,7 @@ function dotShape(state: string, isLive: boolean): RailDotShape {
 export function TimelineRail(props: TimelineRailProps) {
   const { releases, activeRelease, stack, logContext, onOpenLogs, onJumpToResource, refetchReleases, banner, draftNode, onRollback, onCancel, onCopyId, initialWindow = 15 } = props;
   const detail = useReleaseDetailContext();
-  const liveReleaseId = stack.current_release?.id;
+  const liveReleaseId = stack.converged_release?.id;
   const [openIds, setOpenIds] = useState<Set<string>>(
     () => new Set([activeRelease?.id, liveReleaseId].filter((x): x is string => !!x)),
   );

--- a/frontend/src/pages/stacks/components/detail/deployments/use-deploy-lifecycle.ts
+++ b/frontend/src/pages/stacks/components/detail/deployments/use-deploy-lifecycle.ts
@@ -28,7 +28,7 @@ export interface DeriveDeployLifecycleArgs {
   unsaved: boolean;
   /** The latest release attempt (releases[0]). */
   activeRelease?: StackRelease;
-  /** The release currently serving traffic (stack.current_release). */
+  /** The release currently serving traffic (stack.converged_release). */
   liveRelease?: StackRelease;
   /** Snapshot of the latest attempt — what an in-flight deploy is shipping. */
   activeSnapshot?: StackReleaseSnapshot;
@@ -55,7 +55,7 @@ function baselineSnapshot(args: DeriveDeployLifecycleArgs): StackReleaseSnapshot
   const deploying = !!activeRelease && !isTerminal(activeRelease.state);
   if (deploying) return activeSnapshot;
   if (liveSnapshot) return liveSnapshot;
-  if (!stack?.current_release?.id) return EMPTY_SNAPSHOT;
+  if (!stack?.converged_release?.id) return EMPTY_SNAPSHOT;
   return undefined;
 }
 
@@ -109,7 +109,7 @@ export function deriveDeployLifecycle(args: DeriveDeployLifecycleArgs): DeployLi
       : { phase: "staged", stagedDiff: d, vsSeq: liveSeq, nextSeq };
   }
 
-  const liveReleaseId = stack.current_release?.id;
+  const liveReleaseId = stack.converged_release?.id;
   if (!liveReleaseId) {
     // Never converged a release — the whole saved spec is staged for the first deploy,
     // so diff against an empty baseline (every resource/volume/connection reads as added).
@@ -146,7 +146,7 @@ export interface UseDeployLifecycleArgs {
  * snapshots, and derives the lifecycle phase.
  */
 export function useDeployLifecycle({ stack, unsaved, releases, activeRelease, detail }: UseDeployLifecycleArgs): DeployLifecycle {
-  const liveReleaseId = stack?.current_release?.id;
+  const liveReleaseId = stack?.converged_release?.id;
   const liveRelease = liveReleaseId ? releases.find((r) => r.id === liveReleaseId) : undefined;
   const activeId = activeRelease?.id;
 

--- a/frontend/src/pages/stacks/components/detail/index.tsx
+++ b/frontend/src/pages/stacks/components/detail/index.tsx
@@ -227,27 +227,27 @@ export default function StackDetailPage() {
   // Diff anchor: the latest release (the config last shipped via Deploy), falling
   // back to the live (currently converged) release until the releases list loads.
   const baselineReleaseId =
-    releasesResult.activeRelease?.id ?? stackToShow?.current_release?.id;
+    releasesResult.activeRelease?.id ?? stackToShow?.converged_release?.id;
   useEffect(() => {
     if (baselineReleaseId) releaseDetail.ensure(baselineReleaseId);
   }, [baselineReleaseId, releaseDetail]);
   const deployedSnapshot = releaseDetail.peek(baselineReleaseId).data?.snapshot;
 
-  // Live release (stack.current_release): what's actually serving traffic — source
+  // Live release (stack.converged_release): what's actually serving traffic — source
   // for live per-resource status (public ingress endpoints below).
-  const currentReleaseId = stackToShow?.current_release?.id;
+  const convergedReleaseId = stackToShow?.converged_release?.id;
   useEffect(() => {
-    if (currentReleaseId) releaseDetail.ensure(currentReleaseId);
-  }, [currentReleaseId, releaseDetail]);
-  const currentReleaseDetail = releaseDetail.peek(currentReleaseId).data;
+    if (convergedReleaseId) releaseDetail.ensure(convergedReleaseId);
+  }, [convergedReleaseId, releaseDetail]);
+  const convergedReleaseDetail = releaseDetail.peek(convergedReleaseId).data;
 
   // "Status" release: the active non-terminal release when a deploy is under way
   // (so the canvas/drawer reflect the in-flight rollout, not stale current-release
-  // data), else the live current_release. Distinct from currentReleaseId above,
+  // data), else the live converged_release. Distinct from convergedReleaseId above,
   // which stays pinned to what's actually serving traffic for the header's PUBLIC row.
   const nonTerminalRelease = releasesResult.releases.find((r) => !isTerminal(r.state));
-  const statusReleaseId = nonTerminalRelease?.id ?? stackToShow?.current_release?.id;
-  const statusReleaseState = nonTerminalRelease?.state ?? stackToShow?.current_release?.state;
+  const statusReleaseId = nonTerminalRelease?.id ?? stackToShow?.converged_release?.id;
+  const statusReleaseState = nonTerminalRelease?.state ?? stackToShow?.converged_release?.state;
   // Refetch on every id/state change (mount, and each transition — including the
   // terminal one, since statusReleaseState is a dep) plus a 5s poll while non-terminal.
   // Depend on the stable refresh callback, NOT the releaseDetail object (rebuilt every
@@ -269,13 +269,13 @@ export default function StackDetailPage() {
   // PUBLIC row. Drafts have no live ingress, so the row stays empty.
   const publicEndpoints = useMemo(() => {
     if (isDraft) return [];
-    const liveResources = currentReleaseDetail?.live_status?.resources ?? {};
+    const liveResources = convergedReleaseDetail?.live_status?.resources ?? {};
     return (effectiveStack?.spec.stack_resources ?? []).flatMap((r) => {
       const ingress = r.name ? liveResources[r.name]?.public_ingress ?? [] : [];
       const best = pickBestIngress(ingress, orgDomains);
       return best && r.name ? [{ service: r.name, url: best.url, port: best.target_port }] : [];
     });
-  }, [isDraft, effectiveStack, orgDomains, currentReleaseDetail]);
+  }, [isDraft, effectiveStack, orgDomains, convergedReleaseDetail]);
 
   // Current server state as form data — what the canvas displays and the edit
   // session's working draft seeds from.
@@ -578,7 +578,7 @@ export default function StackDetailPage() {
     detail: releaseDetail,
   });
 
-  // When a release settles into ANY terminal state, the stack's current_release /
+  // When a release settles into ANY terminal state, the stack's converged_release /
   // latest_release summaries are stale until refetched — the staged panel would
   // keep diffing against the old snapshot otherwise. Refetch once per transition,
   // keyed on the polled releases list (not on the stack's own pointer).
@@ -605,9 +605,9 @@ export default function StackDetailPage() {
     }
   }, [activeRelease, stackToShow?.latest_release, refetchStack]);
 
-  // Live snapshot: already lazily fetched above (currentReleaseId ensure); peek
+  // Live snapshot: already lazily fetched above (convergedReleaseId ensure); peek
   // here to gate canDiscardDraft and pass to the revert hook.
-  const liveSnapshot = currentReleaseDetail?.snapshot;
+  const liveSnapshot = convergedReleaseDetail?.snapshot;
 
   const [revertConfirmOpen, setRevertConfirmOpen] = useState(false);
   const [viewChangesOpen, setViewChangesOpen] = useState(false);

--- a/frontend/src/pages/stacks/components/list/tests/stack-card.test.tsx
+++ b/frontend/src/pages/stacks/components/list/tests/stack-card.test.tsx
@@ -29,7 +29,7 @@ describe("DeployStackCard", () => {
           stack={{
             ...baseStack,
             latest_release: { id: "r1", state: ReleaseState.Released },
-            current_release: { id: "r1", state: ReleaseState.Released, health: "ok" },
+            converged_release: { id: "r1", state: ReleaseState.Released, health: "ok" },
           } as Stack}
         />
       </MemoryRouter>,
@@ -75,7 +75,7 @@ describe("DeployStackCard", () => {
           stack={{
             ...baseStack,
             latest_release: { id: "r3", state: ReleaseState.Failed },
-            current_release: { id: "r1", state: ReleaseState.Released, health: "ok" },
+            converged_release: { id: "r1", state: ReleaseState.Released, health: "ok" },
           } as Stack}
         />
       </MemoryRouter>,
@@ -90,7 +90,7 @@ describe("headerStatus", () => {
     const s = {
       ...baseStack,
       lifecycle: "deleting",
-      current_release: { id: "r1", state: ReleaseState.Released, health: "ok" },
+      converged_release: { id: "r1", state: ReleaseState.Released, health: "ok" },
       latest_release: { id: "r1", state: ReleaseState.Released },
     } as Stack;
     expect(headerStatus(s)).toEqual({ label: "Deleting", variant: "pending" });

--- a/frontend/src/pages/stacks/contexts/stack-context.tsx
+++ b/frontend/src/pages/stacks/contexts/stack-context.tsx
@@ -9,7 +9,7 @@ interface StackContextType {
   // required for write-through from async callbacks (avoids clobbering the
   // list with a stale render-closure snapshot).
   setStacks: Dispatch<SetStateAction<Stack[]>>;
-  addStack: (stack: Omit<Stack, 'id' | 'created_at' | 'lifecycle' | 'current_release' | 'latest_release'>) => void;
+  addStack: (stack: Omit<Stack, 'id' | 'created_at' | 'lifecycle' | 'converged_release' | 'latest_release'>) => void;
   removeStack: (id: string) => void;
 }
 
@@ -21,7 +21,7 @@ export function StackProvider({ children }: { children: ReactNode }) {
   const [stacks, setStacks] = useState<Stack[]>([]);
 
   // Add a new stack
-  const addStack = (stackData: Omit<Stack, 'id' | 'created_at' | 'lifecycle' | 'current_release' | 'latest_release'>) => {
+  const addStack = (stackData: Omit<Stack, 'id' | 'created_at' | 'lifecycle' | 'converged_release' | 'latest_release'>) => {
     // id, created_at, and lifecycle are always set here; spec comes from stackData
     const newStack: Stack = {
       id: `stack-${Date.now()}`,

--- a/magefile.go
+++ b/magefile.go
@@ -102,7 +102,7 @@ const (
 	PnpmVersion      = "v10.33.2"
 
 	// Stackdome agent Helm chart
-	DefaultStackdomeChartVersion = "0.6.5-alpha"
+	DefaultStackdomeChartVersion = "0.6.6-alpha"
 	StackdomeChartRepo           = "oci://quay.io/stackdome/charts/stackdome-agent"
 	StackdomeChartReleaseName    = "stackdome-agent"
 	StackdomeChartNamespace      = "stackdome-control-plane"

--- a/pkg/api/openapi/api/openapi.yaml
+++ b/pkg/api/openapi/api/openapi.yaml
@@ -7343,12 +7343,7 @@ components:
           deploy_timeout_minutes: 2
           min_successful_releases: 5
           release_retention_limit: 5
-        annotations:
-        - value: value
-          key: key
-        - value: value
-          key: key
-        current_release:
+        converged_release:
           sequence: 7
           completed_at: 2000-01-23T04:56:07.000+00:00
           health: null
@@ -7356,6 +7351,11 @@ components:
           id: id
           state: null
           message: message
+        annotations:
+        - value: value
+          key: key
+        - value: value
+          key: key
         created_at: 2000-01-23T04:56:07.000+00:00
         spec:
           stack_resources:
@@ -7788,7 +7788,7 @@ components:
           $ref: '#/components/schemas/StackSettings'
         lifecycle:
           $ref: '#/components/schemas/StackLifecycle'
-        current_release:
+        converged_release:
           $ref: '#/components/schemas/ReleaseSummary'
         latest_release:
           $ref: '#/components/schemas/ReleaseSummary'
@@ -7832,12 +7832,7 @@ components:
             deploy_timeout_minutes: 2
             min_successful_releases: 5
             release_retention_limit: 5
-          annotations:
-          - value: value
-            key: key
-          - value: value
-            key: key
-          current_release:
+          converged_release:
             sequence: 7
             completed_at: 2000-01-23T04:56:07.000+00:00
             health: null
@@ -7845,6 +7840,11 @@ components:
             id: id
             state: null
             message: message
+          annotations:
+          - value: value
+            key: key
+          - value: value
+            key: key
           created_at: 2000-01-23T04:56:07.000+00:00
           spec:
             stack_resources:
@@ -8246,12 +8246,7 @@ components:
             deploy_timeout_minutes: 2
             min_successful_releases: 5
             release_retention_limit: 5
-          annotations:
-          - value: value
-            key: key
-          - value: value
-            key: key
-          current_release:
+          converged_release:
             sequence: 7
             completed_at: 2000-01-23T04:56:07.000+00:00
             health: null
@@ -8259,6 +8254,11 @@ components:
             id: id
             state: null
             message: message
+          annotations:
+          - value: value
+            key: key
+          - value: value
+            key: key
           created_at: 2000-01-23T04:56:07.000+00:00
           spec:
             stack_resources:
@@ -13191,12 +13191,14 @@ components:
       - ok
       - progressing
       - degraded
+      - unavailable
       - failed
       type: string
       x-enum-varnames:
       - RELEASE_HEALTH_OK
       - RELEASE_HEALTH_PROGRESSING
       - RELEASE_HEALTH_DEGRADED
+      - RELEASE_HEALTH_UNAVAILABLE
       - RELEASE_HEALTH_FAILED
     ReleaseSummary:
       description: Lightweight release reference embedded in the stack for list views.

--- a/pkg/api/openapi/docs/ReleaseHealth.md
+++ b/pkg/api/openapi/docs/ReleaseHealth.md
@@ -9,6 +9,8 @@
 
 * `RELEASE_HEALTH_DEGRADED` (value: `"degraded"`)
 
+* `RELEASE_HEALTH_UNAVAILABLE` (value: `"unavailable"`)
+
 * `RELEASE_HEALTH_FAILED` (value: `"failed"`)
 
 

--- a/pkg/api/openapi/docs/Stack.md
+++ b/pkg/api/openapi/docs/Stack.md
@@ -16,7 +16,7 @@ Name | Type | Description | Notes
 **Spec** | [**StackSpec**](StackSpec.md) |  | 
 **Settings** | Pointer to [**StackSettings**](StackSettings.md) |  | [optional] 
 **Lifecycle** | Pointer to [**StackLifecycle**](StackLifecycle.md) |  | [optional] 
-**CurrentRelease** | Pointer to [**ReleaseSummary**](ReleaseSummary.md) |  | [optional] 
+**ConvergedRelease** | Pointer to [**ReleaseSummary**](ReleaseSummary.md) |  | [optional] 
 **LatestRelease** | Pointer to [**ReleaseSummary**](ReleaseSummary.md) |  | [optional] 
 **CreatedAt** | Pointer to **time.Time** |  | [optional] [readonly] 
 **UpdatedAt** | Pointer to **time.Time** |  | [optional] [readonly] 
@@ -330,30 +330,30 @@ SetLifecycle sets Lifecycle field to given value.
 
 HasLifecycle returns a boolean if a field has been set.
 
-### GetCurrentRelease
+### GetConvergedRelease
 
-`func (o *Stack) GetCurrentRelease() ReleaseSummary`
+`func (o *Stack) GetConvergedRelease() ReleaseSummary`
 
-GetCurrentRelease returns the CurrentRelease field if non-nil, zero value otherwise.
+GetConvergedRelease returns the ConvergedRelease field if non-nil, zero value otherwise.
 
-### GetCurrentReleaseOk
+### GetConvergedReleaseOk
 
-`func (o *Stack) GetCurrentReleaseOk() (*ReleaseSummary, bool)`
+`func (o *Stack) GetConvergedReleaseOk() (*ReleaseSummary, bool)`
 
-GetCurrentReleaseOk returns a tuple with the CurrentRelease field if it's non-nil, zero value otherwise
+GetConvergedReleaseOk returns a tuple with the ConvergedRelease field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetCurrentRelease
+### SetConvergedRelease
 
-`func (o *Stack) SetCurrentRelease(v ReleaseSummary)`
+`func (o *Stack) SetConvergedRelease(v ReleaseSummary)`
 
-SetCurrentRelease sets CurrentRelease field to given value.
+SetConvergedRelease sets ConvergedRelease field to given value.
 
-### HasCurrentRelease
+### HasConvergedRelease
 
-`func (o *Stack) HasCurrentRelease() bool`
+`func (o *Stack) HasConvergedRelease() bool`
 
-HasCurrentRelease returns a boolean if a field has been set.
+HasConvergedRelease returns a boolean if a field has been set.
 
 ### GetLatestRelease
 

--- a/pkg/api/openapi/model_release_health.go
+++ b/pkg/api/openapi/model_release_health.go
@@ -23,6 +23,7 @@ const (
 	RELEASE_HEALTH_OK          ReleaseHealth = "ok"
 	RELEASE_HEALTH_PROGRESSING ReleaseHealth = "progressing"
 	RELEASE_HEALTH_DEGRADED    ReleaseHealth = "degraded"
+	RELEASE_HEALTH_UNAVAILABLE ReleaseHealth = "unavailable"
 	RELEASE_HEALTH_FAILED      ReleaseHealth = "failed"
 )
 
@@ -31,6 +32,7 @@ var AllowedReleaseHealthEnumValues = []ReleaseHealth{
 	"ok",
 	"progressing",
 	"degraded",
+	"unavailable",
 	"failed",
 }
 

--- a/pkg/api/openapi/model_stack.go
+++ b/pkg/api/openapi/model_stack.go
@@ -17,22 +17,22 @@ import (
 
 // Stack struct for Stack
 type Stack struct {
-	Id             *string         `json:"id,omitempty"`
-	OrganisationId *string         `json:"organisation_id,omitempty"`
-	ProjectId      *string         `json:"project_id,omitempty"`
-	UserId         *string         `json:"user_id,omitempty"`
-	Name           string          `json:"name"`
-	Namespace      *string         `json:"namespace,omitempty"`
-	Labels         []Label         `json:"labels,omitempty"`
-	Annotations    []Annotation    `json:"annotations,omitempty"`
-	Revision       *string         `json:"revision,omitempty"`
-	Spec           StackSpec       `json:"spec"`
-	Settings       *StackSettings  `json:"settings,omitempty"`
-	Lifecycle      *StackLifecycle `json:"lifecycle,omitempty"`
-	CurrentRelease *ReleaseSummary `json:"current_release,omitempty"`
-	LatestRelease  *ReleaseSummary `json:"latest_release,omitempty"`
-	CreatedAt      *time.Time      `json:"created_at,omitempty"`
-	UpdatedAt      *time.Time      `json:"updated_at,omitempty"`
+	Id               *string         `json:"id,omitempty"`
+	OrganisationId   *string         `json:"organisation_id,omitempty"`
+	ProjectId        *string         `json:"project_id,omitempty"`
+	UserId           *string         `json:"user_id,omitempty"`
+	Name             string          `json:"name"`
+	Namespace        *string         `json:"namespace,omitempty"`
+	Labels           []Label         `json:"labels,omitempty"`
+	Annotations      []Annotation    `json:"annotations,omitempty"`
+	Revision         *string         `json:"revision,omitempty"`
+	Spec             StackSpec       `json:"spec"`
+	Settings         *StackSettings  `json:"settings,omitempty"`
+	Lifecycle        *StackLifecycle `json:"lifecycle,omitempty"`
+	ConvergedRelease *ReleaseSummary `json:"converged_release,omitempty"`
+	LatestRelease    *ReleaseSummary `json:"latest_release,omitempty"`
+	CreatedAt        *time.Time      `json:"created_at,omitempty"`
+	UpdatedAt        *time.Time      `json:"updated_at,omitempty"`
 }
 
 // NewStack instantiates a new Stack object
@@ -422,36 +422,36 @@ func (o *Stack) SetLifecycle(v StackLifecycle) {
 	o.Lifecycle = &v
 }
 
-// GetCurrentRelease returns the CurrentRelease field value if set, zero value otherwise.
-func (o *Stack) GetCurrentRelease() ReleaseSummary {
-	if o == nil || o.CurrentRelease == nil {
+// GetConvergedRelease returns the ConvergedRelease field value if set, zero value otherwise.
+func (o *Stack) GetConvergedRelease() ReleaseSummary {
+	if o == nil || o.ConvergedRelease == nil {
 		var ret ReleaseSummary
 		return ret
 	}
-	return *o.CurrentRelease
+	return *o.ConvergedRelease
 }
 
-// GetCurrentReleaseOk returns a tuple with the CurrentRelease field value if set, nil otherwise
+// GetConvergedReleaseOk returns a tuple with the ConvergedRelease field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Stack) GetCurrentReleaseOk() (*ReleaseSummary, bool) {
-	if o == nil || o.CurrentRelease == nil {
+func (o *Stack) GetConvergedReleaseOk() (*ReleaseSummary, bool) {
+	if o == nil || o.ConvergedRelease == nil {
 		return nil, false
 	}
-	return o.CurrentRelease, true
+	return o.ConvergedRelease, true
 }
 
-// HasCurrentRelease returns a boolean if a field has been set.
-func (o *Stack) HasCurrentRelease() bool {
-	if o != nil && o.CurrentRelease != nil {
+// HasConvergedRelease returns a boolean if a field has been set.
+func (o *Stack) HasConvergedRelease() bool {
+	if o != nil && o.ConvergedRelease != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetCurrentRelease gets a reference to the given ReleaseSummary and assigns it to the CurrentRelease field.
-func (o *Stack) SetCurrentRelease(v ReleaseSummary) {
-	o.CurrentRelease = &v
+// SetConvergedRelease gets a reference to the given ReleaseSummary and assigns it to the ConvergedRelease field.
+func (o *Stack) SetConvergedRelease(v ReleaseSummary) {
+	o.ConvergedRelease = &v
 }
 
 // GetLatestRelease returns the LatestRelease field value if set, zero value otherwise.
@@ -588,8 +588,8 @@ func (o Stack) MarshalJSON() ([]byte, error) {
 	if o.Lifecycle != nil {
 		toSerialize["lifecycle"] = o.Lifecycle
 	}
-	if o.CurrentRelease != nil {
-		toSerialize["current_release"] = o.CurrentRelease
+	if o.ConvergedRelease != nil {
+		toSerialize["converged_release"] = o.ConvergedRelease
 	}
 	if o.LatestRelease != nil {
 		toSerialize["latest_release"] = o.LatestRelease

--- a/pkg/models/release_live_status.go
+++ b/pkg/models/release_live_status.go
@@ -7,6 +7,7 @@ const (
 	ReleaseHealthOK          ReleaseHealth = "ok"
 	ReleaseHealthProgressing ReleaseHealth = "progressing"
 	ReleaseHealthDegraded    ReleaseHealth = "degraded"
+	ReleaseHealthUnavailable ReleaseHealth = "unavailable"
 	ReleaseHealthFailed      ReleaseHealth = "failed"
 )
 
@@ -23,8 +24,8 @@ type ReleaseLiveStatus struct {
 // StackReleaseRefs pairs the currently converged (live) release with the
 // highest-sequence one for stack embedding.
 type StackReleaseRefs struct {
-	Current *StackRelease
-	Latest  *StackRelease
+	Converged *StackRelease
+	Latest    *StackRelease
 }
 
 // BuildReleaseLiveStatus overlays current stack/resource status onto a release.
@@ -56,7 +57,7 @@ func BuildReleaseLiveStatus(release *StackRelease, stack *Stack) *ReleaseLiveSta
 	}
 
 	return &ReleaseLiveStatus{
-		Health:           rollupHealth(release, stack, liveResources),
+		Health:           rollupHealth(release, stack),
 		Resources:        resources,
 		Conditions:       stack.Status.Conditions,
 		TargetRevision:   stack.Status.TargetRevision,
@@ -64,25 +65,25 @@ func BuildReleaseLiveStatus(release *StackRelease, stack *Stack) *ReleaseLiveSta
 	}
 }
 
-func rollupHealth(release *StackRelease, stack *Stack, resources []*StackResource) ReleaseHealth {
-	health := ReleaseHealthOK
-	for _, r := range resources {
-		switch {
-		case r.Status == nil || r.Status.State == StackResourcePhasePending || r.Status.State == StackResourcePhaseUnknown:
-			if health == ReleaseHealthOK {
-				health = ReleaseHealthProgressing
-			}
-		case r.Status.State == StackResourcePhaseFailed:
-			return ReleaseHealthFailed
-		}
+// rollupHealth maps the stack's aggregate conditions (cluster-agent v0.6.6+) to a
+// single release health, mirroring the agent's phase priority:
+// Failed(Stalled) > Progressing > Degraded > Converged. The fall-through splits on
+// whether the release is still deploying (progressing) or a live release that fell
+// out of serving (unavailable). Converged implies Available, so ok needs no Available check.
+func rollupHealth(release *StackRelease, stack *Stack) ReleaseHealth {
+	conds := stack.Status.Conditions
+	switch {
+	case IsConditionTrue(conds, string(StackConditionStalled)):
+		return ReleaseHealthFailed
+	case IsConditionTrue(conds, string(StackConditionProgressing)):
+		return ReleaseHealthProgressing
+	case IsConditionTrue(conds, string(StackConditionDegraded)):
+		return ReleaseHealthDegraded
+	case IsConditionTrue(conds, string(StackConditionConverged)):
+		return ReleaseHealthOK
+	case release.State.Active():
+		return ReleaseHealthProgressing // active deploy, no rollout condition yet (pods not created)
+	default:
+		return ReleaseHealthUnavailable // live release, no positive condition, not serving
 	}
-	if health == ReleaseHealthOK {
-		if IsConditionTrue(stack.Status.Conditions, string(StackConditionDegraded)) {
-			return ReleaseHealthDegraded
-		}
-		if release.State.Active() {
-			return ReleaseHealthProgressing
-		}
-	}
-	return health
 }

--- a/pkg/models/release_live_status.go
+++ b/pkg/models/release_live_status.go
@@ -67,9 +67,11 @@ func BuildReleaseLiveStatus(release *StackRelease, stack *Stack) *ReleaseLiveSta
 
 // rollupHealth maps the stack's aggregate conditions (cluster-agent v0.6.6+) to a
 // single release health, mirroring the agent's phase priority:
-// Failed(Stalled) > Progressing > Degraded > Converged. The fall-through splits on
-// whether the release is still deploying (progressing) or a live release that fell
-// out of serving (unavailable). Converged implies Available, so ok needs no Available check.
+// Failed(Stalled) > Progressing > Degraded > Converged. Available is checked below
+// Converged to keep a serving-but-not-yet-converged stack (e.g. still on the prior
+// revision) out of the unavailable arm. The fall-through splits on whether the
+// release is still deploying (progressing) or a live release that fell out of
+// serving (unavailable).
 func rollupHealth(release *StackRelease, stack *Stack) ReleaseHealth {
 	conds := stack.Status.Conditions
 	switch {
@@ -81,6 +83,8 @@ func rollupHealth(release *StackRelease, stack *Stack) ReleaseHealth {
 		return ReleaseHealthDegraded
 	case IsConditionTrue(conds, string(StackConditionConverged)):
 		return ReleaseHealthOK
+	case IsConditionTrue(conds, string(StackConditionAvailable)):
+		return ReleaseHealthOK // serving traffic (e.g. prior revision) though not yet converged
 	case release.State.Active():
 		return ReleaseHealthProgressing // active deploy, no rollout condition yet (pods not created)
 	default:

--- a/pkg/models/release_live_status_test.go
+++ b/pkg/models/release_live_status_test.go
@@ -73,6 +73,13 @@ var _ = ginkgo.Describe("BuildReleaseLiveStatus", func() {
 		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthOK))
 	})
 
+	ginkgo.It("rolls up ok when serving (Available) but not yet converged", func() {
+		// Serving traffic on the prior revision while the newest release has not
+		// converged — Available without Converged must not read as unavailable.
+		stack.Status.Conditions = []Condition{cond(StackConditionAvailable)}
+		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthOK))
+	})
+
 	ginkgo.It("rolls up progressing from the Progressing condition", func() {
 		stack.Status.Conditions = []Condition{cond(StackConditionProgressing)}
 		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthProgressing))

--- a/pkg/models/release_live_status_test.go
+++ b/pkg/models/release_live_status_test.go
@@ -9,6 +9,11 @@ var _ = ginkgo.Describe("BuildReleaseLiveStatus", func() {
 	var stack *Stack
 	var release *StackRelease
 
+	// cond builds a True stack condition of the given type.
+	cond := func(t StackConditionType) Condition {
+		return Condition{Type: string(t), Status: string(ConditionTrue)}
+	}
+
 	ginkgo.BeforeEach(func() {
 		release = &StackRelease{
 			ID:    "rel-1",
@@ -22,7 +27,8 @@ var _ = ginkgo.Describe("BuildReleaseLiveStatus", func() {
 				TargetRevision:     "rev-2",
 				ObservedCrRevision: "rev-2",
 				LastConverged:      &StackConvergenceRecord{ReleaseID: "rel-1", Revision: "rev-2"},
-				Conditions:         []Condition{},
+				// Healthy converged baseline: settled and serving.
+				Conditions: []Condition{cond(StackConditionConverged), cond(StackConditionAvailable)},
 			},
 			StackResources: []*StackResource{
 				{Name: "web", Status: &StackResourceStatus{State: StackResourcePhaseReady, Replicas: 2, AvailableReplicas: 2}},
@@ -42,6 +48,7 @@ var _ = ginkgo.Describe("BuildReleaseLiveStatus", func() {
 
 	ginkgo.It("overlays an active release even when another release is converged", func() {
 		release = &StackRelease{ID: "rel-2", State: ReleaseStateInProgress, Snapshot: release.Snapshot}
+		stack.Status.Conditions = []Condition{cond(StackConditionProgressing)}
 		ls := BuildReleaseLiveStatus(release, stack)
 		gomega.Expect(ls).NotTo(gomega.BeNil())
 		gomega.Expect(ls.Health).To(gomega.Equal(ReleaseHealthProgressing))
@@ -58,44 +65,51 @@ var _ = ginkgo.Describe("BuildReleaseLiveStatus", func() {
 		gomega.Expect(BuildReleaseLiveStatus(release, stack)).To(gomega.BeNil())
 	})
 
-	ginkgo.It("rolls up failed when any resource failed", func() {
-		stack.StackResources[0].Status.State = StackResourcePhaseFailed
-		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthFailed))
+	// Health is a direct rollup of the stack's aggregate conditions (cluster-agent
+	// v0.6.6+), mirroring the agent's phase priority Failed > Progressing > Degraded > Converged.
+
+	ginkgo.It("rolls up ok from the Converged condition", func() {
+		stack.Status.Conditions = []Condition{cond(StackConditionConverged), cond(StackConditionAvailable)}
+		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthOK))
 	})
 
-	ginkgo.It("rolls up progressing when any resource is pending", func() {
-		stack.StackResources[1].Status.State = StackResourcePhasePending
+	ginkgo.It("rolls up progressing from the Progressing condition", func() {
+		stack.Status.Conditions = []Condition{cond(StackConditionProgressing)}
 		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthProgressing))
 	})
 
-	ginkgo.It("rolls up progressing when a resource has no status yet", func() {
-		stack.StackResources[1].Status = nil
-		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthProgressing))
-	})
-
-	ginkgo.It("rolls up degraded from the stack Degraded condition when no resource failed", func() {
-		stack.Status.Conditions = []Condition{{Type: string(StackConditionDegraded), Status: string(ConditionTrue)}}
+	ginkgo.It("rolls up degraded from the Degraded condition", func() {
+		stack.Status.Conditions = []Condition{cond(StackConditionDegraded)}
 		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthDegraded))
 	})
 
-	ginkgo.It("prefers progressing over degraded while any resource is still coming up", func() {
-		// A resource mid-rollout makes the whole release progressing; the Degraded
-		// condition is only surfaced once nothing is progressing, so the transient
-		// state wins and degraded doesn't fire early.
-		stack.StackResources[1].Status.State = StackResourcePhasePending
-		stack.Status.Conditions = []Condition{{Type: string(StackConditionDegraded), Status: string(ConditionTrue)}}
-		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthProgressing))
-	})
-
-	ginkgo.It("rolls up progressing when any resource is unknown", func() {
-		stack.StackResources[1].Status.State = StackResourcePhaseUnknown
-		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthProgressing))
-	})
-
-	ginkgo.It("rolls up failed when unknown and failed resources are both present", func() {
-		stack.StackResources[0].Status.State = StackResourcePhaseUnknown
-		stack.StackResources[1].Status.State = StackResourcePhaseFailed
+	ginkgo.It("rolls up failed from the Stalled condition", func() {
+		stack.Status.Conditions = []Condition{cond(StackConditionStalled)}
 		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthFailed))
+	})
+
+	ginkgo.It("prefers failed over progressing when both Stalled and Progressing are set", func() {
+		stack.Status.Conditions = []Condition{cond(StackConditionStalled), cond(StackConditionProgressing)}
+		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthFailed))
+	})
+
+	ginkgo.It("prefers progressing over degraded when both are set", func() {
+		stack.Status.Conditions = []Condition{cond(StackConditionProgressing), cond(StackConditionDegraded)}
+		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthProgressing))
+	})
+
+	ginkgo.It("rolls up progressing for an active release with no rollout condition yet", func() {
+		release.State = ReleaseStateInProgress
+		stack.Status.Conditions = []Condition{}
+		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthProgressing))
+	})
+
+	ginkgo.It("rolls up unavailable for a live release that is no longer serving", func() {
+		// Live (non-active) release with no positive condition and not serving —
+		// rolled out once, now down.
+		release.State = ReleaseStateReleased
+		stack.Status.Conditions = []Condition{}
+		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthUnavailable))
 	})
 
 	ginkgo.It("scopes live_status.resources to only the release's snapshot members", func() {
@@ -109,15 +123,5 @@ var _ = ginkgo.Describe("BuildReleaseLiveStatus", func() {
 		gomega.Expect(ls.Resources).To(gomega.HaveLen(1))
 		gomega.Expect(ls.Resources).To(gomega.HaveKey("web"))
 		gomega.Expect(ls.Resources).NotTo(gomega.HaveKey("busybox"))
-	})
-
-	ginkgo.It("ignores a resource's failed status when it is absent from the release snapshot", func() {
-		release.Snapshot = StackSnapshot{Resources: []*StackResource{{Name: "web"}}}
-		stack.StackResources = append(stack.StackResources, &StackResource{
-			Name:   "busybox",
-			Status: &StackResourceStatus{State: StackResourcePhaseFailed},
-		})
-
-		gomega.Expect(BuildReleaseLiveStatus(release, stack).Health).To(gomega.Equal(ReleaseHealthOK))
 	})
 })

--- a/pkg/models/stack.go
+++ b/pkg/models/stack.go
@@ -99,6 +99,7 @@ type StackConditionType string
 
 const (
 	StackConditionAvailable      StackConditionType = "Available"
+	StackConditionConverged      StackConditionType = "Converged"
 	StackConditionResourcesReady StackConditionType = "ResourcesReady"
 	StackConditionStalled        StackConditionType = "Stalled"
 	StackConditionDegraded       StackConditionType = "Degraded"
@@ -149,6 +150,17 @@ type Stack struct {
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
 	DeletionTimestamp *time.Time `gorm:"default:NULL"`
+}
+
+func (s *Stack) HasConvergedRelease() bool {
+	return s.Status != nil && s.Status.LastConverged != nil && s.Status.LastConverged.ReleaseID != ""
+}
+
+func (s *Stack) GetConvergedReleaseID() string {
+	if s.Status == nil || s.Status.LastConverged == nil {
+		return ""
+	}
+	return s.Status.LastConverged.ReleaseID
 }
 
 // hasImageBuilds

--- a/pkg/presenters/stack.go
+++ b/pkg/presenters/stack.go
@@ -16,22 +16,22 @@ func PresentStackList(stacks []*models.Stack, refs map[string]models.StackReleas
 
 func PresentStack(s *models.Stack, refs models.StackReleaseRefs) openapi.Stack {
 	return openapi.Stack{
-		Id:             &s.ID,
-		OrganisationId: &s.OrganisationID,
-		ProjectId:      &s.ProjectID,
-		UserId:         &s.UserID,
-		Name:           s.Name,
-		Namespace:      &s.Namespace,
-		Labels:         presentLabels(s.Labels),
-		Revision:       &s.CrRevision,
-		Annotations:    presentAnnotations(s.Annotations),
-		Spec:           presentStackSpec(s),
-		Settings:       presentStackSettings(s),
-		Lifecycle:      ptr.To(presentStackLifecycle(s)),
-		CurrentRelease: presentReleaseSummary(refs.Current, s, true),
-		LatestRelease:  presentReleaseSummary(refs.Latest, s, false),
-		CreatedAt:      &s.CreatedAt,
-		UpdatedAt:      &s.UpdatedAt,
+		Id:               &s.ID,
+		OrganisationId:   &s.OrganisationID,
+		ProjectId:        &s.ProjectID,
+		UserId:           &s.UserID,
+		Name:             s.Name,
+		Namespace:        &s.Namespace,
+		Labels:           presentLabels(s.Labels),
+		Revision:         &s.CrRevision,
+		Annotations:      presentAnnotations(s.Annotations),
+		Spec:             presentStackSpec(s),
+		Settings:         presentStackSettings(s),
+		Lifecycle:        ptr.To(presentStackLifecycle(s)),
+		ConvergedRelease: presentReleaseSummary(refs.Converged, convergedReleaseHealth(refs.Converged, s)),
+		LatestRelease:    presentReleaseSummary(refs.Latest, latestReleaseHealth(refs.Latest)),
+		CreatedAt:        &s.CreatedAt,
+		UpdatedAt:        &s.UpdatedAt,
 	}
 }
 
@@ -42,28 +42,36 @@ func presentStackLifecycle(s *models.Stack) openapi.StackLifecycle {
 	return openapi.STACK_LIFECYCLE_ACTIVE
 }
 
-func presentReleaseSummary(r *models.StackRelease, s *models.Stack, isCurrent bool) *openapi.ReleaseSummary {
+func presentReleaseSummary(r *models.StackRelease, health *openapi.ReleaseHealth) *openapi.ReleaseSummary {
 	if r == nil {
 		return nil
 	}
-	summary := &openapi.ReleaseSummary{
+	return &openapi.ReleaseSummary{
 		Id:          &r.ID,
 		Sequence:    ptr.To(int32(r.Sequence)),
 		State:       ptr.To(openapi.StackReleaseState(r.State)),
 		Message:     &r.Message,
 		CreatedAt:   &r.CreatedAt,
 		CompletedAt: r.CompletedAt,
+		Health:      health,
 	}
-	summary.Health = summaryHealth(r, s, isCurrent)
-	return summary
 }
 
-func summaryHealth(r *models.StackRelease, s *models.Stack, isCurrent bool) *openapi.ReleaseHealth {
-	if isCurrent {
-		if live := models.BuildReleaseLiveStatus(r, s); live != nil {
-			return ptr.To(openapi.ReleaseHealth(live.Health))
-		}
-		return ptr.To(openapi.RELEASE_HEALTH_PROGRESSING)
+// convergedReleaseHealth is the live runtime rollup of the stack's converged
+// release — what is actually running now. refs.Converged is only ever the stack's
+// converged release, so BuildReleaseLiveStatus always returns an overlay for it.
+func convergedReleaseHealth(r *models.StackRelease, s *models.Stack) *openapi.ReleaseHealth {
+	if r == nil {
+		return nil
+	}
+	return ptr.To(openapi.ReleaseHealth(models.BuildReleaseLiveStatus(r, s).Health))
+}
+
+// latestReleaseHealth is the newest attempt's coarse lifecycle outcome. A nil
+// result means "settled — read converged_release for the running health".
+func latestReleaseHealth(r *models.StackRelease) *openapi.ReleaseHealth {
+	if r == nil {
+		return nil
 	}
 	switch r.State {
 	case models.ReleaseStateFailed:

--- a/pkg/presenters/stack_test.go
+++ b/pkg/presenters/stack_test.go
@@ -205,7 +205,7 @@ var _ = Describe("PresentStack release-centric fields", func() {
 		s := &models.Stack{ID: "s1", Name: "app"}
 		out := presenters.PresentStack(s, models.StackReleaseRefs{})
 		Expect(*out.Lifecycle).To(Equal(openapi.STACK_LIFECYCLE_ACTIVE))
-		Expect(out.CurrentRelease).To(BeNil())
+		Expect(out.ConvergedRelease).To(BeNil())
 		Expect(out.LatestRelease).To(BeNil())
 	})
 
@@ -220,15 +220,21 @@ var _ = Describe("PresentStack release-centric fields", func() {
 		current := &models.StackRelease{ID: "r1", Sequence: 3, State: models.ReleaseStateReleased, Message: "Release is live"}
 		latest := &models.StackRelease{ID: "r2", Sequence: 4, State: models.ReleaseStateInProgress}
 		s := &models.Stack{
-			ID:     "s1",
-			Status: &models.StackStatus{LastConverged: &models.StackConvergenceRecord{ReleaseID: "r1"}},
+			ID: "s1",
+			Status: &models.StackStatus{
+				LastConverged: &models.StackConvergenceRecord{ReleaseID: "r1"},
+				Conditions: []models.Condition{
+					{Type: string(models.StackConditionConverged), Status: string(models.ConditionTrue)},
+					{Type: string(models.StackConditionAvailable), Status: string(models.ConditionTrue)},
+				},
+			},
 			StackResources: []*models.StackResource{
 				{Name: "web", Status: &models.StackResourceStatus{State: models.StackResourcePhaseReady}},
 			},
 		}
-		out := presenters.PresentStack(s, models.StackReleaseRefs{Current: current, Latest: latest})
-		Expect(*out.CurrentRelease.Id).To(Equal("r1"))
-		Expect(*out.CurrentRelease.Health).To(Equal(openapi.RELEASE_HEALTH_OK))
+		out := presenters.PresentStack(s, models.StackReleaseRefs{Converged: current, Latest: latest})
+		Expect(*out.ConvergedRelease.Id).To(Equal("r1"))
+		Expect(*out.ConvergedRelease.Health).To(Equal(openapi.RELEASE_HEALTH_OK))
 		Expect(*out.LatestRelease.Id).To(Equal("r2"))
 		Expect(*out.LatestRelease.Health).To(Equal(openapi.RELEASE_HEALTH_PROGRESSING))
 	})

--- a/pkg/services/stack_release_service.go
+++ b/pkg/services/stack_release_service.go
@@ -182,12 +182,6 @@ func (s *stackReleaseService) createReleaseForStack(ctx context.Context, stack *
 	if err := s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, &models.StackRelease{ID: created.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue release: %s", err.Error())
 	}
-	s.logger.WithFields(map[string]interface{}{
-		logger.FieldStackID:   stack.ID,
-		logger.FieldReleaseID: created.ID,
-		"sequence":            created.Sequence,
-		"cause":               cause.Kind,
-	}).Info(ctx, "created release")
 	return created, nil
 }
 
@@ -264,12 +258,6 @@ func (s *stackReleaseService) RollbackRelease(ctx context.Context, stackID, from
 	if err := s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, &models.StackRelease{ID: created.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue release: %s", err.Error())
 	}
-	s.logger.WithFields(map[string]interface{}{
-		logger.FieldStackID:   stackID,
-		logger.FieldReleaseID: created.ID,
-		"sequence":            created.Sequence,
-		"rollback_from":       src.Sequence,
-	}).Info(ctx, "created rollback release")
 	return created, nil
 }
 
@@ -310,64 +298,6 @@ func (s *stackReleaseService) GetReleaseDetail(ctx context.Context, releaseID st
 	return release, models.BuildReleaseLiveStatus(release, stack), nil
 }
 
-// InternalGetReleaseRefs batch-resolves the latest and currently converged
-// release for each given stack. No permission checks: callers have already
-// authorized the stacks.
-func (s *stackReleaseService) InternalGetReleaseRefs(ctx context.Context, stacks []*models.Stack) (map[string]models.StackReleaseRefs, *errors.ServiceError) {
-	stackIDs := make([]string, len(stacks))
-	for i, stack := range stacks {
-		stackIDs[i] = stack.ID
-	}
-
-	latestByStackID, sErr := s.store.GetLatestByStackIDs(ctx, stackIDs)
-	if sErr != nil {
-		return nil, sErr
-	}
-
-	refs := make(map[string]models.StackReleaseRefs, len(stacks))
-	var missingCurrentIDs []string
-	for _, stack := range stacks {
-		entry := models.StackReleaseRefs{Latest: latestByStackID[stack.ID]}
-		if currentID := convergedReleaseID(stack); currentID != "" {
-			if entry.Latest != nil && entry.Latest.ID == currentID {
-				entry.Current = entry.Latest
-			} else {
-				missingCurrentIDs = append(missingCurrentIDs, currentID)
-			}
-		}
-		refs[stack.ID] = entry
-	}
-
-	if len(missingCurrentIDs) > 0 {
-		currentByID, sErr := s.store.GetByIDs(ctx, missingCurrentIDs)
-		if sErr != nil {
-			return nil, sErr
-		}
-		for _, stack := range stacks {
-			currentID := convergedReleaseID(stack)
-			if currentID == "" {
-				continue
-			}
-			entry := refs[stack.ID]
-			if entry.Current == nil {
-				entry.Current = currentByID[currentID]
-				refs[stack.ID] = entry
-			}
-		}
-	}
-
-	return refs, nil
-}
-
-// convergedReleaseID returns the release ID the stack last converged to, or
-// "" if the stack has never converged.
-func convergedReleaseID(stack *models.Stack) string {
-	if stack.Status == nil || stack.Status.LastConverged == nil {
-		return ""
-	}
-	return stack.Status.LastConverged.ReleaseID
-}
-
 func (s *stackReleaseService) ListReleases(ctx context.Context, stackID string, params stores.ListParams) (*stores.PaginatedResult[*models.StackRelease], *errors.ServiceError) {
 	stack, sErr := s.stackQuery.GetStack(ctx, stackID)
 	if sErr != nil {
@@ -384,15 +314,14 @@ func (s *stackReleaseService) ListReleases(ctx context.Context, stackID string, 
 const (
 	releaseEventsDefaultLimit = 100
 	releaseEventsMaxLimit     = 500
+	// releaseCancelledMessage is the user-facing message recorded on the
+	// release_cancelled terminal event.
+	releaseCancelledMessage = "Release cancelled"
+
+	// releaseLiveMessage is the user-facing message recorded on the
+	// release_released terminal event.
+	releaseLiveMessage = "Release is live"
 )
-
-// releaseCancelledMessage is the user-facing message recorded on the
-// release_cancelled terminal event.
-const releaseCancelledMessage = "Release cancelled"
-
-// releaseLiveMessage is the user-facing message recorded on the
-// release_released terminal event.
-const releaseLiveMessage = "Release is live"
 
 // ReleaseEventPage is a sequence-cursor page of release events.
 type ReleaseEventPage struct {
@@ -504,12 +433,68 @@ func (s *stackReleaseService) CancelRelease(ctx context.Context, releaseID strin
 	// The CAS win already persisted the cancellation; recording is best-effort.
 	rel.State = models.ReleaseStateCancelled
 	if recErr := s.eventRecorder.RecordReleaseTerminal(ctx, rel, models.ReleaseStateCancelled, releaseCancelledMessage); recErr != nil {
-		s.logger.Error(ctx, "release %s: failed to record release_cancelled event: %v", rel.ID, recErr)
+		s.logger.Errorf("release %s: failed to record release_cancelled event: %v", rel.ID, recErr)
 	}
 	return nil
 }
 
 // --- Internal methods (no permission checks, called by workers/controllers) ---
+
+// InternalGetReleaseRefs batch-resolves the latest and currently converged
+// release for each given stack. No permission checks: callers have already
+// authorized the stacks.
+func (s *stackReleaseService) InternalGetReleaseRefs(ctx context.Context, stacks []*models.Stack) (map[string]models.StackReleaseRefs, *errors.ServiceError) {
+	stackIDs := make([]string, len(stacks))
+	for i, stack := range stacks {
+		stackIDs[i] = stack.ID
+	}
+
+	latestReleasesByStackID, sErr := s.store.GetLatestByStackIDs(ctx, stackIDs)
+	if sErr != nil {
+		return nil, sErr
+	}
+
+	covergedReleaseIDs := make([]string, 0)
+	for _, stack := range stacks {
+		latestRelease := latestReleasesByStackID[stack.ID]
+		// We dont want to fetch the converged release if:
+		// - There is no latest release (the stack is not deployed, so no question of convergence)
+		// - The stack has no converged release (the stack is not converged)
+		// - The converged release is the same as the latest release (the stack is converged to the latest release)
+		if latestRelease == nil || !stack.HasConvergedRelease() || stack.GetConvergedReleaseID() == latestRelease.ID {
+			continue
+		}
+		covergedReleaseIDs = append(covergedReleaseIDs, stack.GetConvergedReleaseID())
+	}
+
+	convergedReleases, sErr := s.store.GetByIDs(ctx, covergedReleaseIDs)
+	if sErr != nil {
+		return nil, sErr
+	}
+
+	convergedReleasesByStackID := make(map[string]*models.StackRelease)
+	for _, release := range convergedReleases {
+		convergedReleasesByStackID[release.StackID] = release
+	}
+
+	refs := make(map[string]models.StackReleaseRefs, len(stacks))
+	for _, stack := range stacks {
+		latestRelease := latestReleasesByStackID[stack.ID]
+		entry := models.StackReleaseRefs{
+			Latest: latestRelease,
+		}
+		// If the stack has a converged release and it is the same as the latest release,
+		// set the converged release to the latest release.
+		if stack.HasConvergedRelease() && latestRelease != nil && stack.GetConvergedReleaseID() == latestRelease.ID {
+			entry.Converged = latestRelease
+		} else {
+			entry.Converged = convergedReleasesByStackID[stack.ID]
+		}
+		refs[stack.ID] = entry
+	}
+
+	return refs, nil
+}
 
 func (s *stackReleaseService) InternalGet(ctx context.Context, releaseID string) (*models.StackRelease, *errors.ServiceError) {
 	return s.store.GetByID(ctx, releaseID)
@@ -574,16 +559,16 @@ func (s *stackReleaseService) MarkFailedWithValidationErrors(ctx context.Context
 	}
 	rel, getErr := s.store.GetByID(ctx, id)
 	if getErr != nil {
-		s.logger.Error(ctx, "release %s: failed to load release for failure events: %v", id, getErr)
+		s.logger.Errorf("release %s: failed to load release for failure events: %v", id, getErr)
 		return true, nil
 	}
 	for _, verr := range verrs {
 		if recErr := s.eventRecorder.RecordReleaseCheckFailed(ctx, rel, verr.ResourceName, validationCheckKey(verr), verr.Message); recErr != nil {
-			s.logger.Error(ctx, "release %s: failed to record release_check_failed event: %v", id, recErr)
+			s.logger.Errorf("release %s: failed to record release_check_failed event: %v", id, recErr)
 		}
 	}
 	if recErr := s.eventRecorder.RecordReleaseTerminal(ctx, rel, models.ReleaseStateFailed, message); recErr != nil {
-		s.logger.Error(ctx, "release %s: failed to record release_failed event: %v", id, recErr)
+		s.logger.Errorf("release %s: failed to record release_failed event: %v", id, recErr)
 	}
 	return true, nil
 }
@@ -594,11 +579,11 @@ func (s *stackReleaseService) MarkFailedWithValidationErrors(ctx context.Context
 func (s *stackReleaseService) recordTerminalEvent(ctx context.Context, id string, state models.StackReleaseState, message string) {
 	rel, serr := s.store.GetByID(ctx, id)
 	if serr != nil {
-		s.logger.Error(ctx, "release %s: failed to load release for %s event: %v", id, state, serr)
+		s.logger.Errorf("release %s: failed to load release for %s event: %v", id, state, serr)
 		return
 	}
 	if recErr := s.eventRecorder.RecordReleaseTerminal(ctx, rel, state, message); recErr != nil {
-		s.logger.Error(ctx, "release %s: failed to record %s event: %v", id, state, recErr)
+		s.logger.Errorf("release %s: failed to record %s event: %v", id, state, recErr)
 	}
 }
 

--- a/pkg/services/stack_release_service_test.go
+++ b/pkg/services/stack_release_service_test.go
@@ -768,6 +768,10 @@ var _ = Describe("stackReleaseService.GetReleaseDetail", func() {
 			ProjectID: detailProjectID,
 			Status: &models.StackStatus{
 				LastConverged: &models.StackConvergenceRecord{ReleaseID: "rel-1", Revision: "rev-1"},
+				Conditions: []models.Condition{
+					{Type: string(models.StackConditionConverged), Status: string(models.ConditionTrue)},
+					{Type: string(models.StackConditionAvailable), Status: string(models.ConditionTrue)},
+				},
 			},
 			StackResources: []*models.StackResource{
 				{Name: "web", Status: &models.StackResourceStatus{State: models.StackResourcePhaseReady}},
@@ -823,7 +827,7 @@ var _ = Describe("stackReleaseService.InternalGetReleaseRefs", func() {
 		ctrl.Finish()
 	})
 
-	It("resolves latest and current per stack in a batch", func() {
+	It("resolves latest and converged per stack in a batch", func() {
 		stacks := []*models.Stack{
 			{ID: "s1", Status: &models.StackStatus{LastConverged: &models.StackConvergenceRecord{ReleaseID: "r-live"}}},
 			{ID: "s2"}, // never deployed
@@ -838,22 +842,24 @@ var _ = Describe("stackReleaseService.InternalGetReleaseRefs", func() {
 		refs, serr := svc.InternalGetReleaseRefs(ctx, stacks)
 		Expect(serr).To(BeNil())
 		Expect(refs["s1"].Latest.ID).To(Equal("r-new"))
-		Expect(refs["s1"].Current.ID).To(Equal("r-live"))
+		Expect(refs["s1"].Converged.ID).To(Equal("r-live"))
 		Expect(refs["s2"].Latest).To(BeNil())
-		Expect(refs["s2"].Current).To(BeNil())
+		Expect(refs["s2"].Converged).To(BeNil())
 	})
 
-	It("skips the by-ids query when latest already covers current", func() {
+	It("reuses latest as converged when already converged to it", func() {
 		stacks := []*models.Stack{
 			{ID: "s1", Status: &models.StackStatus{LastConverged: &models.StackConvergenceRecord{ReleaseID: "r-new"}}},
 		}
 		latest := &models.StackRelease{ID: "r-new", StackID: "s1", Sequence: 9}
 		releaseStore.EXPECT().GetLatestByStackIDs(ctx, []string{"s1"}).
 			Return(map[string]*models.StackRelease{"s1": latest}, nil)
+		releaseStore.EXPECT().GetByIDs(ctx, []string{}).
+			Return(map[string]*models.StackRelease{}, nil)
 
 		refs, serr := svc.InternalGetReleaseRefs(ctx, stacks)
 		Expect(serr).To(BeNil())
-		Expect(refs["s1"].Current).To(BeIdenticalTo(refs["s1"].Latest))
+		Expect(refs["s1"].Converged).To(BeIdenticalTo(refs["s1"].Latest))
 	})
 })
 

--- a/pkg/services/stack_service.go
+++ b/pkg/services/stack_service.go
@@ -47,7 +47,6 @@ type StackQueryService interface {
 	GetStack(ctx context.Context, ID string) (*models.Stack, *errors.ServiceError)
 	GetStackTopology(ctx context.Context, ID string) (*models.StackTopology, *errors.ServiceError)
 	InternalGetStack(ctx context.Context, ID string) (*models.Stack, *errors.ServiceError)
-	// GetStacksByUserID(ctx context.Context, projectID, orgID, userID string) ([]*models.Stack, *errors.ServiceError)
 	GetStacksByProjectID(ctx context.Context, projectID string) ([]*models.Stack, *errors.ServiceError)
 	GetStacksByOrganisationID(ctx context.Context, organisationID string) ([]*models.Stack, *errors.ServiceError)
 	ListStacksForCurrentUser(ctx context.Context, orgID string) ([]*models.Stack, *errors.ServiceError)

--- a/pkg/stores/pgstore/stack_release.go
+++ b/pkg/stores/pgstore/stack_release.go
@@ -365,11 +365,9 @@ func (s *stackReleaseStore) GetLatestByStackIDs(ctx context.Context, stackIDs []
 	}
 	var releases []*models.StackRelease
 	err := s.sessionFactory.New(ctx).
-		Where("id IN (?)", s.sessionFactory.New(ctx).
-			Model(&models.StackRelease{}).
-			Select("DISTINCT ON (stack_id) id").
-			Where("stack_id IN ?", stackIDs).
-			Order("stack_id, sequence DESC")).
+		Select("DISTINCT ON (stack_id) *").
+		Where("stack_id IN ?", stackIDs).
+		Order("stack_id, sequence DESC").
 		Find(&releases).Error
 	if err != nil {
 		return nil, errors.GeneralError("failed to get latest releases: %s", err.Error())

--- a/pkg/testutil/deps.go
+++ b/pkg/testutil/deps.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Stackdome agent Helm chart (bundles cluster-agent + all dependencies)
-	DefaultChartVersion = "0.6.5-alpha"
+	DefaultChartVersion = "0.6.6-alpha"
 	ChartRepo           = "oci://quay.io/stackdome/charts/stackdome-agent"
 	ChartReleaseName    = "stackdome-agent"
 	ChartNamespace      = "stackdome-control-plane"

--- a/test/int/release_e2e_test.go
+++ b/test/int/release_e2e_test.go
@@ -64,9 +64,9 @@ var _ = Describe("Release E2E", Ordered, func() {
 			By("Verifying the release-centric stack summary reflects convergence")
 			convergedStack := shared.GetStack(client, orgID, projectName, stackID)
 			Expect(convergedStack.GetLifecycle()).To(Equal(openapi.STACK_LIFECYCLE_ACTIVE))
-			currentRelease := convergedStack.GetCurrentRelease()
-			Expect(currentRelease.GetId()).To(Equal(released.GetId()))
-			Expect(currentRelease.GetHealth()).To(Equal(openapi.RELEASE_HEALTH_OK))
+			convergedRelease := convergedStack.GetConvergedRelease()
+			Expect(convergedRelease.GetId()).To(Equal(released.GetId()))
+			Expect(convergedRelease.GetHealth()).To(Equal(openapi.RELEASE_HEALTH_OK))
 			latestRelease := convergedStack.GetLatestRelease()
 			Expect(latestRelease.GetId()).To(Equal(released.GetId()))
 

--- a/test/int/shared/cluster_helpers.go
+++ b/test/int/shared/cluster_helpers.go
@@ -320,7 +320,7 @@ func WaitForStackCRExists(ctx context.Context, clusterClient client.Client, name
 // WaitForStackActive polls the stack API until it responds 200 with an
 // active lifecycle. The wait for stacks that never deploy (e.g. skip-cluster-
 // provisioning fixtures): they have no releases, so WaitForStackReady's
-// current_release gate would never pass.
+// converged_release gate would never pass.
 func WaitForStackActive(apiClient *openapi.APIClient, orgID, projectName, stackID string, timeout time.Duration) *openapi.Stack {
 	var stack *openapi.Stack
 	Eventually(func(g Gomega) {
@@ -344,18 +344,18 @@ func WaitForStackReady(apiClient *openapi.APIClient, orgID, projectName, stackID
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(httpResp.StatusCode).To(Equal(200))
 
-		current, ok := resp.GetCurrentReleaseOk()
-		g.Expect(ok).To(BeTrue(), "stack should have a current_release")
+		current, ok := resp.GetConvergedReleaseOk()
+		g.Expect(ok).To(BeTrue(), "stack should have a converged_release")
 
 		state, stateOk := current.GetStateOk()
-		g.Expect(stateOk).To(BeTrue(), "current_release should have a state")
+		g.Expect(stateOk).To(BeTrue(), "converged_release should have a state")
 		if *state == openapi.RELEASE_STATE_FAILED {
 			StopTrying(fmt.Sprintf("stack %s release %s went terminal Failed while waiting for Released", stackID, current.GetId())).Now()
 		}
 		g.Expect(*state).To(Equal(openapi.RELEASE_STATE_RELEASED), "current release should be Released, got: %s", *state)
 
 		health, healthOk := current.GetHealthOk()
-		g.Expect(healthOk).To(BeTrue(), "current_release should have health")
+		g.Expect(healthOk).To(BeTrue(), "converged_release should have health")
 		g.Expect(*health).To(Equal(openapi.RELEASE_HEALTH_OK), "current release should be healthy, got: %s", *health)
 
 		stack = resp
@@ -604,7 +604,7 @@ func getStackResourceLiveStatus(apiClient *openapi.APIClient, orgID, projectName
 	Expect(httpResp.StatusCode).To(Equal(200))
 
 	releaseID := ""
-	if current, ok := stack.GetCurrentReleaseOk(); ok {
+	if current, ok := stack.GetConvergedReleaseOk(); ok {
 		releaseID = current.GetId()
 	} else if latest, ok := stack.GetLatestReleaseOk(); ok {
 		releaseID = latest.GetId()

--- a/test/int/stack_dual_flow_test.go
+++ b/test/int/stack_dual_flow_test.go
@@ -68,12 +68,12 @@ var _ = Describe("Stack dual-flow (thin vs fat)", func() {
 		By("Waiting for the stack to become Ready")
 		ready := shared.WaitForStackReady(client, orgID, projectName, shell.GetId(), 5*time.Minute)
 
-		currentRelease, ok := ready.GetCurrentReleaseOk()
-		Expect(ok).To(BeTrue(), "ready stack should have a current_release")
-		Expect(currentRelease.GetState()).To(Equal(openapi.RELEASE_STATE_RELEASED))
-		Expect(currentRelease.GetHealth()).To(Equal(openapi.RELEASE_HEALTH_OK))
+		convergedRelease, ok := ready.GetConvergedReleaseOk()
+		Expect(ok).To(BeTrue(), "ready stack should have a converged_release")
+		Expect(convergedRelease.GetState()).To(Equal(openapi.RELEASE_STATE_RELEASED))
+		Expect(convergedRelease.GetHealth()).To(Equal(openapi.RELEASE_HEALTH_OK))
 
-		releaseDetail := shared.GetRelease(client, orgID, projectName, shell.GetId(), currentRelease.GetId())
+		releaseDetail := shared.GetRelease(client, orgID, projectName, shell.GetId(), convergedRelease.GetId())
 		liveStatus, ok := releaseDetail.GetLiveStatusOk()
 		Expect(ok).To(BeTrue())
 		Expect(liveStatus.GetConditions()).NotTo(BeEmpty(), "ready stack should have conditions")
@@ -91,10 +91,10 @@ var _ = Describe("Stack dual-flow (thin vs fat)", func() {
 		By("Waiting for the stack to become Ready")
 		ready := shared.WaitForStackReady(client, orgID, projectName, stackID, 5*time.Minute)
 
-		currentRelease, ok := ready.GetCurrentReleaseOk()
-		Expect(ok).To(BeTrue(), "ready stack should have a current_release")
-		Expect(currentRelease.GetState()).To(Equal(openapi.RELEASE_STATE_RELEASED))
-		Expect(currentRelease.GetHealth()).To(Equal(openapi.RELEASE_HEALTH_OK))
+		convergedRelease, ok := ready.GetConvergedReleaseOk()
+		Expect(ok).To(BeTrue(), "ready stack should have a converged_release")
+		Expect(convergedRelease.GetState()).To(Equal(openapi.RELEASE_STATE_RELEASED))
+		Expect(convergedRelease.GetHealth()).To(Equal(openapi.RELEASE_HEALTH_OK))
 	})
 
 	It("both flows produce the same topology", func() {

--- a/test/int/stack_e2e_test.go
+++ b/test/int/stack_e2e_test.go
@@ -61,9 +61,9 @@ var _ = Describe("Stack E2E", Ordered, func() {
 			readyStack := shared.WaitForStackReady(client, orgID, projectName, stackID, 5*time.Minute)
 
 			By("Verifying current release is healthy with conditions")
-			currentRelease, ok := readyStack.GetCurrentReleaseOk()
+			convergedRelease, ok := readyStack.GetConvergedReleaseOk()
 			Expect(ok).To(BeTrue())
-			releaseDetail := shared.GetRelease(client, orgID, projectName, stackID, currentRelease.GetId())
+			releaseDetail := shared.GetRelease(client, orgID, projectName, stackID, convergedRelease.GetId())
 			liveStatus, ok := releaseDetail.GetLiveStatusOk()
 			Expect(ok).To(BeTrue())
 			Expect(liveStatus.GetConditions()).NotTo(BeEmpty())


### PR DESCRIPTION
## 📝 What this does
Moves release health onto the converged release and derives it from cluster-agent v0.6.6-alpha's independent Stack conditions, so a stack that rolled out but stopped serving traffic surfaces as `unavailable` instead of a false `ok`.

## 🔀 Changes
- Renamed `current_release` to `converged_release` across the API surface, generated clients, presenters, and frontend consumers.
- Reworked `rollupHealth` to read `stack.Status.Conditions` instead of iterating resource state, adding an `unavailable` health value.
- Split presenter health into converged-release runtime rollup and latest-attempt lifecycle outcome.
- Refactored release-refs resolution around converged-release helpers and simplified the latest-per-stack query.
- Bumped the stackdome-agent chart to 0.6.6-alpha.

## 🧪 How to test
- [ ] Deploy a stack, confirm the header health reads from `converged_release`.
- [ ] Take a live stack out of service, confirm health shows `unavailable` (error variant).
- [ ] Deploy a failing release over a live one, confirm converged health stays accurate.