### PR TITLE
Feature: Author resource connections on a not-yet-created draft stack

### DIFF
--- a/frontend/src/pages/stacks/components/canvas/ResourceDrawer.tsx
+++ b/frontend/src/pages/stacks/components/canvas/ResourceDrawer.tsx
@@ -13,6 +13,7 @@ import { StackResourceDeploymentTab } from "@/pages/stacks/components/shared/sta
 import { StackResourceEnvironmentTab } from "@/pages/stacks/components/shared/stack-resource-environment-tab";
 import { useResourceTabProps } from "@/pages/stacks/components/shared/hooks/use-resource-tab-props";
 import { nodePresentation } from "@/pages/stacks/lib/canvas/node-presentation";
+import { deriveResourceOutputNames } from "@/pages/stacks/lib/derive-resource-outputs";
 import { NodeGlyph } from "./nodes/node-glyph";
 
 /** Radix tab values used by the sub-tab components (they render their own TabsContent). */
@@ -94,7 +95,7 @@ export function ResourceDrawer({
         index: i,
         outputs:
           serverOutputsByName?.get(r.name ?? "") ??
-          (r.outputs ?? []).map((o: { name: string }) => o.name),
+          deriveResourceOutputNames(r),
       })),
     [session.draft.resources, serverOutputsByName],
   );

--- a/frontend/src/pages/stacks/components/shared/hooks/use-resource-tab-props.ts
+++ b/frontend/src/pages/stacks/components/shared/hooks/use-resource-tab-props.ts
@@ -169,7 +169,8 @@ export function useResourceTabProps(args: {
     [context.allResources, thisResourceName],
   );
   // Prefer the server-truth outputs for this resource's own name; fall back to
-  // the draft copy's outputs (empty for a resource added but not yet saved).
+  // outputs derived from the draft's ports (a resource added but not yet saved
+  // has no server-computed outputs).
   const selfOutputs = useMemo(
     () =>
       context.serverOutputsByName?.get(resource.name ?? "") ??

--- a/frontend/src/pages/stacks/components/shared/hooks/use-resource-tab-props.ts
+++ b/frontend/src/pages/stacks/components/shared/hooks/use-resource-tab-props.ts
@@ -16,6 +16,7 @@ import type { PostgresAddon } from "@/api/addons";
 import { StackResourceConfigurationTab, pickConfigurationDraft } from "../stack-resource-configuration-tab";
 import { StackResourceDeploymentTab, pickDeploymentDraft } from "../stack-resource-deployment-tab";
 import { StackResourceEnvironmentTab } from "../stack-resource-environment-tab";
+import { deriveResourceOutputNames } from "@/pages/stacks/lib/derive-resource-outputs";
 
 /**
  * Page-level context the three resource sub-tabs need but that does not vary per
@@ -172,8 +173,8 @@ export function useResourceTabProps(args: {
   const selfOutputs = useMemo(
     () =>
       context.serverOutputsByName?.get(resource.name ?? "") ??
-      (resource.outputs ?? []).map((o: { name: string }) => o.name),
-    [context.serverOutputsByName, resource.name, resource.outputs],
+      deriveResourceOutputNames(resource),
+    [context.serverOutputsByName, resource.name, resource.ports],
   );
 
   return {

--- a/frontend/src/pages/stacks/lib/derive-resource-outputs.test.ts
+++ b/frontend/src/pages/stacks/lib/derive-resource-outputs.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { deriveResourceOutputNames } from "./derive-resource-outputs";
+
+// Mirror of pkg/models/output_descriptor.go::StackResourceOutputDescriptors.
+// Keep these cases in sync with that function.
+describe("deriveResourceOutputNames", () => {
+  it("returns only host when the resource has no ports", () => {
+    expect(deriveResourceOutputNames({ ports: [] })).toEqual(["host"]);
+    expect(deriveResourceOutputNames({})).toEqual(["host"]);
+    expect(deriveResourceOutputNames({ ports: null })).toEqual(["host"]);
+  });
+
+  it("adds port.<name> and url.<name> for a private port", () => {
+    expect(
+      deriveResourceOutputNames({ ports: [{ name: "http-80", exposed_to_public: false }] }),
+    ).toEqual(["host", "port.http-80", "url.http-80"]);
+  });
+
+  it("adds public.<name>.host and public.<name>.url for a public port", () => {
+    expect(
+      deriveResourceOutputNames({ ports: [{ name: "http-80", exposed_to_public: true }] }),
+    ).toEqual([
+      "host",
+      "port.http-80",
+      "url.http-80",
+      "public.http-80.host",
+      "public.http-80.url",
+    ]);
+  });
+
+  it("handles multiple ports (mixed public/private) in order", () => {
+    expect(
+      deriveResourceOutputNames({
+        ports: [
+          { name: "api", exposed_to_public: true },
+          { name: "grpc", exposed_to_public: false },
+        ],
+      }),
+    ).toEqual([
+      "host",
+      "port.api",
+      "url.api",
+      "public.api.host",
+      "public.api.url",
+      "port.grpc",
+      "url.grpc",
+    ]);
+  });
+
+  it("skips ports with no name (cannot form a stable output key)", () => {
+    expect(
+      deriveResourceOutputNames({ ports: [{ exposed_to_public: true }] }),
+    ).toEqual(["host"]);
+  });
+});

--- a/frontend/src/pages/stacks/lib/derive-resource-outputs.ts
+++ b/frontend/src/pages/stacks/lib/derive-resource-outputs.ts
@@ -1,0 +1,21 @@
+// Client mirror of pkg/models/output_descriptor.go::StackResourceOutputDescriptors.
+// The server computes a resource's output DESCRIPTORS purely from its spec
+// (host + per-port names). The values need a deployment; the names do not, so we
+// derive them here for draft resources that have never been persisted. Keep this
+// in sync with the Go function above.
+
+export interface OutputSourceResource {
+  ports?: ReadonlyArray<{ name?: string; exposed_to_public?: boolean }> | null;
+}
+
+export function deriveResourceOutputNames(resource: OutputSourceResource): string[] {
+  const names = ["host"];
+  for (const port of resource.ports ?? []) {
+    if (!port.name) continue;
+    names.push(`port.${port.name}`, `url.${port.name}`);
+    if (port.exposed_to_public) {
+      names.push(`public.${port.name}.host`, `public.${port.name}.url`);
+    }
+  }
+  return names;
+}


### PR DESCRIPTION
## 📝 What this does
When you build a new stack from building blocks, its resources live client-side as a draft until you hit Deploy. Draft resources exposed no output names, so the connection/env pickers ("From: Resource" and "From: Self") were empty and disabled — you couldn't wire `mysql → web` until after the stack existed. This computes each draft resource's output names client-side so connections are authorable before the first deploy.

## 🔀 Changes
- Added a pure `deriveResourceOutputNames` that mirrors the server's `StackResourceOutputDescriptors` (host + per-port `port.<name>`/`url.<name>`, plus `public.<name>.*` for public ports).
- Used it as the draft fallback for both the sibling "Resource" picker and the "Self" picker; server-computed outputs still win once the stack exists.
- No backend or persistence change — connections already ride the atomic apply on Deploy.

## 🧪 How to test
- [ ] Create a new stack from blocks (web on :80 public + mysql), do not deploy.
- [ ] Open web → Environment → add var → From: Self → confirm the output list is populated (`host`, `port.http-80`, `url.http-80`, `public.http-80.*`).
- [ ] Add var → From: Resource → mysql → confirm outputs populate (`host`, `port.tcp-3306`, `url.tcp-3306`) and the `mysql → web` edge appears on the canvas.
- [ ] Deploy and confirm the pickers then resolve from server-computed outputs.