### PR TITLE
Feature: Human-readable stack-resource output names

### DIFF
--- a/config/openapi/stackdome_api.yaml
+++ b/config/openapi/stackdome_api.yaml
@@ -4890,7 +4890,7 @@ components:
       properties:
         name:
           type: string
-          description: Stable output accessor name, for example `host` or `public.http.url`.
+          description: Stable output accessor name, for example `host` or `public_url`.
         type:
           type: string
           description: Scalar value type exposed by this output.
@@ -5134,7 +5134,7 @@ components:
       properties:
         output:
           type: string
-          description: Output accessor on the connection's `from` node, such as `url` or `public.http.url`.
+          description: Output accessor on the connection's `from` node, such as `url` or `public_url`.
         template:
           type: string
           description: Template used when one target value must be composed from multiple outputs.
@@ -5925,7 +5925,7 @@ components:
           description: Literal environment variable value.
         self_output:
           type: string
-          description: Read this environment variable from one of the resource's own declared outputs, for example public.http.url.
+          description: Read this environment variable from one of the resource's own declared outputs, for example public_url.
 
 
     Condition:

--- a/frontend/src/api/types/openapi.d.ts
+++ b/frontend/src/api/types/openapi.d.ts
@@ -7801,7 +7801,7 @@ export interface components {
         };
         /** @description Declared output metadata for a topology node. Values are not returned here. */
         OutputDescriptor: {
-            /** @description Stable output accessor name, for example `host` or `public.http.url`. */
+            /** @description Stable output accessor name, for example `host` or `public_url`. */
             name: string;
             /**
              * @description Scalar value type exposed by this output.
@@ -7924,7 +7924,7 @@ export interface components {
         /** @description Describes how to read a value from the connection's `from` node. This is only used inside `StackConnection.mappings[]`.
          *      */
         ValueRef: {
-            /** @description Output accessor on the connection's `from` node, such as `url` or `public.http.url`. */
+            /** @description Output accessor on the connection's `from` node, such as `url` or `public_url`. */
             output?: string;
             /** @description Template used when one target value must be composed from multiple outputs. */
             template?: string;
@@ -8298,7 +8298,7 @@ export interface components {
             name: string;
             /** @description Literal environment variable value. */
             value?: string;
-            /** @description Read this environment variable from one of the resource's own declared outputs, for example public.http.url. */
+            /** @description Read this environment variable from one of the resource's own declared outputs, for example public_url. */
             self_output?: string;
         };
         Condition: {

--- a/frontend/src/pages/stacks/components/detail/deployments/tests/release-snapshot-diff.test.ts
+++ b/frontend/src/pages/stacks/components/detail/deployments/tests/release-snapshot-diff.test.ts
@@ -100,9 +100,9 @@ describe("diffSnapshots connections", () => {
 
   it("flags a changed mapping value on an existing connection", () => {
     const prev = mk({ resources: [], connections: [conn("DATABASE_URL", "url")] });
-    const cur = mk({ resources: [], connections: [conn("DATABASE_URL", "public.url")] });
+    const cur = mk({ resources: [], connections: [conn("DATABASE_URL", "public_url")] });
     expect(diffSnapshots(prev, cur).connections).toEqual([
-      { name: "env · db → api", change: "modified", rows: [{ key: "DATABASE_URL", from: "url", to: "public.url", kind: "changed" }] },
+      { name: "env · db → api", change: "modified", rows: [{ key: "DATABASE_URL", from: "url", to: "public_url", kind: "changed" }] },
     ]);
   });
 
@@ -145,11 +145,11 @@ describe("diffSnapshots connections", () => {
     });
     const cur = mk({
       resources: [web({ name: "api2" })],
-      connections: [{ ...conn("DATABASE_URL", "public.url"), to: { type: "stack_resource", name: "api2" } }],
+      connections: [{ ...conn("DATABASE_URL", "public_url"), to: { type: "stack_resource", name: "api2" } }],
     });
     const out = diffSnapshots(prev, cur);
     expect(out.connections).toEqual([
-      { name: "env · db → api2", change: "modified", rows: [{ key: "DATABASE_URL", from: "url", to: "public.url", kind: "changed" }] },
+      { name: "env · db → api2", change: "modified", rows: [{ key: "DATABASE_URL", from: "url", to: "public_url", kind: "changed" }] },
     ]);
   });
 

--- a/frontend/src/pages/stacks/components/detail/index.tsx
+++ b/frontend/src/pages/stacks/components/detail/index.tsx
@@ -288,7 +288,8 @@ export default function StackDetailPage() {
     [stackToShow],
   );
 
-  // Server-computed outputs (host, port.<n>, url.<n>, public.<n>.*) keyed by
+  // Server-computed outputs (host, port/url or port.<name>/url.<name>,
+  // public_host/public_url or public_host.<name>/public_url.<name>) keyed by
   // resource name. The working draft never computes outputs, so a resource added
   // on the canvas carries none until it is saved. The env-var OUTPUT pickers read
   // from this server-truth map (matched by name) instead of the draft copy, and

--- a/frontend/src/pages/stacks/components/shared/env-row.tsx
+++ b/frontend/src/pages/stacks/components/shared/env-row.tsx
@@ -4,7 +4,9 @@ import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -15,6 +17,7 @@ import {
   CLUSTER_WIDE_FIELDS,
   type AddonOutputField,
 } from "@/pages/stacks/lib/addon-presets";
+import { groupOutputs, type ParsedOutput } from "@/pages/stacks/lib/parse-output-key";
 
 export type EnvFrom = FormEnvVarData["from"];
 
@@ -317,6 +320,38 @@ function SecretValueCell({
   );
 }
 
+function OutputOptions({ outputs }: { outputs: string[] }) {
+  const { internal, public: pub } = groupOutputs(outputs);
+  const renderItem = (o: ParsedOutput) => (
+    <SelectItem key={o.key} value={o.key}>
+      <span className="flex w-full items-center justify-between gap-2">
+        <span>
+          {o.label}
+          {o.port ? <span className="text-muted-foreground"> · {o.port}</span> : null}
+        </span>
+        <span className="ml-2 flex items-center gap-2">
+          <span className="text-[10px] italic text-muted-foreground">resolved at deploy</span>
+          <span className="rounded bg-muted px-1 font-mono text-[10px] text-muted-foreground">{o.key}</span>
+        </span>
+      </span>
+    </SelectItem>
+  );
+  return (
+    <>
+      <SelectGroup>
+        <SelectLabel>🔒 Internal</SelectLabel>
+        {internal.map(renderItem)}
+      </SelectGroup>
+      {pub.length > 0 && (
+        <SelectGroup>
+          <SelectLabel>🌐 Public</SelectLabel>
+          {pub.map(renderItem)}
+        </SelectGroup>
+      )}
+    </>
+  );
+}
+
 function ResourceOutputCell({
   resourceOptions,
   resourceName,
@@ -352,7 +387,7 @@ function ResourceOutputCell({
             <SelectValue placeholder={outputs.length === 0 ? "No outputs" : "select output..."} />
           </SelectTrigger>
           <SelectContent>
-            {outputs.map((o) => (<SelectItem key={o} value={o}>{o}</SelectItem>))}
+            <OutputOptions outputs={outputs} />
           </SelectContent>
         </Select>
       )}
@@ -375,7 +410,7 @@ function SelfOutputCell({
         <SelectValue placeholder={outputs.length === 0 ? "No outputs declared" : "select output..."} />
       </SelectTrigger>
       <SelectContent>
-        {outputs.map((o) => (<SelectItem key={o} value={o}>{o}</SelectItem>))}
+        <OutputOptions outputs={outputs} />
       </SelectContent>
     </Select>
   );

--- a/frontend/src/pages/stacks/components/shared/stack-resource-configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/shared/stack-resource-configuration-tab.tsx
@@ -180,10 +180,14 @@ function StackResourceConfigurationTabImpl({
 
   const addPort = () => {
     const existing = draft.ports || [];
+    const number = 80;
     update({
       ports: [
         ...existing,
-        { name: `port-${existing.length + 1}`, number: 80, protocol: "tcp", exposed_to_public: false },
+        // Name derived from the number (port-<number>) so outputs read e.g.
+        // url.port-8080 instead of a meaningless positional url.port-2. k8s port
+        // names must contain a letter, so a bare number can't be the name.
+        { name: `port-${number}`, number, protocol: "tcp", exposed_to_public: false },
       ],
     });
   };
@@ -193,9 +197,17 @@ function StackResourceConfigurationTabImpl({
     patch: Partial<{ number: number; protocol: "http" | "tcp"; exposed_to_public: boolean; subdomain_prefix: string }>,
   ) => {
     update({
-      ports: (draft.ports || []).map((port: Port, i: number) =>
-        i === pidx ? { ...port, ...patch } : port,
-      ),
+      ports: (draft.ports || []).map((port: Port, i: number) => {
+        if (i !== pidx) return port;
+        const next = { ...port, ...patch };
+        // Keep the auto-derived name tracking the number so the output key stays
+        // meaningful (url.port-8080). Only re-derive while the name is still the
+        // auto value; a name the user set by hand is left untouched.
+        if (patch.number !== undefined && (!port.name || port.name === `port-${port.number}`)) {
+          next.name = `port-${patch.number}`;
+        }
+        return next;
+      }),
     });
   };
 

--- a/frontend/src/pages/stacks/components/shared/tests/env-row.test.tsx
+++ b/frontend/src/pages/stacks/components/shared/tests/env-row.test.tsx
@@ -191,15 +191,31 @@ describe("EnvRow (self variant)", () => {
       <EnvRow
         row={baseSelfRow()}
         {...noopProps}
-        selfOutputs={["public.http.url", "host"]}
+        selfOutputs={["public_url.web", "host"]}
         onChangeSelf={onChangeSelf}
       />,
     );
     await user.click(screen.getByTestId("self-output-trigger"));
-    expect(
-      await screen.findByRole("option", { name: "public.http.url" }),
-    ).toBeInTheDocument();
-    await user.click(screen.getByRole("option", { name: "public.http.url" }));
-    expect(onChangeSelf).toHaveBeenCalledWith("public.http.url");
+    const option = await screen.findByRole("option", { name: /Public URL/ });
+    expect(option).toHaveTextContent("public_url.web");
+    await user.click(option);
+    expect(onChangeSelf).toHaveBeenCalledWith("public_url.web");
+  });
+
+  it("groups outputs under Internal and Public labels with a raw-key tag", async () => {
+    const user = userEvent.setup();
+    render(
+      <EnvRow
+        row={baseSelfRow()}
+        {...noopProps}
+        selfOutputs={["host", "public_url.web"]}
+        onChangeSelf={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByTestId("self-output-trigger"));
+    expect(await screen.findByText("🔒 Internal")).toBeInTheDocument();
+    expect(screen.getByText("🌐 Public")).toBeInTheDocument();
+    const hostOption = screen.getByRole("option", { name: /^Host/ });
+    expect(hostOption).toHaveTextContent("host");
   });
 });

--- a/frontend/src/pages/stacks/lib/derive-resource-outputs.test.ts
+++ b/frontend/src/pages/stacks/lib/derive-resource-outputs.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { deriveResourceOutputNames } from "./derive-resource-outputs";
 
 // Mirror of pkg/models/output_descriptor.go::StackResourceOutputDescriptors.
-// Keep these cases in sync with that function.
 describe("deriveResourceOutputNames", () => {
   it("returns only host when the resource has no ports", () => {
     expect(deriveResourceOutputNames({ ports: [] })).toEqual(["host"]);
@@ -10,46 +9,40 @@ describe("deriveResourceOutputNames", () => {
     expect(deriveResourceOutputNames({ ports: null })).toEqual(["host"]);
   });
 
-  it("adds port.<name> and url.<name> for a private port", () => {
+  it("drops the port suffix for a single private port", () => {
     expect(
-      deriveResourceOutputNames({ ports: [{ name: "http-80", exposed_to_public: false }] }),
-    ).toEqual(["host", "port.http-80", "url.http-80"]);
+      deriveResourceOutputNames({ ports: [{ name: "3306", exposed_to_public: false }] }),
+    ).toEqual(["host", "port", "url"]);
   });
 
-  it("adds public.<name>.host and public.<name>.url for a public port", () => {
+  it("adds unsuffixed public_host/public_url for a single public port", () => {
     expect(
-      deriveResourceOutputNames({ ports: [{ name: "http-80", exposed_to_public: true }] }),
-    ).toEqual([
-      "host",
-      "port.http-80",
-      "url.http-80",
-      "public.http-80.host",
-      "public.http-80.url",
-    ]);
+      deriveResourceOutputNames({ ports: [{ name: "80", exposed_to_public: true }] }),
+    ).toEqual(["host", "port", "url", "public_host", "public_url"]);
   });
 
-  it("handles multiple ports (mixed public/private) in order", () => {
+  it("suffixes every per-port key with the port name when multi-port", () => {
     expect(
       deriveResourceOutputNames({
         ports: [
-          { name: "api", exposed_to_public: true },
+          { name: "80", exposed_to_public: true },
           { name: "grpc", exposed_to_public: false },
         ],
       }),
     ).toEqual([
       "host",
-      "port.api",
-      "url.api",
-      "public.api.host",
-      "public.api.url",
-      "port.grpc",
-      "url.grpc",
+      "port.80", "url.80", "public_host.80", "public_url.80",
+      "port.grpc", "url.grpc",
     ]);
   });
 
-  it("skips ports with no name (cannot form a stable output key)", () => {
+  it("skips ports with no name and does not count them toward multi-port", () => {
     expect(
       deriveResourceOutputNames({ ports: [{ exposed_to_public: true }] }),
     ).toEqual(["host"]);
+    // one named + one unnamed = single-port scheme (unnamed dropped)
+    expect(
+      deriveResourceOutputNames({ ports: [{ name: "3306" }, { exposed_to_public: true }] }),
+    ).toEqual(["host", "port", "url"]);
   });
 });

--- a/frontend/src/pages/stacks/lib/derive-resource-outputs.ts
+++ b/frontend/src/pages/stacks/lib/derive-resource-outputs.ts
@@ -9,12 +9,15 @@ export interface OutputSourceResource {
 }
 
 export function deriveResourceOutputNames(resource: OutputSourceResource): string[] {
+  const ports = (resource.ports ?? []).filter((p) => p.name);
+  const multiPort = ports.length > 1;
+  const key = (base: string, portName: string) => (multiPort ? `${base}.${portName}` : base);
+
   const names = ["host"];
-  for (const port of resource.ports ?? []) {
-    if (!port.name) continue;
-    names.push(`port.${port.name}`, `url.${port.name}`);
+  for (const port of ports) {
+    names.push(key("port", port.name!), key("url", port.name!));
     if (port.exposed_to_public) {
-      names.push(`public.${port.name}.host`, `public.${port.name}.url`);
+      names.push(key("public_host", port.name!), key("public_url", port.name!));
     }
   }
   return names;

--- a/frontend/src/pages/stacks/lib/parse-output-key.test.ts
+++ b/frontend/src/pages/stacks/lib/parse-output-key.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { parseOutputKey, groupOutputs } from "./parse-output-key";
+
+describe("parseOutputKey", () => {
+  it("maps clean single-port keys to internal labels", () => {
+    expect(parseOutputKey("host")).toEqual({ group: "internal", label: "Host", key: "host" });
+    expect(parseOutputKey("port")).toEqual({ group: "internal", label: "Port", key: "port" });
+    expect(parseOutputKey("url")).toEqual({ group: "internal", label: "URL", key: "url" });
+  });
+
+  it("maps public_ keys to the public group", () => {
+    expect(parseOutputKey("public_host")).toEqual({ group: "public", label: "Public Host", key: "public_host" });
+    expect(parseOutputKey("public_url")).toEqual({ group: "public", label: "Public URL", key: "public_url" });
+  });
+
+  it("extracts the port suffix without confusing url vs public_url", () => {
+    expect(parseOutputKey("url.3306")).toEqual({ group: "internal", label: "URL", port: "3306", key: "url.3306" });
+    expect(parseOutputKey("public_url.web")).toEqual({ group: "public", label: "Public URL", port: "web", key: "public_url.web" });
+  });
+
+  it("falls back to the raw key for anything unrecognized", () => {
+    expect(parseOutputKey("weird")).toEqual({ group: "internal", label: "weird", key: "weird" });
+  });
+});
+
+describe("groupOutputs", () => {
+  it("splits into internal and public buckets preserving order", () => {
+    const g = groupOutputs(["host", "port", "url", "public_host", "public_url"]);
+    expect(g.internal.map((o) => o.key)).toEqual(["host", "port", "url"]);
+    expect(g.public.map((o) => o.key)).toEqual(["public_host", "public_url"]);
+  });
+});

--- a/frontend/src/pages/stacks/lib/parse-output-key.ts
+++ b/frontend/src/pages/stacks/lib/parse-output-key.ts
@@ -1,0 +1,38 @@
+export interface ParsedOutput {
+  group: "internal" | "public";
+  label: string;
+  port?: string;
+  key: string;
+}
+
+// Longest bases first so "public_url" wins over "url" and "public_host" over "host".
+const BASES: { base: string; group: "internal" | "public"; label: string }[] = [
+  { base: "public_host", group: "public", label: "Public Host" },
+  { base: "public_url", group: "public", label: "Public URL" },
+  { base: "port", group: "internal", label: "Port" },
+  { base: "url", group: "internal", label: "URL" },
+  { base: "host", group: "internal", label: "Host" },
+];
+
+export function parseOutputKey(key: string): ParsedOutput {
+  for (const { base, group, label } of BASES) {
+    if (key === base) return { group, label, key };
+    if (key.startsWith(base + ".")) {
+      return { group, label, port: key.slice(base.length + 1), key };
+    }
+  }
+  return { group: "internal", label: key, key };
+}
+
+export function groupOutputs(outputs: string[]): {
+  internal: ParsedOutput[];
+  public: ParsedOutput[];
+} {
+  const internal: ParsedOutput[] = [];
+  const pub: ParsedOutput[] = [];
+  for (const o of outputs) {
+    const parsed = parseOutputKey(o);
+    (parsed.group === "public" ? pub : internal).push(parsed);
+  }
+  return { internal, public: pub };
+}

--- a/frontend/src/pages/stacks/lib/tests/connection-mapping.test.ts
+++ b/frontend/src/pages/stacks/lib/tests/connection-mapping.test.ts
@@ -19,9 +19,9 @@ describe("splitEnvRows", () => {
   });
 
   it("emits self rows as env vars with self_output", () => {
-    const rows: FormEnvRow[] = [{ from: "self", name: "TOOLJET_HOST", selfOutput: "public.http.url" }];
+    const rows: FormEnvRow[] = [{ from: "self", name: "TOOLJET_HOST", selfOutput: "public_url.http" }];
     const { envVars, connections } = splitEnvRows("web", rows);
-    expect(envVars).toEqual([{ name: "TOOLJET_HOST", self_output: "public.http.url" }]);
+    expect(envVars).toEqual([{ name: "TOOLJET_HOST", self_output: "public_url.http" }]);
     expect(connections).toEqual([]);
   });
 

--- a/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
+++ b/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
@@ -64,16 +64,16 @@ describe("env round-trip", () => {
       sourceType: "image" as const,
       source: { image: { ref: "nginx" } },
       execution_config: {
-        environment_variables: [{ from: "self" as const, name: "URL", selfOutput: "public.http.url" }],
+        environment_variables: [{ from: "self" as const, name: "URL", selfOutput: "public_url.http" }],
       },
     };
     const api = convertFormResourceToApiResource(form as never);
     expect(api.execution_config?.environment_variables).toEqual([
-      { name: "URL", self_output: "public.http.url" },
+      { name: "URL", self_output: "public_url.http" },
     ]);
     const back = convertApiResourceToFormResource(api as never);
     expect(back.execution_config?.environment_variables).toEqual([
-      { from: "self", name: "URL", selfOutput: "public.http.url" },
+      { from: "self", name: "URL", selfOutput: "public_url.http" },
     ]);
   });
 

--- a/pkg/api/openapi/api/openapi.yaml
+++ b/pkg/api/openapi/api/openapi.yaml
@@ -9494,7 +9494,7 @@ components:
         type: string
       properties:
         name:
-          description: "Stable output accessor name, for example `host` or `public.http.url`."
+          description: "Stable output accessor name, for example `host` or `public_url`."
           type: string
         type:
           description: Scalar value type exposed by this output.
@@ -9930,7 +9930,7 @@ components:
       properties:
         output:
           description: "Output accessor on the connection's `from` node, such as `url`\
-            \ or `public.http.url`."
+            \ or `public_url`."
           type: string
         template:
           description: Template used when one target value must be composed from multiple
@@ -11360,7 +11360,7 @@ components:
           type: string
         self_output:
           description: "Read this environment variable from one of the resource's\
-            \ own declared outputs, for example public.http.url."
+            \ own declared outputs, for example public_url."
           type: string
       required:
       - name

--- a/pkg/api/openapi/docs/EnvVar.md
+++ b/pkg/api/openapi/docs/EnvVar.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | 
 **Value** | Pointer to **string** | Literal environment variable value. | [optional] 
-**SelfOutput** | Pointer to **string** | Read this environment variable from one of the resource&#39;s own declared outputs, for example public.http.url. | [optional] 
+**SelfOutput** | Pointer to **string** | Read this environment variable from one of the resource&#39;s own declared outputs, for example public_url. | [optional] 
 
 ## Methods
 

--- a/pkg/api/openapi/docs/OutputDescriptor.md
+++ b/pkg/api/openapi/docs/OutputDescriptor.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **string** | Stable output accessor name, for example &#x60;host&#x60; or &#x60;public.http.url&#x60;. | 
+**Name** | **string** | Stable output accessor name, for example &#x60;host&#x60; or &#x60;public_url&#x60;. | 
 **Type** | **string** | Scalar value type exposed by this output. | 
 **Sensitive** | **bool** | True when the output value is sensitive and should never be returned in normal metadata APIs. | 
 

--- a/pkg/api/openapi/docs/ValueRef.md
+++ b/pkg/api/openapi/docs/ValueRef.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Output** | Pointer to **string** | Output accessor on the connection&#39;s &#x60;from&#x60; node, such as &#x60;url&#x60; or &#x60;public.http.url&#x60;. | [optional] 
+**Output** | Pointer to **string** | Output accessor on the connection&#39;s &#x60;from&#x60; node, such as &#x60;url&#x60; or &#x60;public_url&#x60;. | [optional] 
 **Template** | Pointer to **string** | Template used when one target value must be composed from multiple outputs. | [optional] 
 **Values** | Pointer to [**map[string]OutputValueRef**](OutputValueRef.md) | Named template inputs, each resolving one output from the connection&#39;s &#x60;from&#x60; node. | [optional] 
 

--- a/pkg/api/openapi/model_env_var.go
+++ b/pkg/api/openapi/model_env_var.go
@@ -19,7 +19,7 @@ type EnvVar struct {
 	Name string `json:"name"`
 	// Literal environment variable value.
 	Value *string `json:"value,omitempty"`
-	// Read this environment variable from one of the resource's own declared outputs, for example public.http.url.
+	// Read this environment variable from one of the resource's own declared outputs, for example public_url.
 	SelfOutput *string `json:"self_output,omitempty"`
 }
 

--- a/pkg/api/openapi/model_output_descriptor.go
+++ b/pkg/api/openapi/model_output_descriptor.go
@@ -16,7 +16,7 @@ import (
 
 // OutputDescriptor Declared output metadata for a topology node. Values are not returned here.
 type OutputDescriptor struct {
-	// Stable output accessor name, for example `host` or `public.http.url`.
+	// Stable output accessor name, for example `host` or `public_url`.
 	Name string `json:"name"`
 	// Scalar value type exposed by this output.
 	Type string `json:"type"`

--- a/pkg/api/openapi/model_value_ref.go
+++ b/pkg/api/openapi/model_value_ref.go
@@ -16,7 +16,7 @@ import (
 
 // ValueRef Describes how to read a value from the connection's `from` node. This is only used inside `StackConnection.mappings[]`.
 type ValueRef struct {
-	// Output accessor on the connection's `from` node, such as `url` or `public.http.url`.
+	// Output accessor on the connection's `from` node, such as `url` or `public_url`.
 	Output *string `json:"output,omitempty"`
 	// Template used when one target value must be composed from multiple outputs.
 	Template *string `json:"template,omitempty"`

--- a/pkg/models/output_descriptor.go
+++ b/pkg/models/output_descriptor.go
@@ -22,6 +22,8 @@ const (
 	OutputNameSSLMode       = "sslmode"
 	OutputNameCACertificate = "ca_certificate"
 	OutputNameURL           = "url"
+	OutputNamePublicHost    = "public_host"
+	OutputNamePublicURL     = "public_url"
 )
 
 type OutputDescriptor struct {
@@ -54,29 +56,35 @@ func (p *PostgresAddon) EnsureDeclaredOutputs() []OutputDescriptor {
 	return p.Outputs
 }
 
+// stackResourceOutputKey builds a per-port output key. A single-port resource
+// drops the suffix entirely; a multi-port resource disambiguates by port name.
+func stackResourceOutputKey(base, portName string, multiPort bool) string {
+	if !multiPort {
+		return base
+	}
+	return base + "." + portName
+}
+
 func (r *StackResource) ToOutputMap() map[string]string {
 	outputs := make(map[string]string)
 
 	host := r.InternalServiceHost()
 	outputs[OutputNameHost] = host
 
+	multiPort := len(r.Ports) > 1
 	for _, port := range r.Ports {
-		outputs["port."+port.Name] = strconv.Itoa(port.Number)
+		outputs[stackResourceOutputKey(OutputNamePort, port.Name, multiPort)] = strconv.Itoa(port.Number)
 		if port.Protocol == PortProtocolHTTP {
-			outputs["url."+port.Name] = fmt.Sprintf("http://%s:%d", host, port.Number)
+			outputs[stackResourceOutputKey(OutputNameURL, port.Name, multiPort)] = fmt.Sprintf("http://%s:%d", host, port.Number)
 		} else {
-			outputs["url."+port.Name] = fmt.Sprintf("%s:%d", host, port.Number)
+			outputs[stackResourceOutputKey(OutputNameURL, port.Name, multiPort)] = fmt.Sprintf("%s:%d", host, port.Number)
 		}
 
-		if !port.ExposedToPublic {
+		if !port.ExposedToPublic || port.ExposedFqdn == "" {
 			continue
 		}
-
-		if port.ExposedFqdn == "" {
-			continue
-		}
-		outputs["public."+port.Name+".host"] = port.ExposedFqdn
-		outputs["public."+port.Name+".url"] = "http://" + port.ExposedFqdn
+		outputs[stackResourceOutputKey(OutputNamePublicHost, port.Name, multiPort)] = port.ExposedFqdn
+		outputs[stackResourceOutputKey(OutputNamePublicURL, port.Name, multiPort)] = "http://" + port.ExposedFqdn
 	}
 
 	return outputs
@@ -99,39 +107,19 @@ func (s *Secret) ToOutputMap() map[string]string {
 
 func StackResourceOutputDescriptors(resource *StackResource) []OutputDescriptor {
 	outputs := []OutputDescriptor{
-		{
-			Name:      OutputNameHost,
-			Type:      OutputValueTypeString,
-			Sensitive: false,
-		},
+		{Name: OutputNameHost, Type: OutputValueTypeString, Sensitive: false},
 	}
 
+	multiPort := len(resource.Ports) > 1
 	for _, port := range resource.Ports {
 		outputs = append(outputs,
-			OutputDescriptor{
-				Name:      "port." + port.Name,
-				Type:      OutputValueTypeInteger,
-				Sensitive: false,
-			},
-			OutputDescriptor{
-				Name:      "url." + port.Name,
-				Type:      OutputValueTypeString,
-				Sensitive: false,
-			},
+			OutputDescriptor{Name: stackResourceOutputKey(OutputNamePort, port.Name, multiPort), Type: OutputValueTypeInteger, Sensitive: false},
+			OutputDescriptor{Name: stackResourceOutputKey(OutputNameURL, port.Name, multiPort), Type: OutputValueTypeString, Sensitive: false},
 		)
-
 		if port.ExposedToPublic {
 			outputs = append(outputs,
-				OutputDescriptor{
-					Name:      "public." + port.Name + ".host",
-					Type:      OutputValueTypeString,
-					Sensitive: false,
-				},
-				OutputDescriptor{
-					Name:      "public." + port.Name + ".url",
-					Type:      OutputValueTypeString,
-					Sensitive: false,
-				},
+				OutputDescriptor{Name: stackResourceOutputKey(OutputNamePublicHost, port.Name, multiPort), Type: OutputValueTypeString, Sensitive: false},
+				OutputDescriptor{Name: stackResourceOutputKey(OutputNamePublicURL, port.Name, multiPort), Type: OutputValueTypeString, Sensitive: false},
 			)
 		}
 	}

--- a/pkg/models/output_descriptor_test.go
+++ b/pkg/models/output_descriptor_test.go
@@ -1,0 +1,83 @@
+package models
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("StackResource output naming", func() {
+	newResource := func(ports ...Port) *StackResource {
+		return &StackResource{Name: "mysql", Ports: ports}
+	}
+	names := func(r *StackResource) []string {
+		out := []string{}
+		for _, d := range StackResourceOutputDescriptors(r) {
+			out = append(out, d.Name)
+		}
+		return out
+	}
+
+	ginkgo.It("emits only host for a zero-port resource", func() {
+		gomega.Expect(names(newResource())).To(gomega.Equal([]string{OutputNameHost}))
+	})
+
+	ginkgo.It("drops the port suffix for a single-port resource", func() {
+		r := newResource(Port{Name: "3306", Number: 3306, Protocol: PortProtocolTCP})
+		gomega.Expect(names(r)).To(gomega.Equal([]string{
+			OutputNameHost, OutputNamePort, OutputNameURL,
+		}))
+	})
+
+	ginkgo.It("adds public_host/public_url (unsuffixed) for a single public port", func() {
+		r := newResource(Port{Name: "80", Number: 80, Protocol: PortProtocolHTTP, ExposedToPublic: true, ExposedFqdn: "web.example.com"})
+		gomega.Expect(names(r)).To(gomega.Equal([]string{
+			OutputNameHost, OutputNamePort, OutputNameURL,
+			OutputNamePublicHost, OutputNamePublicURL,
+		}))
+	})
+
+	ginkgo.It("suffixes every per-port key with the port name for a multi-port resource", func() {
+		r := newResource(
+			Port{Name: "3306", Number: 3306, Protocol: PortProtocolTCP},
+			Port{Name: "metrics", Number: 9090, Protocol: PortProtocolHTTP},
+		)
+		gomega.Expect(names(r)).To(gomega.Equal([]string{
+			OutputNameHost,
+			"port.3306", "url.3306",
+			"port.metrics", "url.metrics",
+		}))
+	})
+
+	ginkgo.It("keeps ToOutputMap keys identical to the descriptor names (no drift)", func() {
+		cases := []*StackResource{
+			newResource(),
+			newResource(Port{Name: "3306", Number: 3306, Protocol: PortProtocolTCP}),
+			newResource(Port{Name: "80", Number: 80, Protocol: PortProtocolHTTP, ExposedToPublic: true, ExposedFqdn: "web.example.com"}),
+			newResource(
+				Port{Name: "3306", Number: 3306, Protocol: PortProtocolTCP},
+				Port{Name: "80", Number: 80, Protocol: PortProtocolHTTP, ExposedToPublic: true, ExposedFqdn: "web.example.com"},
+			),
+		}
+		for _, r := range cases {
+			descNames := map[string]bool{}
+			for _, d := range StackResourceOutputDescriptors(r) {
+				descNames[d.Name] = true
+			}
+			for k := range r.ToOutputMap() {
+				gomega.Expect(descNames).To(gomega.HaveKey(k), "ToOutputMap key %q missing from descriptors", k)
+			}
+			gomega.Expect(len(r.ToOutputMap())).To(gomega.Equal(len(descNames)))
+		}
+	})
+
+	ginkgo.It("emits multi-port values under the suffixed keys", func() {
+		r := newResource(
+			Port{Name: "3306", Number: 3306, Protocol: PortProtocolTCP},
+			Port{Name: "80", Number: 80, Protocol: PortProtocolHTTP, ExposedToPublic: true, ExposedFqdn: "web.example.com"},
+		)
+		m := r.ToOutputMap()
+		gomega.Expect(m["url.3306"]).To(gomega.Equal("mysql:3306"))
+		gomega.Expect(m["url.80"]).To(gomega.Equal("http://mysql:80"))
+		gomega.Expect(m[OutputNamePublicURL+".80"]).To(gomega.Equal("http://web.example.com"))
+	})
+})

--- a/pkg/presenters/stack_resource_test.go
+++ b/pkg/presenters/stack_resource_test.go
@@ -60,8 +60,8 @@ func TestPresentStackResource_includesDerivedOutputs(t *testing.T) {
 		"host",
 		"port.http",
 		"url.http",
-		"public.http.host",
-		"public.http.url",
+		"public_host.http",
+		"public_url.http",
 		"port.metrics",
 		"url.metrics",
 	}

--- a/pkg/presenters/stack_test.go
+++ b/pkg/presenters/stack_test.go
@@ -34,7 +34,7 @@ func TestPresentStackIncludesConnections(t *testing.T) {
 							Name: "REDIS_URL",
 						},
 						Value: models.ValueRef{
-							Output: "url.http",
+							Output: models.OutputNameURL,
 						},
 					},
 				},
@@ -57,8 +57,8 @@ func TestPresentStackIncludesConnections(t *testing.T) {
 	if out.Spec.Connections[0].From.GetId() != "pg-1" {
 		t.Fatalf("expected from pg-1, got %q", out.Spec.Connections[0].From.GetId())
 	}
-	if out.Spec.Connections[0].Mappings[0].Value.GetOutput() != "url.http" {
-		t.Fatalf("expected mapping output url.http, got %q", out.Spec.Connections[0].Mappings[0].Value.GetOutput())
+	if out.Spec.Connections[0].Mappings[0].Value.GetOutput() != models.OutputNameURL {
+		t.Fatalf("expected mapping output %s, got %q", models.OutputNameURL, out.Spec.Connections[0].Mappings[0].Value.GetOutput())
 	}
 	config := out.Spec.Connections[0].GetConfig()
 	if config.PostgresEnvConfig == nil {
@@ -84,7 +84,7 @@ func TestConvertStackIncludesConnections(t *testing.T) {
 		*openapi.NewValueRef(),
 	)
 	mapping.Target.SetName("REDIS_URL")
-	mapping.Value.SetOutput("url.http")
+	mapping.Value.SetOutput(models.OutputNameURL)
 	conn.SetMappings([]openapi.ConnectionMapping{*mapping})
 	db := "app"
 	scope := "owner"
@@ -110,8 +110,8 @@ func TestConvertStackIncludesConnections(t *testing.T) {
 	if out.Connections[0].From.Name != "redis" {
 		t.Fatalf("expected from redis, got %q", out.Connections[0].From.Name)
 	}
-	if out.Connections[0].Mappings[0].Value.Output != "url.http" {
-		t.Fatalf("expected mapping output url.http, got %q", out.Connections[0].Mappings[0].Value.Output)
+	if out.Connections[0].Mappings[0].Value.Output != models.OutputNameURL {
+		t.Fatalf("expected mapping output %s, got %q", models.OutputNameURL, out.Connections[0].Mappings[0].Value.Output)
 	}
 	if out.Connections[0].Config["database"] != "app" {
 		t.Fatalf("expected connection config database app, got %#v", out.Connections[0].Config["database"])
@@ -160,7 +160,7 @@ func TestPresentAndConvertStackPreservesEnvVarSelfOutput(t *testing.T) {
 				Ports:       models.Ports{{Name: "http", Number: 8080, Protocol: "http", ExposedToPublic: true}},
 				ExecutionConfig: &models.ExecutionConfig{
 					Env: []models.EnvVar{
-						{Name: "PUBLIC_URL", SelfOutput: "public.http.url"},
+						{Name: "PUBLIC_URL", SelfOutput: models.OutputNamePublicURL},
 					},
 				},
 			},
@@ -172,7 +172,7 @@ func TestPresentAndConvertStackPreservesEnvVarSelfOutput(t *testing.T) {
 		t.Fatalf("expected one presented env var")
 	}
 	presentedEnv := presented.Spec.StackResources[0].GetExecutionConfig().EnvironmentVariables[0]
-	if presentedEnv.GetSelfOutput() != "public.http.url" {
+	if presentedEnv.GetSelfOutput() != models.OutputNamePublicURL {
 		t.Fatalf("expected presented self_output, got %q", presentedEnv.GetSelfOutput())
 	}
 
@@ -188,14 +188,14 @@ func TestPresentAndConvertStackPreservesEnvVarSelfOutput(t *testing.T) {
 				EnvironmentVariables: []openapi.EnvVar{
 					{
 						Name:       "PUBLIC_URL",
-						SelfOutput: openapi.PtrString("public.http.url"),
+						SelfOutput: openapi.PtrString(models.OutputNamePublicURL),
 					},
 				},
 			},
 		},
 	})
 	converted := presenters.ConvertStack(openapi.NewStack("demo", *spec))
-	if converted.StackResources[0].ExecutionConfig.Env[0].SelfOutput != "public.http.url" {
+	if converted.StackResources[0].ExecutionConfig.Env[0].SelfOutput != models.OutputNamePublicURL {
 		t.Fatalf("expected converted self_output, got %q", converted.StackResources[0].ExecutionConfig.Env[0].SelfOutput)
 	}
 }

--- a/pkg/presenters/stack_topology_test.go
+++ b/pkg/presenters/stack_topology_test.go
@@ -14,7 +14,7 @@ func TestPresentStackTopology(t *testing.T) {
 				Ref:     models.TopologyNodeRef{Type: models.TopologyNodeTypeStackResource, Name: "api"},
 				Label:   "api",
 				State:   "Ready",
-				Outputs: []models.OutputDescriptor{{Name: "url.http", Type: models.OutputValueTypeString}},
+				Outputs: []models.OutputDescriptor{{Name: models.OutputNameURL, Type: models.OutputValueTypeString}},
 			},
 		},
 		Edges: []models.TopologyEdge{
@@ -27,7 +27,7 @@ func TestPresentStackTopology(t *testing.T) {
 				Mappings: []models.ConnectionMapping{
 					{
 						Target: models.ConnectionTarget{Type: models.ConnectionTargetTypeEnv, Name: "API_URL"},
-						Value:  models.ValueRef{Output: "url.http"},
+						Value:  models.ValueRef{Output: models.OutputNameURL},
 					},
 				},
 			},
@@ -51,7 +51,7 @@ func TestPresentStackTopology(t *testing.T) {
 	if out.Edges[0].GetSourceOfTruth() != "connection" {
 		t.Fatalf("expected connection source_of_truth, got %q", out.Edges[0].GetSourceOfTruth())
 	}
-	if out.Edges[0].Mappings[0].Value.GetOutput() != "url.http" {
-		t.Fatalf("expected mapping output url.http, got %q", out.Edges[0].Mappings[0].Value.GetOutput())
+	if out.Edges[0].Mappings[0].Value.GetOutput() != models.OutputNameURL {
+		t.Fatalf("expected mapping output %s, got %q", models.OutputNameURL, out.Edges[0].Mappings[0].Value.GetOutput())
 	}
 }

--- a/pkg/stackdeploy/resolver_test.go
+++ b/pkg/stackdeploy/resolver_test.go
@@ -24,7 +24,7 @@ func TestResolveDoesNotMutateInputStack(t *testing.T) {
 				Name:      "api",
 				Namespace: "ns-1",
 				ExecutionConfig: &models.ExecutionConfig{
-					Env: []models.EnvVar{{Name: "PUBLIC_URL", SelfOutput: "public.http.url"}},
+					Env: []models.EnvVar{{Name: "PUBLIC_URL", SelfOutput: models.OutputNamePublicURL}},
 				},
 				Ports: models.Ports{
 					{Name: "http", Number: 8080, Protocol: "http", ExposedToPublic: true, ExposedFqdn: "api.example.com"},
@@ -143,22 +143,22 @@ func TestResolveStackResourceEnvConnection(t *testing.T) {
 				Mappings: []models.ConnectionMapping{
 					{
 						Target: models.ConnectionTarget{Type: models.ConnectionTargetTypeEnv, Name: "API_HOST"},
-						Value:  models.ValueRef{Output: "host"},
+						Value:  models.ValueRef{Output: models.OutputNameHost},
 					},
 					{
 						Target: models.ConnectionTarget{Type: models.ConnectionTargetTypeEnv, Name: "API_URL"},
-						Value:  models.ValueRef{Output: "url.http"},
+						Value:  models.ValueRef{Output: models.OutputNameURL},
 					},
 					{
 						Target: models.ConnectionTarget{Type: models.ConnectionTargetTypeEnv, Name: "API_PUBLIC_URL"},
-						Value:  models.ValueRef{Output: "public.http.url"},
+						Value:  models.ValueRef{Output: models.OutputNamePublicURL},
 					},
 					{
 						Target: models.ConnectionTarget{Type: models.ConnectionTargetTypeEnv, Name: "API_TEMPLATE_URL"},
 						Value: models.ValueRef{
 							Template: "http://{{public_host}}:{{port}}",
 							Values: map[string]models.OutputValueRef{
-								"public_host": {Output: "public.http.host"}, "port": {Output: "port.http"},
+								"public_host": {Output: models.OutputNamePublicHost}, "port": {Output: models.OutputNamePort},
 							},
 						},
 					},

--- a/pkg/stackfile/connection_builders_test.go
+++ b/pkg/stackfile/connection_builders_test.go
@@ -50,15 +50,15 @@ func TestBuildEnvRefConnections_TemplateRef(t *testing.T) {
 
 func TestBuildEnvRefConnections_TemplateWithDottedOutput(t *testing.T) {
 	env := map[string]string{
-		"CALLBACK": "https://{{ api.public.http.url }}/callback",
+		"CALLBACK": "https://{{ api.public_url.http }}/callback",
 	}
 	conns := buildEnvRefConnections("worker", env)
 
 	m := conns[0].Mappings[0]
-	if *m.Value.Template != "https://{{ public_http_url }}/callback" {
+	if *m.Value.Template != "https://{{ public_url_http }}/callback" {
 		t.Errorf("expected dotted output converted to underscore var, got %q", *m.Value.Template)
 	}
-	assertTemplateVar(t, m, "public_http_url", "public.http.url")
+	assertTemplateVar(t, m, "public_url_http", "public_url.http")
 }
 
 func TestBuildEnvRefConnections_MultipleRefsFromSameSource(t *testing.T) {
@@ -98,7 +98,7 @@ func TestBuildEnvRefConnections_DifferentSourcesCreateSeparateConnections(t *tes
 
 func TestBuildEnvRefConnections_SkipsSelfRefs(t *testing.T) {
 	env := map[string]string{
-		"SITE_URL": "{{ self.public.http.url }}",
+		"SITE_URL": "{{ self.public_url }}",
 	}
 	conns := buildEnvRefConnections("app", env)
 
@@ -123,7 +123,7 @@ func TestBuildEnvRefConnections_MixedLiteralsAndRefs(t *testing.T) {
 	env := map[string]string{
 		"DB_HOST":   "{{ db.host }}",
 		"LOG_LEVEL": "info",
-		"SITE_URL":  "{{ self.public.http.url }}",
+		"SITE_URL":  "{{ self.public_url }}",
 	}
 	conns := buildEnvRefConnections("app", env)
 

--- a/pkg/stackfile/convert_test.go
+++ b/pkg/stackfile/convert_test.go
@@ -3,7 +3,11 @@ package stackfile
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	openapi "github.com/Stackdome/stackdome/pkg/api/openapi"
+	"github.com/Stackdome/stackdome/pkg/models"
 )
 
 func TestToStack_BasicImageResource(t *testing.T) {
@@ -963,3 +967,14 @@ func envVarsToMap(vars []openapi.EnvVar) map[string]openapi.EnvVar {
 	}
 	return m
 }
+
+var _ = Describe("outputToVarName under the new scheme", func() {
+	DescribeTable("dots become underscores; clean keys pass through",
+		func(output, want string) { Expect(outputToVarName(output)).To(Equal(want)) },
+		Entry("host", models.OutputNameHost, "host"),
+		Entry("url", models.OutputNameURL, "url"),
+		Entry("public_url", models.OutputNamePublicURL, "public_url"),
+		Entry("url.3306", "url.3306", "url_3306"),
+		Entry("public_url.web", "public_url.web", "public_url_web"),
+	)
+})

--- a/pkg/stackfile/convert_test.go
+++ b/pkg/stackfile/convert_test.go
@@ -220,7 +220,7 @@ func TestToStack_SelfOutputEnv(t *testing.T) {
 					{Name: "http", Port: 8080, Public: true, Subdomain: "app"},
 				},
 				Env: map[string]string{
-					"SITE_URL": "{{ self.public.http.url }}",
+					"SITE_URL": "{{ self.public_url }}",
 				},
 			},
 		},
@@ -234,8 +234,8 @@ func TestToStack_SelfOutputEnv(t *testing.T) {
 
 	envMap := envVarsToMap(res.ExecutionConfig.EnvironmentVariables)
 	v := envMap["SITE_URL"]
-	if v.SelfOutput == nil || *v.SelfOutput != "public.http.url" {
-		t.Errorf("expected self output 'public.http.url', got %v", v.SelfOutput)
+	if v.SelfOutput == nil || *v.SelfOutput != "public_url" {
+		t.Errorf("expected self output 'public_url', got %v", v.SelfOutput)
 	}
 	if v.Value != nil {
 		t.Error("self output should not have a literal value")
@@ -599,7 +599,7 @@ func TestToStack_FullInfisicalExample(t *testing.T) {
 					{Name: "http", Port: 8080, Protocol: "HTTP", Public: true, Subdomain: "infisical"},
 				},
 				Env: map[string]string{
-					"SITE_URL":          "{{ self.public.http.url }}",
+					"SITE_URL":          "{{ self.public_url }}",
 					"DB_CONNECTION_URI": "postgres://infisical:infisical@{{ db.host }}:5432/infisical",
 					"REDIS_URL":         "redis://{{ redis.host }}:6379",
 					"ENCRYPTION_KEY":    "6c1fe4e407b8911c104518103505b218",

--- a/pkg/stackfile/parse.go
+++ b/pkg/stackfile/parse.go
@@ -2,6 +2,7 @@ package stackfile
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -231,67 +232,36 @@ func validateSelfOutput(resourceName, envKey, output string, ports []PortDef) er
 }
 
 func validateOutputAgainstPorts(resourceName, envKey, source, output string, ports []PortDef) error {
-	if output == models.OutputNameHost {
+	valid := map[string]struct{}{models.OutputNameHost: {}}
+	multiPort := len(ports) > 1
+	key := func(base, portName string) string {
+		if !multiPort {
+			return base
+		}
+		return base + "." + portName
+	}
+	for _, p := range ports {
+		valid[key(models.OutputNamePort, p.Name)] = struct{}{}
+		valid[key(models.OutputNameURL, p.Name)] = struct{}{}
+		if p.Public {
+			valid[key(models.OutputNamePublicHost, p.Name)] = struct{}{}
+			valid[key(models.OutputNamePublicURL, p.Name)] = struct{}{}
+		}
+	}
+
+	if _, ok := valid[output]; ok {
 		return nil
 	}
 
-	portNames := make(map[string]PortDef)
-	for _, p := range ports {
-		portNames[p.Name] = p
-	}
-
-	parts := strings.Split(output, ".")
-	var label string
+	label := "resource '" + source + "'"
 	if source == sourceSelf {
 		label = "resource '" + resourceName + "'"
-	} else {
-		label = "resource '" + source + "'"
 	}
-
-	switch parts[0] {
-	case models.OutputNamePort:
-		if len(parts) != 2 {
-			return fmt.Errorf("resource '%s' env var '%s': invalid output '%s'. Expected 'port.<port-name>'", resourceName, envKey, output)
-		}
-		if _, ok := portNames[parts[1]]; !ok {
-			return fmt.Errorf("resource '%s' env var '%s': output '%s' references port '%s' which is not defined on %s", resourceName, envKey, output, parts[1], label)
-		}
-
-	case models.OutputNameURL:
-		if len(parts) != 2 {
-			return fmt.Errorf("resource '%s' env var '%s': invalid output '%s'. Expected 'url.<port-name>'", resourceName, envKey, output)
-		}
-		if _, ok := portNames[parts[1]]; !ok {
-			return fmt.Errorf("resource '%s' env var '%s': output '%s' references port '%s' which is not defined on %s", resourceName, envKey, output, parts[1], label)
-		}
-
-	case "public":
-		if len(parts) != 3 {
-			return fmt.Errorf("resource '%s' env var '%s': invalid output '%s'. Expected 'public.<port-name>.host' or 'public.<port-name>.url'", resourceName, envKey, output)
-		}
-		portName := parts[1]
-		suffix := parts[2]
-		if suffix != models.OutputNameHost && suffix != models.OutputNameURL {
-			return fmt.Errorf("resource '%s' env var '%s': invalid output '%s'. Expected 'public.<port-name>.host' or 'public.<port-name>.url'", resourceName, envKey, output)
-		}
-		p, ok := portNames[portName]
-		if !ok {
-			return fmt.Errorf("resource '%s' env var '%s': output '%s' references port '%s' which is not defined on %s", resourceName, envKey, output, portName, label)
-		}
-		if !p.Public {
-			return fmt.Errorf("resource '%s' env var '%s': output '%s' requires port '%s' to have 'public: true'", resourceName, envKey, output, portName)
-		}
-
-	default:
-		valid := []string{models.OutputNameHost}
-		for _, p := range ports {
-			valid = append(valid, "port."+p.Name, "url."+p.Name)
-			if p.Public {
-				valid = append(valid, "public."+p.Name+".host", "public."+p.Name+".url")
-			}
-		}
-		return fmt.Errorf("resource '%s' env var '%s': unknown output '%s' on %s. Valid outputs: %s", resourceName, envKey, output, label, strings.Join(valid, ", "))
+	names := make([]string, 0, len(valid))
+	for k := range valid {
+		names = append(names, k)
 	}
-
-	return nil
+	sort.Strings(names)
+	return fmt.Errorf("resource '%s' env var '%s': unknown output '%s' on %s. Valid outputs: %s",
+		resourceName, envKey, output, label, strings.Join(names, ", "))
 }

--- a/pkg/stackfile/parse.go
+++ b/pkg/stackfile/parse.go
@@ -149,7 +149,7 @@ func validateEnvRefs(resourceName string, env map[string]string, ports []PortDef
 		// Self refs must be exact (entire value is the ref)
 		if hasSelf {
 			if !exactRefPattern.MatchString(envVal) {
-				return fmt.Errorf("resource '%s' env var '%s': self-references must be the only content of the env var (e.g., '{{ self.port.http }}')", resourceName, envKey)
+				return fmt.Errorf("resource '%s' env var '%s': self-references must be the only content of the env var (e.g., '{{ self.port }}')", resourceName, envKey)
 			}
 			if err := validateSelfOutput(resourceName, envKey, refs[0].Output, ports); err != nil {
 				return err

--- a/pkg/stackfile/parse_test.go
+++ b/pkg/stackfile/parse_test.go
@@ -1,0 +1,45 @@
+package stackfile
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Stackdome/stackdome/pkg/models"
+)
+
+var _ = Describe("output validation (human-readable scheme)", func() {
+	// singlePort = one private port named "3306"; multiPort adds a public "web".
+	// Use the package's existing Stackfile-parse entry point to exercise these.
+
+	DescribeTable("single-port resource accepts unsuffixed keys",
+		func(output string, valid bool) {
+			err := validateSelfOutput("app", "ENV", output, []PortDef{{Name: "3306", Public: false}})
+			if valid {
+				Expect(err).NotTo(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
+		},
+		Entry("host", models.OutputNameHost, true),
+		Entry("port", models.OutputNamePort, true),
+		Entry("url", models.OutputNameURL, true),
+		Entry("old suffixed port rejected", "port.3306", false),
+		Entry("public on a private port rejected", models.OutputNamePublicURL, false),
+	)
+
+	DescribeTable("multi-port resource requires the port suffix",
+		func(output string, valid bool) {
+			err := validateSelfOutput("app", "ENV", output, []PortDef{{Name: "3306", Public: false}, {Name: "web", Public: true}})
+			if valid {
+				Expect(err).NotTo(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
+		},
+		Entry("host stays unsuffixed", models.OutputNameHost, true),
+		Entry("url.3306", "url."+"3306", true),
+		Entry("public_url.web", models.OutputNamePublicURL+".web", true),
+		Entry("public_url.3306 (private port) rejected", models.OutputNamePublicURL+".3306", false),
+		Entry("bare url (ambiguous) rejected", models.OutputNameURL, false),
+	)
+})

--- a/pkg/stackfile/stackfile_suite_test.go
+++ b/pkg/stackfile/stackfile_suite_test.go
@@ -1,0 +1,13 @@
+package stackfile
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestStackfile(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Stackfile Suite")
+}

--- a/pkg/stackfile/testdata/infisical.yaml
+++ b/pkg/stackfile/testdata/infisical.yaml
@@ -13,7 +13,7 @@ resources:
       NODE_ENV: production
       ENCRYPTION_KEY: "6c1fe4e407b8911c104518103505b218"
       AUTH_SECRET: "5lrMXKKWCVocS/uerPsl7V+TX/aaUaI7iDkgl3tSmLE="
-      SITE_URL: "{{ self.public.http.url }}"
+      SITE_URL: "{{ self.public_url }}"
       POSTGRES_USER: infisical
       POSTGRES_PASSWORD: infisical
       POSTGRES_DB: infisical

--- a/pkg/stackfile/testdata/kitchen_sink.yaml
+++ b/pkg/stackfile/testdata/kitchen_sink.yaml
@@ -9,7 +9,7 @@ resources:
         public: true
         subdomain: api
     env:
-      SITE_URL: "{{ self.public.http.url }}"
+      SITE_URL: "{{ self.public_url }}"
       CACHE_HOST: "{{ redis.host }}"
       CACHE_URL: "redis://{{ redis.host }}:6379"
       LOG_LEVEL: info

--- a/pkg/validator/stack/stack_validator_test.go
+++ b/pkg/validator/stack/stack_validator_test.go
@@ -320,7 +320,7 @@ func TestValidateForCreateAllowsStackResourceEnvConnectionUsingDeclaredOutput(t 
 					Name: "SELF_URL",
 				},
 				Value: models.ValueRef{
-					Output: "url.http",
+					Output: models.OutputNameURL,
 				},
 			},
 		},
@@ -1210,7 +1210,7 @@ func TestValidateConnectionsRejectsUnknownTargetResource(t *testing.T) {
 		Mappings: []models.ConnectionMapping{
 			{
 				Target: models.ConnectionTarget{Type: models.ConnectionTargetTypeEnv, Name: "WEB_URL"},
-				Value:  models.ValueRef{Output: "url.http"},
+				Value:  models.ValueRef{Output: models.OutputNameURL},
 			},
 		},
 	})
@@ -1242,7 +1242,7 @@ func TestValidateConnectionsAcceptsValidConnection(t *testing.T) {
 		Mappings: []models.ConnectionMapping{
 			{
 				Target: models.ConnectionTarget{Type: models.ConnectionTargetTypeEnv, Name: "SELF_URL"},
-				Value:  models.ValueRef{Output: "url.http"},
+				Value:  models.ValueRef{Output: models.OutputNameURL},
 			},
 		},
 	})
@@ -1294,7 +1294,7 @@ func TestValidateConnectionsIgnoresUnrelatedResourceInvalidity(t *testing.T) {
 			Mappings: []models.ConnectionMapping{
 				{
 					Target: models.ConnectionTarget{Type: models.ConnectionTargetTypeEnv, Name: "WEB_URL"},
-					Value:  models.ValueRef{Output: "url.http"},
+					Value:  models.ValueRef{Output: models.OutputNameURL},
 				},
 			},
 		},

--- a/pkg/validator/stackresource/input_rules_test.go
+++ b/pkg/validator/stackresource/input_rules_test.go
@@ -243,11 +243,11 @@ var _ = Describe("validateInputRules", func() {
 
 	It("accepts env self_output referencing a declared output", func() {
 		r := validImageResource()
-		// "host" and "port.http"/"url.http" (from the declared http port) are
-		// this resource's declared outputs.
+		// "host" and "port"/"url" (from the resource's single declared port)
+		// are this resource's declared outputs.
 		r.ExecutionConfig = &models.ExecutionConfig{Env: []models.EnvVar{
-			{Name: "SELF_HOST", SelfOutput: "host"},
-			{Name: "SELF_URL", SelfOutput: "url.http"},
+			{Name: "SELF_HOST", SelfOutput: models.OutputNameHost},
+			{Name: "SELF_URL", SelfOutput: models.OutputNameURL},
 		}}
 		Expect(validateInputRules(r)).To(BeEmpty())
 	})

--- a/test/int/shared/fixtures.go
+++ b/test/int/shared/fixtures.go
@@ -625,7 +625,7 @@ func resourceToResourceEnvConnection(sourceResource, targetResource string) open
 			target := openapi.NewConnectionTarget("env")
 			target.SetName("API_URL")
 			value := openapi.NewValueRef()
-			value.SetOutput("url.http")
+			value.SetOutput(models.OutputNameURL)
 			return *openapi.NewConnectionMapping(*target, *value)
 		}(),
 	})


### PR DESCRIPTION
## 📝 What this does

Stack-resource "outputs" (the connection endpoints another resource references when wiring an env var) had cryptic, artifact-leaking keys like `port.http-80` and `public.http-80.url`. This renames them to a readable scheme and presents them in a grouped, labelled picker so users can actually tell what they're wiring.

## 🔀 Changes

- Renamed output keys to `host` / `port` / `url` (+ `public_host` / `public_url` for internet-facing ports); single-port resources drop the port suffix, multi-port disambiguates by port name.
- Reworked the env-var output dropdown into grouped Internal / Public lists with plain-English labels and a raw-key tag (value preview shows a "resolved at deploy" placeholder for now).
- Brought the Stackfile output validator, the draft-resource client deriver, and the OpenAPI spec examples in lockstep with the new scheme.
- Named newly added ports from their number (`port-8080`) instead of a positional counter, so multi-port output keys stay meaningful and stay valid as Kubernetes port names.

## 🧪 How to test

- [ ] Open a resource → Environment → add a variable → set source to Self or Resource → open the output picker; confirm grouped Internal 🔒 / Public 🌐 options with readable labels and a key tag.
- [ ] Add a second port to a resource and edit its number; confirm the outputs suffix by the port name (e.g. `url.port-8080`) and single-port resources show no suffix.
- [ ] Deploy a stack referencing a resource output and confirm the env var resolves.