### PR TITLE
Feature: Registry-aware source selection in stack drawer

### DIFF
--- a/frontend/src/components/git-source-picker/repo-combobox.tsx
+++ b/frontend/src/components/git-source-picker/repo-combobox.tsx
@@ -144,7 +144,7 @@ export function RepoCombobox({ id, value, integrationId, onChange, hasError }: R
   };
 
   const display = value ? (integrationId ? repoTail(value) : value) : null;
-  const looksLikeUrl = /^https?:\/\//i.test(query);
+  const looksLikeUrl = /^(https?|ssh|git):\/\//i.test(query) || /^git@/.test(query);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/frontend/src/components/git-source-picker/repo-combobox.tsx
+++ b/frontend/src/components/git-source-picker/repo-combobox.tsx
@@ -128,23 +128,38 @@ export function RepoCombobox({ id, value, integrationId, onChange, hasError }: R
     }
   };
 
+  // Trimmed once and reused everywhere the query is validated or emitted —
+  // stray leading/trailing whitespace from a paste should never reach the
+  // form value.
+  const trimmedQuery = query.trim();
+
   const useAsUrl = () => {
-    onChange({ repo_url: query, integration_id: undefined });
+    onChange({ repo_url: trimmedQuery, integration_id: undefined });
     setOpen(false);
   };
 
   // Credentials hosts can't list repos; typed paths compose against the host.
+  // Strip any leading/trailing slashes and an existing trailing ".git" from
+  // the typed path first, so pasting "acme/api.git" doesn't double up into
+  // "acme/api.git.git".
   const useOnHost = () => {
     if (!selected?.host || !selected.id) return;
+    const path = trimmedQuery
+      .replace(/^\/+/, "")
+      .replace(/\/+$/, "")
+      .replace(/\.git\/?$/, "");
     onChange({
-      repo_url: `https://${selected.host}/${query.replace(/^\/+/, "")}.git`,
+      repo_url: `https://${selected.host}/${path}.git`,
       integration_id: selected.id,
     });
     setOpen(false);
   };
 
   const display = value ? (integrationId ? repoTail(value) : value) : null;
-  const looksLikeUrl = /^(https?|ssh|git):\/\//i.test(query) || /^git@/.test(query);
+  // scp-style refs (user@host:path, e.g. deploy@git.corp.io:acme/api.git)
+  // aren't limited to a "git" user, so match the general `user@host:` shape.
+  const looksLikeUrl =
+    /^(https?|ssh|git):\/\//i.test(trimmedQuery) || /^[\w.-]+@[\w.-]+:/.test(trimmedQuery);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/frontend/src/components/git-source-picker/repo-combobox.tsx
+++ b/frontend/src/components/git-source-picker/repo-combobox.tsx
@@ -165,7 +165,7 @@ export function RepoCombobox({ id, value, integrationId, onChange, hasError }: R
           <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
         <Command shouldFilter={false}>
           {integrations.length > 1 && (
             <div className="border-b p-2">

--- a/frontend/src/components/git-source-picker/repo-combobox.tsx
+++ b/frontend/src/components/git-source-picker/repo-combobox.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useState } from "react";
+import { ChevronDown, Link2, Lock, Globe } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import {
+  listGitIntegrations,
+  searchRepositories,
+  getRepository,
+  type GitIntegration,
+  type GitRepository,
+} from "@/api/git-integrations";
+import { getErrorMessage } from "@/api/client";
+import { getCurrentOrganizationId } from "@/helpers/common";
+import {
+  GIT_INTEGRATION_TYPE_GITHUB_APP,
+  GIT_INTEGRATION_TYPE_CREDENTIALS,
+} from "@/pages/git-integrations/lib/derive-row";
+import { usableIntegrations } from "./credentials-dropdown";
+import { repoTail } from "./git-source-picker";
+
+export interface RepoPick {
+  repo_url: string;
+  integration_id: string | undefined;
+}
+
+interface RepoComboboxProps {
+  id: string;
+  /** Current source.git.repo_url */
+  value: string;
+  /** Set when the current URL was picked through an integration. */
+  integrationId?: string;
+  onChange: (pick: RepoPick) => void;
+  hasError?: boolean;
+}
+
+/** Compact repository combobox for the stack drawer: searches repos across
+    usable git integrations, accepts free text as a repository URL. */
+export function RepoCombobox({ id, value, integrationId, onChange, hasError }: RepoComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [integrations, setIntegrations] = useState<GitIntegration[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [repos, setRepos] = useState<GitRepository[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selected = integrations.find((i) => i.id === selectedId) ?? null;
+
+  // Integrations load lazily on first open; failure degrades to URL-only entry.
+  useEffect(() => {
+    if (!open || loaded) return;
+    const orgId = getCurrentOrganizationId();
+    if (!orgId) {
+      setLoaded(true);
+      return;
+    }
+    listGitIntegrations(orgId)
+      .then((res) => {
+        const list = usableIntegrations(res.items ?? []);
+        setIntegrations(list);
+        setSelectedId((current) => {
+          if (current && list.some((i) => i.id === current)) return current;
+          const app = list.find((i) => i.type === GIT_INTEGRATION_TYPE_GITHUB_APP);
+          return app?.id ?? list[0]?.id ?? null;
+        });
+      })
+      .catch((e) => setError(getErrorMessage(e)))
+      .finally(() => setLoaded(true));
+  }, [open, loaded]);
+
+  // Debounced repo search — only GitHub App integrations can list repos.
+  useEffect(() => {
+    if (!open || selected?.type !== GIT_INTEGRATION_TYPE_GITHUB_APP) {
+      setRepos([]);
+      return;
+    }
+    const orgId = getCurrentOrganizationId();
+    if (!orgId || !selected.id) return;
+    let cancelled = false;
+    setSearching(true);
+    const t = setTimeout(() => {
+      searchRepositories(orgId, selected.id!, { query: query || undefined })
+        .then((page) => {
+          if (cancelled) return;
+          setRepos(page.items ?? []);
+          setError(null);
+        })
+        .catch((e) => {
+          if (!cancelled) setError(getErrorMessage(e));
+        })
+        .finally(() => {
+          if (!cancelled) setSearching(false);
+        });
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [open, selected?.id, selected?.type, query]);
+
+  const pickRepo = async (repo: GitRepository) => {
+    const orgId = getCurrentOrganizationId();
+    if (!orgId || !selected?.id || !repo.full_name) return;
+    const [owner, name] = repo.full_name.split("/");
+    try {
+      const detail = await getRepository(orgId, selected.id, owner, name);
+      onChange({
+        repo_url: detail.clone_url ?? repo.clone_url ?? "",
+        integration_id: selected.id,
+      });
+      setOpen(false);
+    } catch (e) {
+      setError(getErrorMessage(e));
+    }
+  };
+
+  const useAsUrl = () => {
+    onChange({ repo_url: query, integration_id: undefined });
+    setOpen(false);
+  };
+
+  // Credentials hosts can't list repos; typed paths compose against the host.
+  const useOnHost = () => {
+    if (!selected?.host || !selected.id) return;
+    onChange({
+      repo_url: `https://${selected.host}/${query.replace(/^\/+/, "")}.git`,
+      integration_id: selected.id,
+    });
+    setOpen(false);
+  };
+
+  const display = value ? (integrationId ? repoTail(value) : value) : null;
+  const looksLikeUrl = /^https?:\/\//i.test(query);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-invalid={hasError || undefined}
+          className={cn(
+            "h-9 w-full justify-between font-mono text-[12.5px] font-normal",
+            !display && "text-muted-foreground",
+            hasError && "border-danger",
+          )}
+        >
+          <span className="truncate">{display ?? "Select repository or enter URL"}</span>
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <Command shouldFilter={false}>
+          {integrations.length > 1 && (
+            <div className="border-b p-2">
+              <Select value={selectedId ?? undefined} onValueChange={setSelectedId}>
+                <SelectTrigger className="h-8 text-xs" aria-label="Integration">
+                  <SelectValue placeholder="Integration" />
+                </SelectTrigger>
+                <SelectContent>
+                  {integrations.map((i) => (
+                    <SelectItem key={i.id} value={i.id!}>
+                      {i.host}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+          <CommandInput
+            placeholder="Search repositories or paste a URL…"
+            value={query}
+            onValueChange={setQuery}
+          />
+          <CommandList>
+            {error && <div className="px-3 py-2 text-xs text-danger">{error}</div>}
+            {selected?.type === GIT_INTEGRATION_TYPE_GITHUB_APP && (
+              <CommandGroup>
+                {repos.map((repo) => (
+                  <CommandItem
+                    key={repo.full_name}
+                    value={repo.full_name!}
+                    onSelect={() => void pickRepo(repo)}
+                  >
+                    {repo.private ? (
+                      <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+                    ) : (
+                      <Globe className="h-3.5 w-3.5 text-muted-foreground" />
+                    )}
+                    <span className="flex-1 truncate font-mono text-[12.5px]">{repo.full_name}</span>
+                    {repo.default_branch && (
+                      <span className="text-[11px] text-muted-foreground">{repo.default_branch}</span>
+                    )}
+                  </CommandItem>
+                ))}
+                {!searching && repos.length === 0 && (
+                  <CommandEmpty>No repositories found.</CommandEmpty>
+                )}
+              </CommandGroup>
+            )}
+            {query && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  {looksLikeUrl && (
+                    <CommandItem value={`url-${query}`} onSelect={useAsUrl}>
+                      <Link2 className="h-3.5 w-3.5 text-muted-foreground" />
+                      <span className="truncate text-[12.5px]">Use &quot;{query}&quot; as repository URL</span>
+                    </CommandItem>
+                  )}
+                  {!looksLikeUrl && selected?.type === GIT_INTEGRATION_TYPE_CREDENTIALS && (
+                    <CommandItem value={`host-${query}`} onSelect={useOnHost}>
+                      <Link2 className="h-3.5 w-3.5 text-muted-foreground" />
+                      <span className="truncate text-[12.5px]">
+                        Use {selected.host}/{query}
+                      </span>
+                    </CommandItem>
+                  )}
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/components/git-source-picker/tests/repo-combobox.test.tsx
+++ b/frontend/src/components/git-source-picker/tests/repo-combobox.test.tsx
@@ -21,6 +21,18 @@ beforeAll(() => {
       unobserve() {}
       disconnect() {}
     };
+  // Radix Select uses pointer-capture APIs that jsdom doesn't implement.
+  // Stub them so userEvent.click on the Integration SelectTrigger opens it.
+  const stubs: Record<string, () => unknown> = {
+    hasPointerCapture: () => false,
+    releasePointerCapture: () => undefined,
+    setPointerCapture: () => undefined,
+    scrollIntoView: () => undefined,
+  };
+  for (const [name, impl] of Object.entries(stubs)) {
+    const proto = Element.prototype as unknown as Record<string, unknown>;
+    if (!proto[name]) proto[name] = vi.fn(impl);
+  }
 });
 
 afterEach(cleanup);
@@ -129,5 +141,47 @@ describe("RepoCombobox", () => {
     await user.click(screen.getByRole("combobox"));
     await user.type(screen.getByPlaceholderText(/search repositories/i), "https://x.io/y.git");
     expect(await screen.findByText(/use "https:\/\/x\.io\/y\.git"/i)).toBeInTheDocument();
+  });
+
+  it("trims surrounding whitespace off a pasted URL before emitting it", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<RepoCombobox id="repo" value="" onChange={onChange} />);
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/search repositories/i), "  https://x.io/y.git  ");
+    await user.click(await screen.findByText(/use ".*https:\/\/x\.io\/y\.git.*"/i));
+    expect(onChange).toHaveBeenCalledWith({
+      repo_url: "https://x.io/y.git",
+      integration_id: undefined,
+    });
+  });
+
+  it("recognizes a non-'git' scp-style user as a URL", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<RepoCombobox id="repo" value="" onChange={onChange} />);
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/search repositories/i), "deploy@git.corp.io:acme/api.git");
+    await user.click(await screen.findByText(/use "deploy@git\.corp\.io:acme\/api\.git"/i));
+    expect(onChange).toHaveBeenCalledWith({
+      repo_url: "deploy@git.corp.io:acme/api.git",
+      integration_id: undefined,
+    });
+  });
+
+  it("collapses a typed trailing .git so useOnHost never doubles it", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<RepoCombobox id="repo" value="" onChange={onChange} />);
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => expect(listGitIntegrations).toHaveBeenCalled());
+    await user.click(await screen.findByRole("combobox", { name: "Integration" }));
+    await user.click(await screen.findByRole("option", { name: "git.internal.example.com" }));
+    await user.type(screen.getByPlaceholderText(/search repositories/i), "acme/api.git");
+    await user.click(await screen.findByText(/use git\.internal\.example\.com\/acme\/api\.git/i));
+    expect(onChange).toHaveBeenCalledWith({
+      repo_url: "https://git.internal.example.com/acme/api.git",
+      integration_id: "int-creds",
+    });
   });
 });

--- a/frontend/src/components/git-source-picker/tests/repo-combobox.test.tsx
+++ b/frontend/src/components/git-source-picker/tests/repo-combobox.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RepoCombobox } from "../repo-combobox";
+import {
+  GIT_INTEGRATION_TYPE_GITHUB_APP,
+  GIT_INTEGRATION_TYPE_CREDENTIALS,
+  STATUS_INSTALLED,
+  STATUS_ACTIVE,
+} from "@/pages/git-integrations/lib/derive-row";
+
+// cmdk (used by the Command primitive) reads ResizeObserver on mount, which
+// jsdom doesn't implement.
+beforeAll(() => {
+  global.ResizeObserver =
+    global.ResizeObserver ||
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+});
+
+afterEach(cleanup);
+
+vi.mock("@/api/git-integrations", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  listGitIntegrations: vi.fn(),
+  searchRepositories: vi.fn(),
+  getRepository: vi.fn(),
+}));
+vi.mock("@/helpers/common", () => ({ getCurrentOrganizationId: () => "org-1" }));
+
+import { listGitIntegrations, searchRepositories, getRepository } from "@/api/git-integrations";
+
+const app = {
+  id: "int-app",
+  host: "github.com",
+  type: GIT_INTEGRATION_TYPE_GITHUB_APP,
+  status: STATUS_INSTALLED,
+  credentials_configured: true,
+};
+const creds = {
+  id: "int-creds",
+  host: "git.internal.example.com",
+  type: GIT_INTEGRATION_TYPE_CREDENTIALS,
+  status: STATUS_ACTIVE,
+  credentials_configured: true,
+};
+
+beforeEach(() => {
+  vi.mocked(listGitIntegrations).mockResolvedValue({ items: [app, creds] });
+  vi.mocked(searchRepositories).mockResolvedValue({
+    items: [{ full_name: "acme/api", private: true, default_branch: "main" }],
+  });
+  vi.mocked(getRepository).mockResolvedValue({
+    full_name: "acme/api",
+    clone_url: "https://github.com/acme/api.git",
+    default_branch: "main",
+  });
+});
+
+describe("RepoCombobox", () => {
+  it("shows the repo tail when the value came from an integration", () => {
+    render(
+      <RepoCombobox
+        id="repo"
+        value="https://github.com/acme/api.git"
+        integrationId="int-app"
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("combobox")).toHaveTextContent("acme/api");
+  });
+
+  it("shows the raw URL when no integration is attached", () => {
+    render(<RepoCombobox id="repo" value="https://example.com/x.git" onChange={vi.fn()} />);
+    expect(screen.getByRole("combobox")).toHaveTextContent("https://example.com/x.git");
+  });
+
+  it("lists searched repositories and picks one with its integration id", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<RepoCombobox id="repo" value="" onChange={onChange} />);
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => expect(listGitIntegrations).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText("acme/api")).toBeInTheDocument());
+    await user.click(screen.getByText("acme/api"));
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith({
+        repo_url: "https://github.com/acme/api.git",
+        integration_id: "int-app",
+      }),
+    );
+  });
+
+  it("offers typed text as a repository URL and clears the integration", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<RepoCombobox id="repo" value="" onChange={onChange} />);
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/search repositories/i), "https://example.com/repo.git");
+    await user.click(await screen.findByText(/use "https:\/\/example\.com\/repo\.git"/i));
+    expect(onChange).toHaveBeenCalledWith({
+      repo_url: "https://example.com/repo.git",
+      integration_id: undefined,
+    });
+  });
+
+  it("falls back to URL entry when integrations fail to load", async () => {
+    vi.mocked(listGitIntegrations).mockRejectedValue(new Error("boom"));
+    const user = userEvent.setup();
+    render(<RepoCombobox id="repo" value="" onChange={vi.fn()} />);
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/search repositories/i), "https://x.io/y.git");
+    expect(await screen.findByText(/use "https:\/\/x\.io\/y\.git"/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/git-source-picker/tests/repo-combobox.test.tsx
+++ b/frontend/src/components/git-source-picker/tests/repo-combobox.test.tsx
@@ -109,6 +109,19 @@ describe("RepoCombobox", () => {
     });
   });
 
+  it("offers an ssh/scp-style URL as a repository URL", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<RepoCombobox id="repo" value="" onChange={onChange} />);
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/search repositories/i), "git@github.com:acme/api.git");
+    await user.click(await screen.findByText(/use "git@github\.com:acme\/api\.git"/i));
+    expect(onChange).toHaveBeenCalledWith({
+      repo_url: "git@github.com:acme/api.git",
+      integration_id: undefined,
+    });
+  });
+
   it("falls back to URL entry when integrations fail to load", async () => {
     vi.mocked(listGitIntegrations).mockRejectedValue(new Error("boom"));
     const user = userEvent.setup();

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -336,7 +336,10 @@ function StackResourceConfigurationTabImpl({
                 baseline={baseline}
                 path="source.image.ref"
                 compact
-                onReset={onDiscardField ? () => onDiscardField("source.image.ref") : undefined}
+                onReset={onDiscardField ? () => {
+                  onDiscardField("source.image.ref");
+                  onDiscardField("source.image.registry_credentials_id");
+                } : undefined}
               >
                 <ImageRegistrySelect
                   id={`image-registry-${index}`}
@@ -361,7 +364,10 @@ function StackResourceConfigurationTabImpl({
                 baseline={baseline}
                 path="source.image.ref"
                 compact
-                onReset={onDiscardField ? () => onDiscardField("source.image.ref") : undefined}
+                onReset={onDiscardField ? () => {
+                  onDiscardField("source.image.ref");
+                  onDiscardField("source.image.registry_credentials_id");
+                } : undefined}
               >
                 {(() => {
                   const { host, remainder } = splitImageRef(draft.source?.image?.ref || "");

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -64,6 +64,9 @@ export interface ConfigurationDraft {
   source?: Resource["source"];
   gitRevisionType?: Resource["gitRevisionType"];
   gitRevisionValue?: Resource["gitRevisionValue"];
+  // Abandoned-branch stash for the "Build from" toggle — see the handler below.
+  stashedGitSource?: Resource["stashedGitSource"];
+  stashedImageSource?: Resource["stashedImageSource"];
   volume_mounts?: Resource["volume_mounts"];
   ports?: Resource["ports"];
 }
@@ -77,6 +80,8 @@ export function pickConfigurationDraft(resource: Resource): ConfigurationDraft {
     source: resource.source,
     gitRevisionType: resource.gitRevisionType,
     gitRevisionValue: resource.gitRevisionValue,
+    stashedGitSource: resource.stashedGitSource,
+    stashedImageSource: resource.stashedImageSource,
     volume_mounts: resource.volume_mounts,
     ports: resource.ports,
   };
@@ -313,12 +318,24 @@ function StackResourceConfigurationTabImpl({
               value={draft.sourceType || "image"}
               onValueChange={(val) => {
                 const sourceType = val as "image" | "git";
-                update({
-                  sourceType,
-                  source: sourceType === "git"
-                    ? { git: { repo_url: "", dockerfile_path: "Dockerfile", build_context: "." } }
-                    : { image: { ref: "" } },
-                });
+                // The API rejects a source with both `git` and `image` set
+                // (source_conflict), so the abandoned branch can't stay live
+                // in `source`. Stash it in a form-only field instead of
+                // discarding it, and restore the other branch from its own
+                // stash (falling back to fresh defaults the first time).
+                if (sourceType === "git") {
+                  update({
+                    sourceType,
+                    source: { git: draft.stashedGitSource ?? { repo_url: "", dockerfile_path: "Dockerfile", build_context: "." } },
+                    stashedImageSource: draft.source?.image ?? draft.stashedImageSource,
+                  });
+                } else {
+                  update({
+                    sourceType,
+                    source: { image: draft.stashedImageSource ?? { ref: "" } },
+                    stashedGitSource: draft.source?.git ?? draft.stashedGitSource,
+                  });
+                }
               }}
               options={[
                 { value: "image", label: "Container image", icon: <Box size={15} /> },

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -382,7 +382,14 @@ function StackResourceConfigurationTabImpl({
                         id={`container-image-${index}`}
                         placeholder={host ? "e.g., acme/api:1.4.2" : "e.g., nginx:latest, redis:7"}
                         value={remainder}
-                        onChange={(e) => updateImageSource({ ref: joinImageRef(host, e.target.value) })}
+                        onChange={(e) => {
+                          const typed = e.target.value;
+                          // A pasted full ref (with its own host) replaces the
+                          // whole ref outright; otherwise compose against the
+                          // active chip host as before.
+                          const { host: typedHost } = splitImageRef(typed);
+                          updateImageSource({ ref: typedHost ? typed : joinImageRef(host, typed) });
+                        }}
                         className={`h-9 flex-1 font-mono text-[12.5px] ${getError(errors, "source.image.ref") ? "border-danger" : ""}`}
                         required={draft.sourceType === "image"}
                         aria-invalid={!!getError(errors, "source.image.ref")}

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -22,6 +22,7 @@ import {
   LedgerSegmented,
 } from "@/pages/stacks/components/editor/tabs/architecture/drawer-tabs/ledger";
 import { FieldShell } from "@/components/branded";
+import { RepoCombobox } from "@/components/git-source-picker/repo-combobox";
 
 import type { FormStackResourceData, FormVolumeExtendedData as VolumeFormData } from "@/pages/stacks/schemas/form-schema";
 
@@ -367,14 +368,14 @@ function StackResourceConfigurationTabImpl({
                 compact
                 onReset={onDiscardField ? () => onDiscardField("source.git.repo_url") : undefined}
               >
-                <Input
+                <RepoCombobox
                   id={`git-repo-${index}`}
                   value={draft.source?.git?.repo_url || ""}
-                  onChange={(e) => updateGitSource({ repo_url: e.target.value })}
-                  placeholder="https://github.com/username/repository.git"
-                  className={`h-9 font-mono text-[12.5px] ${getError(errors, "source.git.repo_url") ? "border-danger" : ""}`}
-                  required={draft.sourceType === "git"}
-                  aria-invalid={!!getError(errors, "source.git.repo_url")}
+                  integrationId={draft.source?.git?.integration_id}
+                  onChange={(pick) =>
+                    updateGitSource({ repo_url: pick.repo_url, integration_id: pick.integration_id })
+                  }
+                  hasError={!!getError(errors, "source.git.repo_url")}
                 />
               </DirtyField>
             </LedgerRow>

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -407,7 +407,10 @@ function StackResourceConfigurationTabImpl({
                 baseline={baseline}
                 path="source.git.repo_url"
                 compact
-                onReset={onDiscardField ? () => onDiscardField("source.git.repo_url") : undefined}
+                onReset={onDiscardField ? () => {
+                  onDiscardField("source.git.repo_url");
+                  onDiscardField("source.git.integration_id");
+                } : undefined}
               >
                 <RepoCombobox
                   id={`git-repo-${index}`}

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -334,12 +334,9 @@ function StackResourceConfigurationTabImpl({
               <DirtyField
                 draft={draft}
                 baseline={baseline}
-                path="source.image.ref"
+                path="source.image"
                 compact
-                onReset={onDiscardField ? () => {
-                  onDiscardField("source.image.ref");
-                  onDiscardField("source.image.registry_credentials_id");
-                } : undefined}
+                onReset={onDiscardField ? () => onDiscardField("source.image") : undefined}
               >
                 <ImageRegistrySelect
                   id={`image-registry-${index}`}
@@ -362,12 +359,9 @@ function StackResourceConfigurationTabImpl({
               <DirtyField
                 draft={draft}
                 baseline={baseline}
-                path="source.image.ref"
+                path="source.image"
                 compact
-                onReset={onDiscardField ? () => {
-                  onDiscardField("source.image.ref");
-                  onDiscardField("source.image.registry_credentials_id");
-                } : undefined}
+                onReset={onDiscardField ? () => onDiscardField("source.image") : undefined}
               >
                 {(() => {
                   const { host, remainder } = splitImageRef(draft.source?.image?.ref || "");

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -502,7 +502,59 @@ function StackResourceConfigurationTabImpl({
               </LedgerRow>
             )}
 
-            <LedgerDisclosure label="Advanced" meta="push registry">
+            <LedgerDisclosure label="Advanced" meta="build & push">
+              <LedgerRow
+                label="Dockerfile path"
+                htmlFor={`dockerfile-path-${index}`}
+                hint="Relative to the build context."
+                error={getError(errors, "source.git.dockerfile_path")}
+              >
+                <DirtyField
+                  draft={draft}
+                  baseline={baseline}
+                  path="source.git.dockerfile_path"
+                  compact
+                  onReset={onDiscardField ? () => onDiscardField("source.git.dockerfile_path") : undefined}
+                >
+                  <Input
+                    id={`dockerfile-path-${index}`}
+                    value={draft.source?.git?.dockerfile_path ?? ""}
+                    onChange={(e) => updateGitSource({ dockerfile_path: e.target.value })}
+                    onBlur={(e) => {
+                      if (!e.target.value.trim()) updateGitSource({ dockerfile_path: "Dockerfile" });
+                    }}
+                    placeholder="Dockerfile"
+                    className="h-9 font-mono text-[12.5px]"
+                  />
+                </DirtyField>
+              </LedgerRow>
+
+              <LedgerRow
+                label="Build context"
+                htmlFor={`build-context-${index}`}
+                hint="Directory passed to the image build."
+                error={getError(errors, "source.git.build_context")}
+              >
+                <DirtyField
+                  draft={draft}
+                  baseline={baseline}
+                  path="source.git.build_context"
+                  compact
+                  onReset={onDiscardField ? () => onDiscardField("source.git.build_context") : undefined}
+                >
+                  <Input
+                    id={`build-context-${index}`}
+                    value={draft.source?.git?.build_context ?? ""}
+                    onChange={(e) => updateGitSource({ build_context: e.target.value })}
+                    onBlur={(e) => {
+                      if (!e.target.value.trim()) updateGitSource({ build_context: "." });
+                    }}
+                    placeholder="."
+                    className="h-9 font-mono text-[12.5px]"
+                  />
+                </DirtyField>
+              </LedgerRow>
+
               <LedgerRow
                 label="Push registry"
                 htmlFor={`push-repo-${index}`}

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/pages/stacks/components/editor/tabs/architecture/drawer-tabs/ledger";
 import { FieldShell } from "@/components/branded";
 import { RepoCombobox } from "@/components/git-source-picker/repo-combobox";
+import { ImageRegistrySelect } from "./image-registry-select";
+import { splitImageRef, joinImageRef } from "@/pages/stacks/lib/image-ref";
 
 import type { FormStackResourceData, FormVolumeExtendedData as VolumeFormData } from "@/pages/stacks/schemas/form-schema";
 
@@ -327,31 +329,64 @@ function StackResourceConfigurationTabImpl({
         </LedgerRow>
 
         {draft.sourceType === "image" ? (
-          <LedgerRow
-            label="Image reference"
-            htmlFor={`container-image-${index}`}
-            required
-            alignTop
-            error={getError(errors, "source.image.ref")}
-          >
-            <DirtyField
-              draft={draft}
-              baseline={baseline}
-              path="source.image.ref"
-              compact
-              onReset={onDiscardField ? () => onDiscardField("source.image.ref") : undefined}
+          <>
+            <LedgerRow label="Registry" htmlFor={`image-registry-${index}`}>
+              <DirtyField
+                draft={draft}
+                baseline={baseline}
+                path="source.image.ref"
+                compact
+                onReset={onDiscardField ? () => onDiscardField("source.image.ref") : undefined}
+              >
+                <ImageRegistrySelect
+                  id={`image-registry-${index}`}
+                  imageRef={draft.source?.image?.ref || ""}
+                  registryCredentialsId={draft.source?.image?.registry_credentials_id}
+                  onChange={(patch) =>
+                    updateImageSource({ ref: patch.ref, registry_credentials_id: patch.registry_credentials_id })
+                  }
+                />
+              </DirtyField>
+            </LedgerRow>
+
+            <LedgerRow
+              label="Image reference"
+              htmlFor={`container-image-${index}`}
+              required
+              alignTop
+              error={getError(errors, "source.image.ref")}
             >
-              <Input
-                id={`container-image-${index}`}
-                placeholder="e.g., nginx:latest, redis:7"
-                value={draft.source?.image?.ref || ""}
-                onChange={(e) => updateImageSource({ ref: e.target.value })}
-                className={`h-9 font-mono text-[12.5px] ${getError(errors, "source.image.ref") ? "border-danger" : ""}`}
-                required={draft.sourceType === "image"}
-                aria-invalid={!!getError(errors, "source.image.ref")}
-              />
-            </DirtyField>
-          </LedgerRow>
+              <DirtyField
+                draft={draft}
+                baseline={baseline}
+                path="source.image.ref"
+                compact
+                onReset={onDiscardField ? () => onDiscardField("source.image.ref") : undefined}
+              >
+                {(() => {
+                  const { host, remainder } = splitImageRef(draft.source?.image?.ref || "");
+                  return (
+                    <div className="flex items-center gap-1">
+                      {host && (
+                        <span className="rounded bg-muted px-1.5 py-1 font-mono text-[11px] text-muted-foreground">
+                          {host}/
+                        </span>
+                      )}
+                      <Input
+                        id={`container-image-${index}`}
+                        placeholder={host ? "e.g., acme/api:1.4.2" : "e.g., nginx:latest, redis:7"}
+                        value={remainder}
+                        onChange={(e) => updateImageSource({ ref: joinImageRef(host, e.target.value) })}
+                        className={`h-9 flex-1 font-mono text-[12.5px] ${getError(errors, "source.image.ref") ? "border-danger" : ""}`}
+                        required={draft.sourceType === "image"}
+                        aria-invalid={!!getError(errors, "source.image.ref")}
+                      />
+                    </div>
+                  );
+                })()}
+              </DirtyField>
+            </LedgerRow>
+          </>
         ) : (
           <>
             <LedgerRow

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/image-registry-select.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/image-registry-select.tsx
@@ -57,7 +57,7 @@ export function ImageRegistrySelect({ id, imageRef, registryCredentialsId, onCha
 
   const matched =
     credentials.find((c) => c.id === registryCredentialsId) ??
-    (host ? credentials.find((c) => c.host && dockerHostsEqual(c.host, host)) : undefined);
+    (host ? credentials.find((c) => dockerHostsEqual(c.host, host)) : undefined);
 
   const pickCredential = (cred: RegistryCredential) => {
     onChange({ ref: joinImageRef(cred.host ?? null, remainder), registry_credentials_id: cred.id });
@@ -103,7 +103,7 @@ export function ImageRegistrySelect({ id, imageRef, registryCredentialsId, onCha
                 <span className="text-[12.5px]">{PUBLIC_LABEL}</span>
               </CommandItem>
               {credentials.map((cred) => (
-                <CommandItem key={cred.id} value={cred.host ?? cred.id!} onSelect={() => pickCredential(cred)}>
+                <CommandItem key={cred.id} value={cred.host} onSelect={() => pickCredential(cred)}>
                   <Package className="h-3.5 w-3.5 text-muted-foreground" />
                   <span className="flex-1 truncate font-mono text-[12.5px]">{cred.host}</span>
                   <span className="text-[11px] text-muted-foreground">{cred.username}</span>

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/image-registry-select.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/image-registry-select.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import { ChevronDown, Globe, Package } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { listRegistryCredentials, type RegistryCredential } from "@/api/registry-credentials";
+import { getCurrentOrganizationId } from "@/helpers/common";
+import { splitImageRef, joinImageRef, dockerHostsEqual } from "@/pages/stacks/lib/image-ref";
+
+export interface ImageSourcePatch {
+  ref: string;
+  registry_credentials_id: string | undefined;
+}
+
+interface ImageRegistrySelectProps {
+  id: string;
+  /** Full source.image.ref (host included when present). */
+  imageRef: string;
+  registryCredentialsId?: string;
+  onChange: (patch: ImageSourcePatch) => void;
+}
+
+const PUBLIC_LABEL = "Public / Docker Hub";
+
+/** Registry picker for the image source: rewrites the ref's host segment and
+    keeps registry_credentials_id in sync with the chosen credential. */
+export function ImageRegistrySelect({ id, imageRef, registryCredentialsId, onChange }: ImageRegistrySelectProps) {
+  const [open, setOpen] = useState(false);
+  const [credentials, setCredentials] = useState<RegistryCredential[]>([]);
+  const [query, setQuery] = useState("");
+
+  const { host, remainder } = splitImageRef(imageRef);
+
+  useEffect(() => {
+    const orgId = getCurrentOrganizationId();
+    if (!orgId) return;
+    let cancelled = false;
+    listRegistryCredentials(orgId)
+      .then((res) => {
+        if (!cancelled) setCredentials(res.items ?? []);
+      })
+      .catch(() => {
+        // Credential list is an enhancement; free-text hosts still work.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const matched =
+    credentials.find((c) => c.id === registryCredentialsId) ??
+    (host ? credentials.find((c) => c.host && dockerHostsEqual(c.host, host)) : undefined);
+
+  const pickCredential = (cred: RegistryCredential) => {
+    onChange({ ref: joinImageRef(cred.host ?? null, remainder), registry_credentials_id: cred.id });
+    setOpen(false);
+  };
+
+  const pickPublic = () => {
+    onChange({ ref: remainder, registry_credentials_id: undefined });
+    setOpen(false);
+  };
+
+  const pickCustom = () => {
+    onChange({ ref: joinImageRef(query.trim(), remainder), registry_credentials_id: undefined });
+    setOpen(false);
+  };
+
+  const display = matched?.host ?? host ?? PUBLIC_LABEL;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "h-9 w-full justify-between font-mono text-[12.5px] font-normal",
+            !host && !matched && "text-muted-foreground",
+          )}
+        >
+          <span className="truncate">{display}</span>
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput placeholder="Registry host…" value={query} onValueChange={setQuery} />
+          <CommandList>
+            <CommandGroup>
+              <CommandItem value="public" onSelect={pickPublic}>
+                <Globe className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-[12.5px]">{PUBLIC_LABEL}</span>
+              </CommandItem>
+              {credentials.map((cred) => (
+                <CommandItem key={cred.id} value={cred.host ?? cred.id!} onSelect={() => pickCredential(cred)}>
+                  <Package className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="flex-1 truncate font-mono text-[12.5px]">{cred.host}</span>
+                  <span className="text-[11px] text-muted-foreground">{cred.username}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+            {query.trim() && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem value={`custom-${query}`} onSelect={pickCustom}>
+                    <span className="truncate text-[12.5px]">Use &quot;{query.trim()}&quot; as registry host</span>
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/image-registry-select.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/image-registry-select.tsx
@@ -103,7 +103,7 @@ export function ImageRegistrySelect({ id, imageRef, registryCredentialsId, onCha
                 <span className="text-[12.5px]">{PUBLIC_LABEL}</span>
               </CommandItem>
               {credentials.map((cred) => (
-                <CommandItem key={cred.id} value={cred.host} onSelect={() => pickCredential(cred)}>
+                <CommandItem key={cred.id} value={cred.id!} onSelect={() => pickCredential(cred)}>
                   <Package className="h-3.5 w-3.5 text-muted-foreground" />
                   <span className="flex-1 truncate font-mono text-[12.5px]">{cred.host}</span>
                   <span className="text-[11px] text-muted-foreground">{cred.username}</span>

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/image-registry-select.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/image-registry-select.tsx
@@ -93,7 +93,7 @@ export function ImageRegistrySelect({ id, imageRef, registryCredentialsId, onCha
           <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
         <Command shouldFilter={false}>
           <CommandInput placeholder="Registry host…" value={query} onValueChange={setQuery} />
           <CommandList>

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { Tabs } from "@/components/ui/tabs";
+import { StackResourceConfigurationTab, pickConfigurationDraft } from "../configuration-tab";
+
+afterEach(cleanup);
+
+// The combobox's network behavior is covered by its own tests; here it is a
+// controlled stub so we can assert the wiring contract.
+vi.mock("@/components/git-source-picker/repo-combobox", () => ({
+  RepoCombobox: ({ value, integrationId, onChange }: {
+    value: string;
+    integrationId?: string;
+    onChange: (p: { repo_url: string; integration_id: string | undefined }) => void;
+  }) => (
+    <button
+      data-testid="repo-combobox"
+      data-value={value}
+      data-integration={integrationId ?? ""}
+      onClick={() => onChange({ repo_url: "https://github.com/acme/api.git", integration_id: "int-app" })}
+    >
+      pick
+    </button>
+  ),
+}));
+
+function renderGitTab(overrides: Record<string, unknown> = {}) {
+  const onPatchResource = vi.fn();
+  const resource = {
+    name: "api",
+    sourceType: "git" as const,
+    source: { git: { repo_url: "", dockerfile_path: "Dockerfile", build_context: "." } },
+    ...overrides,
+  };
+  render(
+    // StackResourceConfigurationTab renders <TabsContent value="general">,
+    // which requires a Radix <Tabs> ancestor (Tabs provides the context
+    // TabsContent reads); the brief's starting spec rendered it bare and
+    // failed with "TabsContent must be used within Tabs". Sibling test
+    // env-addon-group-render.test.tsx wraps StackResourceEnvironmentTab the
+    // same way — follow that convention here.
+    <Tabs defaultValue="general">
+      <StackResourceConfigurationTab
+        draft={pickConfigurationDraft(resource)}
+        baseline={pickConfigurationDraft(resource)}
+        index={0}
+        // `errors` and `volumes` are required props on StackResourceConfigurationTabProps
+        // (unlike allResources/onDiscardField/onCreateVolume/onOpenVolume, which are
+        // optional). getError() indexes into `errors` unconditionally, so an empty
+        // object is required here rather than omitting the prop as the brief's
+        // starting spec did.
+        errors={{}}
+        volumes={[]}
+        onPatchResource={onPatchResource}
+      />
+    </Tabs>,
+  );
+  return { onPatchResource };
+}
+
+describe("git repository row", () => {
+  it("renders the repo combobox with the current url", () => {
+    renderGitTab({
+      source: { git: { repo_url: "https://github.com/a/b.git", dockerfile_path: "Dockerfile", build_context: ".", integration_id: "int-1" } },
+    });
+    const combo = screen.getByTestId("repo-combobox");
+    expect(combo).toHaveAttribute("data-value", "https://github.com/a/b.git");
+    expect(combo).toHaveAttribute("data-integration", "int-1");
+  });
+
+  it("patches repo_url and integration_id together on pick", () => {
+    const { onPatchResource } = renderGitTab();
+    screen.getByTestId("repo-combobox").click();
+    expect(onPatchResource).toHaveBeenCalledWith({
+      source: {
+        git: expect.objectContaining({
+          repo_url: "https://github.com/acme/api.git",
+          integration_id: "int-app",
+        }),
+      },
+    });
+  });
+});

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
@@ -26,13 +26,22 @@ vi.mock("@/components/git-source-picker/repo-combobox", () => ({
   ),
 }));
 
-function renderGitTab(overrides: Record<string, unknown> = {}) {
+function renderGitTab(
+  overrides: Record<string, unknown> = {},
+  options: { baselineOverrides?: Record<string, unknown>; onDiscardField?: (path: string) => void } = {},
+) {
   const onPatchResource = vi.fn();
   const resource = {
     name: "api",
     sourceType: "git" as const,
     source: { git: { repo_url: "", dockerfile_path: "Dockerfile", build_context: "." } },
     ...overrides,
+  };
+  const baselineResource = {
+    name: "api",
+    sourceType: "git" as const,
+    source: { git: { repo_url: "", dockerfile_path: "Dockerfile", build_context: "." } },
+    ...(options.baselineOverrides ?? overrides),
   };
   const { rerender } = render(
     // StackResourceConfigurationTab renders <TabsContent value="general">,
@@ -44,7 +53,7 @@ function renderGitTab(overrides: Record<string, unknown> = {}) {
     <Tabs defaultValue="general">
       <StackResourceConfigurationTab
         draft={pickConfigurationDraft(resource)}
-        baseline={pickConfigurationDraft(resource)}
+        baseline={pickConfigurationDraft(baselineResource)}
         index={0}
         // `errors` and `volumes` are required props on StackResourceConfigurationTabProps
         // (unlike allResources/onDiscardField/onCreateVolume/onOpenVolume, which are
@@ -54,6 +63,7 @@ function renderGitTab(overrides: Record<string, unknown> = {}) {
         errors={{}}
         volumes={[]}
         onPatchResource={onPatchResource}
+        onDiscardField={options.onDiscardField}
       />
     </Tabs>,
   );
@@ -73,11 +83,12 @@ function renderGitTab(overrides: Record<string, unknown> = {}) {
       <Tabs defaultValue="general">
         <StackResourceConfigurationTab
           draft={pickConfigurationDraft(next)}
-          baseline={pickConfigurationDraft(resource)}
+          baseline={pickConfigurationDraft(baselineResource)}
           index={0}
           errors={{}}
           volumes={[]}
           onPatchResource={onPatchResource}
+          onDiscardField={options.onDiscardField}
         />
       </Tabs>,
     );
@@ -149,6 +160,39 @@ describe("git repository row", () => {
         }),
       },
     });
+  });
+
+  it("discards both repo_url and integration_id when the Repository row's reset is clicked", () => {
+    const onDiscardField = vi.fn();
+    renderGitTab(
+      {
+        source: {
+          git: {
+            repo_url: "https://github.com/acme/new-repo.git",
+            dockerfile_path: "Dockerfile",
+            build_context: ".",
+            integration_id: "int-new",
+          },
+        },
+      },
+      {
+        baselineOverrides: {
+          source: {
+            git: {
+              repo_url: "https://github.com/acme/old-repo.git",
+              dockerfile_path: "Dockerfile",
+              build_context: ".",
+              integration_id: "int-old",
+            },
+          },
+        },
+        onDiscardField,
+      },
+    );
+    const resetButton = screen.getByRole("button", { name: /reset to original value/i });
+    resetButton.click();
+    expect(onDiscardField).toHaveBeenCalledWith("source.git.repo_url");
+    expect(onDiscardField).toHaveBeenCalledWith("source.git.integration_id");
   });
 });
 

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
@@ -249,7 +249,7 @@ describe("image source rows", () => {
     });
   });
 
-  it("discards both ref and registry_credentials_id when the Registry row's reset is clicked", () => {
+  it("discards the whole image source when the Registry row's reset is clicked", () => {
     const onDiscardField = vi.fn();
     renderImageTab(
       { source: { image: { ref: "ghcr.io/acme/api:2", registry_credentials_id: "cred-new" } } },
@@ -258,19 +258,21 @@ describe("image source rows", () => {
         onDiscardField,
       },
     );
-    // Both the Registry row and the Image reference row wrap "source.image.ref"
-    // in their own <DirtyField>, so a dirty ref surfaces a reset button on each
-    // — in JSX/DOM order, index 0 is the Registry row's, index 1 the Image
-    // reference row's.
+    // Both the Registry row and the Image reference row wrap "source.image"
+    // in their own <DirtyField>, so a dirty ref or credential surfaces a
+    // reset button on each — in JSX/DOM order, index 0 is the Registry row's,
+    // index 1 the Image reference row's. Discarding the whole "source.image"
+    // subtree in one call (rather than two leaf calls) means a credential-only
+    // change is covered by the same reset, since it dirties the same path.
     const resetButtons = screen.getAllByRole("button", { name: /reset to original value/i });
     expect(resetButtons).toHaveLength(2);
 
     resetButtons[0].click();
-    expect(onDiscardField).toHaveBeenCalledWith("source.image.ref");
-    expect(onDiscardField).toHaveBeenCalledWith("source.image.registry_credentials_id");
+    expect(onDiscardField).toHaveBeenCalledWith("source.image");
+    expect(onDiscardField).toHaveBeenCalledTimes(1);
   });
 
-  it("discards both ref and registry_credentials_id when the Image reference row's reset is clicked", () => {
+  it("discards the whole image source when the Image reference row's reset is clicked", () => {
     const onDiscardField = vi.fn();
     renderImageTab(
       { source: { image: { ref: "ghcr.io/acme/api:2", registry_credentials_id: "cred-new" } } },
@@ -283,8 +285,24 @@ describe("image source rows", () => {
     expect(resetButtons).toHaveLength(2);
 
     resetButtons[1].click();
-    expect(onDiscardField).toHaveBeenCalledWith("source.image.ref");
-    expect(onDiscardField).toHaveBeenCalledWith("source.image.registry_credentials_id");
+    expect(onDiscardField).toHaveBeenCalledWith("source.image");
+    expect(onDiscardField).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows both rows as dirty when only the credential changes and the ref stays the same", () => {
+    const onDiscardField = vi.fn();
+    renderImageTab(
+      { source: { image: { ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-new" } } },
+      {
+        baselineOverrides: { source: { image: { ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-old" } } },
+        onDiscardField,
+      },
+    );
+    // Before the fix, both DirtyFields wrapped "source.image.ref" only, so a
+    // credential-only change (same ref, different registry_credentials_id)
+    // never surfaced a reset button on either row.
+    const resetButtons = screen.getAllByRole("button", { name: /reset to original value/i });
+    expect(resetButtons).toHaveLength(2);
   });
 
   it("shows only the remainder in the ref input and recomposes the host on change", () => {

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
@@ -93,7 +93,27 @@ function renderGitTab(
       </Tabs>,
     );
   };
-  return { onPatchResource, rerenderWithGitSource };
+  // Simulates the parent store applying an onPatchResource call back into the
+  // draft (production shallow-merges the patch onto the full resource — see
+  // onPatchResource in use-resource-tab-props.ts). Needed for round-trip
+  // assertions on the "Build from" toggle, which reads back stashed fields.
+  const rerenderWithPatch = (patch: Record<string, unknown>) => {
+    const next = { ...resource, ...patch };
+    rerender(
+      <Tabs defaultValue="general">
+        <StackResourceConfigurationTab
+          draft={pickConfigurationDraft(next)}
+          baseline={pickConfigurationDraft(baselineResource)}
+          index={0}
+          errors={{}}
+          volumes={[]}
+          onPatchResource={onPatchResource}
+          onDiscardField={options.onDiscardField}
+        />
+      </Tabs>,
+    );
+  };
+  return { onPatchResource, rerenderWithGitSource, rerenderWithPatch };
 }
 
 vi.mock("../image-registry-select", () => ({
@@ -123,7 +143,7 @@ function renderImageTab(
   };
   const draftResource = { ...baseResource, ...overrides };
   const baselineResource = { ...baseResource, ...(options.baselineOverrides ?? overrides) };
-  render(
+  const { rerender } = render(
     <Tabs defaultValue="general">
       <StackResourceConfigurationTab
         draft={pickConfigurationDraft(draftResource)}
@@ -136,7 +156,27 @@ function renderImageTab(
       />
     </Tabs>,
   );
-  return { onPatchResource };
+  // Simulates the parent store applying an onPatchResource call back into the
+  // draft (production shallow-merges the patch onto the full resource — see
+  // onPatchResource in use-resource-tab-props.ts). Needed for round-trip
+  // assertions on the "Build from" toggle, which reads back stashed fields.
+  const rerenderWithPatch = (patch: Record<string, unknown>) => {
+    const next = { ...draftResource, ...patch };
+    rerender(
+      <Tabs defaultValue="general">
+        <StackResourceConfigurationTab
+          draft={pickConfigurationDraft(next)}
+          baseline={pickConfigurationDraft(baselineResource)}
+          index={0}
+          errors={{}}
+          volumes={[]}
+          onPatchResource={onPatchResource}
+          onDiscardField={options.onDiscardField}
+        />
+      </Tabs>,
+    );
+  };
+  return { onPatchResource, rerenderWithPatch };
 }
 
 describe("git repository row", () => {
@@ -325,6 +365,81 @@ describe("image source rows", () => {
     fireEvent.change(input, { target: { value: "quay.io/other/app:2" } });
     expect(onPatchResource).toHaveBeenCalledWith({
       source: { image: expect.objectContaining({ ref: "quay.io/other/app:2" }) },
+    });
+  });
+});
+
+describe("Build from toggle — source preservation", () => {
+  it("stashes the image source when toggling to git, and restores it exactly when toggling back", () => {
+    const { onPatchResource, rerenderWithPatch } = renderImageTab({
+      source: { image: { ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-ghcr" } },
+    });
+
+    // image -> git: the image source is stashed, git gets fresh defaults.
+    screen.getByRole("radio", { name: /git repository/i }).click();
+    expect(onPatchResource).toHaveBeenLastCalledWith({
+      sourceType: "git",
+      source: { git: { repo_url: "", dockerfile_path: "Dockerfile", build_context: "." } },
+      stashedImageSource: { ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-ghcr" },
+    });
+
+    const lastPatch = onPatchResource.mock.calls[onPatchResource.mock.calls.length - 1][0];
+    rerenderWithPatch(lastPatch);
+
+    // git -> image: the exact stashed image source is restored, and the
+    // (untouched, default) git source is stashed in turn.
+    screen.getByRole("radio", { name: /container image/i }).click();
+    expect(onPatchResource).toHaveBeenLastCalledWith({
+      sourceType: "image",
+      source: { image: { ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-ghcr" } },
+      stashedGitSource: { repo_url: "", dockerfile_path: "Dockerfile", build_context: "." },
+    });
+  });
+});
+
+describe("Build from toggle — git source preservation", () => {
+  it("stashes the git source when toggling to image, and restores it exactly when toggling back", () => {
+    const { onPatchResource, rerenderWithPatch } = renderGitTab({
+      source: {
+        git: {
+          repo_url: "https://github.com/acme/api.git",
+          dockerfile_path: "Dockerfile",
+          build_context: ".",
+          integration_id: "int-app",
+        },
+      },
+    });
+
+    // git -> image: the git source is stashed, image gets fresh defaults.
+    screen.getByRole("radio", { name: /container image/i }).click();
+    expect(onPatchResource).toHaveBeenLastCalledWith({
+      sourceType: "image",
+      source: { image: { ref: "" } },
+      stashedGitSource: {
+        repo_url: "https://github.com/acme/api.git",
+        dockerfile_path: "Dockerfile",
+        build_context: ".",
+        integration_id: "int-app",
+      },
+    });
+
+    const lastPatch = onPatchResource.mock.calls[onPatchResource.mock.calls.length - 1][0];
+    rerenderWithPatch(lastPatch);
+
+    // image -> git: the exact stashed git source is restored (repo_url +
+    // integration_id survive), and the default image source is stashed.
+    screen.getByRole("radio", { name: /git repository/i }).click();
+    expect(onPatchResource).toHaveBeenLastCalledWith({
+      sourceType: "git",
+      source: {
+        git: {
+          repo_url: "https://github.com/acme/api.git",
+          dockerfile_path: "Dockerfile",
+          build_context: ".",
+          integration_id: "int-app",
+        },
+      },
+      stashedImageSource: { ref: "" },
     });
   });
 });

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
@@ -34,7 +34,7 @@ function renderGitTab(overrides: Record<string, unknown> = {}) {
     source: { git: { repo_url: "", dockerfile_path: "Dockerfile", build_context: "." } },
     ...overrides,
   };
-  render(
+  const { rerender } = render(
     // StackResourceConfigurationTab renders <TabsContent value="general">,
     // which requires a Radix <Tabs> ancestor (Tabs provides the context
     // TabsContent reads); the brief's starting spec rendered it bare and
@@ -57,7 +57,32 @@ function renderGitTab(overrides: Record<string, unknown> = {}) {
       />
     </Tabs>,
   );
-  return { onPatchResource };
+  // Re-renders with a patched `git` source, simulating the parent store
+  // applying an onPatchResource call back into draft (as it does in
+  // production). Needed for onBlur-restores-default assertions: these are
+  // controlled inputs, and without a real re-render carrying the new value,
+  // React resets the DOM node's value back to the original `value` prop
+  // right after the change event, so by the time blur fires the input no
+  // longer reads as empty.
+  const rerenderWithGitSource = (git: Record<string, unknown>) => {
+    const next = {
+      ...resource,
+      source: { git: { ...(resource as { source: { git: Record<string, unknown> } }).source.git, ...git } },
+    };
+    rerender(
+      <Tabs defaultValue="general">
+        <StackResourceConfigurationTab
+          draft={pickConfigurationDraft(next)}
+          baseline={pickConfigurationDraft(resource)}
+          index={0}
+          errors={{}}
+          volumes={[]}
+          onPatchResource={onPatchResource}
+        />
+      </Tabs>,
+    );
+  };
+  return { onPatchResource, rerenderWithGitSource };
 }
 
 vi.mock("../image-registry-select", () => ({
@@ -123,6 +148,43 @@ describe("git repository row", () => {
           integration_id: "int-app",
         }),
       },
+    });
+  });
+});
+
+describe("advanced build fields", () => {
+  it("patches dockerfile_path", () => {
+    const { onPatchResource } = renderGitTab();
+    fireEvent.click(screen.getByText("Advanced"));
+    const input = screen.getByLabelText(/dockerfile path/i);
+    fireEvent.change(input, { target: { value: "docker/Dockerfile.prod" } });
+    expect(onPatchResource).toHaveBeenCalledWith({
+      source: { git: expect.objectContaining({ dockerfile_path: "docker/Dockerfile.prod" }) },
+    });
+  });
+
+  it("patches build_context", () => {
+    const { onPatchResource } = renderGitTab();
+    fireEvent.click(screen.getByText("Advanced"));
+    const input = screen.getByLabelText(/build context/i);
+    fireEvent.change(input, { target: { value: "services/api" } });
+    expect(onPatchResource).toHaveBeenCalledWith({
+      source: { git: expect.objectContaining({ build_context: "services/api" }) },
+    });
+  });
+
+  it("restores the default on blur when cleared", () => {
+    const { onPatchResource, rerenderWithGitSource } = renderGitTab();
+    fireEvent.click(screen.getByText("Advanced"));
+    const input = screen.getByLabelText(/dockerfile path/i);
+    fireEvent.change(input, { target: { value: "" } });
+    // Carry the cleared value into a re-render (see renderGitTab) so the
+    // controlled input actually reads "" when blur fires, matching how the
+    // real app re-renders with the patched draft between change and blur.
+    rerenderWithGitSource({ dockerfile_path: "" });
+    fireEvent.blur(screen.getByLabelText(/dockerfile path/i));
+    expect(onPatchResource).toHaveBeenLastCalledWith({
+      source: { git: expect.objectContaining({ dockerfile_path: "Dockerfile" }) },
     });
   });
 });

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
@@ -75,23 +75,28 @@ vi.mock("../image-registry-select", () => ({
   ),
 }));
 
-function renderImageTab(overrides: Record<string, unknown> = {}) {
+function renderImageTab(
+  overrides: Record<string, unknown> = {},
+  options: { baselineOverrides?: Record<string, unknown>; onDiscardField?: (path: string) => void } = {},
+) {
   const onPatchResource = vi.fn();
-  const resource = {
+  const baseResource = {
     name: "api",
     sourceType: "image" as const,
     source: { image: { ref: "" } },
-    ...overrides,
   };
+  const draftResource = { ...baseResource, ...overrides };
+  const baselineResource = { ...baseResource, ...(options.baselineOverrides ?? overrides) };
   render(
     <Tabs defaultValue="general">
       <StackResourceConfigurationTab
-        draft={pickConfigurationDraft(resource)}
-        baseline={pickConfigurationDraft(resource)}
+        draft={pickConfigurationDraft(draftResource)}
+        baseline={pickConfigurationDraft(baselineResource)}
         index={0}
         errors={{}}
         volumes={[]}
         onPatchResource={onPatchResource}
+        onDiscardField={options.onDiscardField}
       />
     </Tabs>,
   );
@@ -136,6 +141,44 @@ describe("image source rows", () => {
         image: expect.objectContaining({ ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-ghcr" }),
       },
     });
+  });
+
+  it("discards both ref and registry_credentials_id when the Registry row's reset is clicked", () => {
+    const onDiscardField = vi.fn();
+    renderImageTab(
+      { source: { image: { ref: "ghcr.io/acme/api:2", registry_credentials_id: "cred-new" } } },
+      {
+        baselineOverrides: { source: { image: { ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-old" } } },
+        onDiscardField,
+      },
+    );
+    // Both the Registry row and the Image reference row wrap "source.image.ref"
+    // in their own <DirtyField>, so a dirty ref surfaces a reset button on each
+    // — in JSX/DOM order, index 0 is the Registry row's, index 1 the Image
+    // reference row's.
+    const resetButtons = screen.getAllByRole("button", { name: /reset to original value/i });
+    expect(resetButtons).toHaveLength(2);
+
+    resetButtons[0].click();
+    expect(onDiscardField).toHaveBeenCalledWith("source.image.ref");
+    expect(onDiscardField).toHaveBeenCalledWith("source.image.registry_credentials_id");
+  });
+
+  it("discards both ref and registry_credentials_id when the Image reference row's reset is clicked", () => {
+    const onDiscardField = vi.fn();
+    renderImageTab(
+      { source: { image: { ref: "ghcr.io/acme/api:2", registry_credentials_id: "cred-new" } } },
+      {
+        baselineOverrides: { source: { image: { ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-old" } } },
+        onDiscardField,
+      },
+    );
+    const resetButtons = screen.getAllByRole("button", { name: /reset to original value/i });
+    expect(resetButtons).toHaveLength(2);
+
+    resetButtons[1].click();
+    expect(onDiscardField).toHaveBeenCalledWith("source.image.ref");
+    expect(onDiscardField).toHaveBeenCalledWith("source.image.registry_credentials_id");
   });
 
   it("shows only the remainder in the ref input and recomposes the host on change", () => {

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
@@ -298,4 +298,15 @@ describe("image source rows", () => {
       source: { image: expect.objectContaining({ ref: "ghcr.io/acme/api:2" }) },
     });
   });
+
+  it("replaces the whole ref instead of doubling the host when a full ref is pasted", () => {
+    const { onPatchResource } = renderImageTab({
+      source: { image: { ref: "ghcr.io/acme/api:1" } },
+    });
+    const input = screen.getByLabelText(/image reference/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "quay.io/other/app:2" } });
+    expect(onPatchResource).toHaveBeenCalledWith({
+      source: { image: expect.objectContaining({ ref: "quay.io/other/app:2" }) },
+    });
+  });
 });

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/configuration-tab-source.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import "@testing-library/jest-dom/vitest";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { Tabs } from "@/components/ui/tabs";
 import { StackResourceConfigurationTab, pickConfigurationDraft } from "../configuration-tab";
 
@@ -60,6 +60,44 @@ function renderGitTab(overrides: Record<string, unknown> = {}) {
   return { onPatchResource };
 }
 
+vi.mock("../image-registry-select", () => ({
+  ImageRegistrySelect: ({ imageRef, onChange }: {
+    imageRef: string;
+    onChange: (p: { ref: string; registry_credentials_id: string | undefined }) => void;
+  }) => (
+    <button
+      data-testid="image-registry-select"
+      data-ref={imageRef}
+      onClick={() => onChange({ ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-ghcr" })}
+    >
+      registry
+    </button>
+  ),
+}));
+
+function renderImageTab(overrides: Record<string, unknown> = {}) {
+  const onPatchResource = vi.fn();
+  const resource = {
+    name: "api",
+    sourceType: "image" as const,
+    source: { image: { ref: "" } },
+    ...overrides,
+  };
+  render(
+    <Tabs defaultValue="general">
+      <StackResourceConfigurationTab
+        draft={pickConfigurationDraft(resource)}
+        baseline={pickConfigurationDraft(resource)}
+        index={0}
+        errors={{}}
+        volumes={[]}
+        onPatchResource={onPatchResource}
+      />
+    </Tabs>,
+  );
+  return { onPatchResource };
+}
+
 describe("git repository row", () => {
   it("renders the repo combobox with the current url", () => {
     renderGitTab({
@@ -80,6 +118,35 @@ describe("git repository row", () => {
           integration_id: "int-app",
         }),
       },
+    });
+  });
+});
+
+describe("image source rows", () => {
+  it("renders the registry select with the full ref", () => {
+    renderImageTab({ source: { image: { ref: "ghcr.io/acme/api:1" } } });
+    expect(screen.getByTestId("image-registry-select")).toHaveAttribute("data-ref", "ghcr.io/acme/api:1");
+  });
+
+  it("patches ref and registry_credentials_id together from the select", () => {
+    const { onPatchResource } = renderImageTab({ source: { image: { ref: "acme/api:1" } } });
+    screen.getByTestId("image-registry-select").click();
+    expect(onPatchResource).toHaveBeenCalledWith({
+      source: {
+        image: expect.objectContaining({ ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-ghcr" }),
+      },
+    });
+  });
+
+  it("shows only the remainder in the ref input and recomposes the host on change", () => {
+    const { onPatchResource } = renderImageTab({
+      source: { image: { ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-ghcr" } },
+    });
+    const input = screen.getByLabelText(/image reference/i) as HTMLInputElement;
+    expect(input.value).toBe("acme/api:1");
+    fireEvent.change(input, { target: { value: "acme/api:2" } });
+    expect(onPatchResource).toHaveBeenCalledWith({
+      source: { image: expect.objectContaining({ ref: "ghcr.io/acme/api:2" }) },
     });
   });
 });

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/image-registry-select.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/image-registry-select.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ImageRegistrySelect } from "../image-registry-select";
+
+// cmdk (used by the Command primitive) reads ResizeObserver on mount, and
+// calls scrollIntoView when the highlighted item changes — neither of which
+// jsdom implements.
+beforeAll(() => {
+  global.ResizeObserver =
+    global.ResizeObserver ||
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  Element.prototype.scrollIntoView = Element.prototype.scrollIntoView || (() => {});
+});
+
+afterEach(cleanup);
+
+vi.mock("@/api/registry-credentials", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  listRegistryCredentials: vi.fn(),
+}));
+vi.mock("@/helpers/common", () => ({ getCurrentOrganizationId: () => "org-1" }));
+
+import { listRegistryCredentials } from "@/api/registry-credentials";
+
+const ghcr = { id: "cred-ghcr", host: "ghcr.io", username: "acme-pull-bot" };
+const ecr = { id: "cred-ecr", host: "123.dkr.ecr.us-east-1.amazonaws.com", username: "aws" };
+
+beforeEach(() => {
+  vi.mocked(listRegistryCredentials).mockResolvedValue({ items: [ghcr, ecr] });
+});
+
+describe("ImageRegistrySelect", () => {
+  it("preselects the credential matching the ref host", async () => {
+    render(
+      <ImageRegistrySelect id="reg" imageRef="ghcr.io/acme/api:1" registryCredentialsId="cred-ghcr" onChange={vi.fn()} />,
+    );
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveTextContent("ghcr.io"));
+  });
+
+  it("shows Public / Docker Hub for a bare ref", async () => {
+    render(<ImageRegistrySelect id="reg" imageRef="nginx:latest" onChange={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveTextContent(/public/i));
+  });
+
+  it("re-prefixes the ref and sets credentials on pick", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ImageRegistrySelect id="reg" imageRef="acme/api:1" onChange={onChange} />);
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("ghcr.io"));
+    expect(onChange).toHaveBeenCalledWith({
+      ref: "ghcr.io/acme/api:1",
+      registry_credentials_id: "cred-ghcr",
+    });
+  });
+
+  it("strips the host and clears credentials when Public is picked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ImageRegistrySelect id="reg" imageRef="ghcr.io/acme/api:1" registryCredentialsId="cred-ghcr" onChange={onChange} />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText(/public \/ docker hub/i));
+    expect(onChange).toHaveBeenCalledWith({
+      ref: "acme/api:1",
+      registry_credentials_id: undefined,
+    });
+  });
+
+  it("accepts a custom host and clears credentials", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ImageRegistrySelect id="reg" imageRef="acme/api:1" onChange={onChange} />);
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/registry host/i), "registry.example.com");
+    await user.click(await screen.findByText(/use "registry\.example\.com"/i));
+    expect(onChange).toHaveBeenCalledWith({
+      ref: "registry.example.com/acme/api:1",
+      registry_credentials_id: undefined,
+    });
+  });
+});

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/image-registry-select.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/tests/image-registry-select.test.tsx
@@ -87,4 +87,28 @@ describe("ImageRegistrySelect", () => {
       registry_credentials_id: undefined,
     });
   });
+
+  it("still renders and accepts a custom host when the credential list fails to load", async () => {
+    vi.mocked(listRegistryCredentials).mockRejectedValue(new Error("boom"));
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ImageRegistrySelect id="reg" imageRef="acme/api:1" onChange={onChange} />);
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/registry host/i), "registry.example.com");
+    await user.click(await screen.findByText(/use "registry\.example\.com"/i));
+    expect(onChange).toHaveBeenCalledWith({
+      ref: "registry.example.com/acme/api:1",
+      registry_credentials_id: undefined,
+    });
+  });
+
+  it("prefers the credential id match over the ref host match", async () => {
+    const credA = { id: "cred-a", host: "ghcr.io", username: "a" };
+    const credB = { id: "cred-b", host: "quay.io", username: "b" };
+    vi.mocked(listRegistryCredentials).mockResolvedValue({ items: [credA, credB] });
+    render(
+      <ImageRegistrySelect id="reg" imageRef="ghcr.io/acme/api:1" registryCredentialsId="cred-b" onChange={vi.fn()} />,
+    );
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveTextContent("quay.io"));
+  });
 });

--- a/frontend/src/pages/stacks/lib/image-ref.ts
+++ b/frontend/src/pages/stacks/lib/image-ref.ts
@@ -13,8 +13,12 @@ export function splitImageRef(ref: string): { host: string | null; remainder: st
   return { host: first, remainder: ref.slice(slash + 1) };
 }
 
+/** Join a host and remainder into a single ref, normalizing the seam so
+    composing from a picked host (which may carry a trailing slash) or a typed
+    remainder (which may carry a leading slash) never produces a double slash. */
 export function joinImageRef(host: string | null, remainder: string): string {
-  return host ? `${host}/${remainder}` : remainder;
+  if (!host) return remainder;
+  return `${host.replace(/\/+$/, "")}/${remainder.replace(/^\/+/, "")}`;
 }
 
 export function dockerHostsEqual(a: string, b: string): boolean {

--- a/frontend/src/pages/stacks/lib/image-ref.ts
+++ b/frontend/src/pages/stacks/lib/image-ref.ts
@@ -1,0 +1,25 @@
+/** Docker Hub host aliases the API normalizes between (docker.io ↔ index.docker.io). */
+const DOCKER_HUB_HOSTS = new Set(["docker.io", "index.docker.io", "registry-1.docker.io"]);
+
+/** Split an image ref into registry host and repo:tag remainder. The first
+    path segment is a host only if it contains a dot or port, or is localhost —
+    the same rule the Docker CLI applies. */
+export function splitImageRef(ref: string): { host: string | null; remainder: string } {
+  const slash = ref.indexOf("/");
+  if (slash < 0) return { host: null, remainder: ref };
+  const first = ref.slice(0, slash);
+  const isHost = first.includes(".") || first.includes(":") || first === "localhost";
+  if (!isHost) return { host: null, remainder: ref };
+  return { host: first, remainder: ref.slice(slash + 1) };
+}
+
+export function joinImageRef(host: string | null, remainder: string): string {
+  return host ? `${host}/${remainder}` : remainder;
+}
+
+export function dockerHostsEqual(a: string, b: string): boolean {
+  const la = a.toLowerCase();
+  const lb = b.toLowerCase();
+  if (la === lb) return true;
+  return DOCKER_HUB_HOSTS.has(la) && DOCKER_HUB_HOSTS.has(lb);
+}

--- a/frontend/src/pages/stacks/lib/tests/image-ref.test.ts
+++ b/frontend/src/pages/stacks/lib/tests/image-ref.test.ts
@@ -29,6 +29,12 @@ describe("joinImageRef", () => {
   it("does not double-slash an empty remainder", () => {
     expect(joinImageRef("ghcr.io", "")).toBe("ghcr.io/");
   });
+  it("strips a trailing slash from the host before joining", () => {
+    expect(joinImageRef("ghcr.io/", "acme/api")).toBe("ghcr.io/acme/api");
+  });
+  it("strips a leading slash from the remainder before joining", () => {
+    expect(joinImageRef("ghcr.io", "/acme/api")).toBe("ghcr.io/acme/api");
+  });
 });
 
 describe("dockerHostsEqual", () => {

--- a/frontend/src/pages/stacks/lib/tests/image-ref.test.ts
+++ b/frontend/src/pages/stacks/lib/tests/image-ref.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { splitImageRef, joinImageRef, dockerHostsEqual } from "../image-ref";
+
+describe("splitImageRef", () => {
+  it("returns null host for bare Docker Hub refs", () => {
+    expect(splitImageRef("nginx:latest")).toEqual({ host: null, remainder: "nginx:latest" });
+    expect(splitImageRef("acme/api:1.2")).toEqual({ host: null, remainder: "acme/api:1.2" });
+  });
+
+  it("detects a registry host by dot, port, or localhost", () => {
+    expect(splitImageRef("ghcr.io/acme/api:1.4.2")).toEqual({ host: "ghcr.io", remainder: "acme/api:1.4.2" });
+    expect(splitImageRef("localhost:5000/app")).toEqual({ host: "localhost:5000", remainder: "app" });
+    expect(splitImageRef("registry:5000/app")).toEqual({ host: "registry:5000", remainder: "app" });
+  });
+
+  it("handles empty and host-only refs without crashing", () => {
+    expect(splitImageRef("")).toEqual({ host: null, remainder: "" });
+    expect(splitImageRef("ghcr.io/")).toEqual({ host: "ghcr.io", remainder: "" });
+  });
+});
+
+describe("joinImageRef", () => {
+  it("prefixes host when present", () => {
+    expect(joinImageRef("ghcr.io", "acme/api:1")).toBe("ghcr.io/acme/api:1");
+  });
+  it("returns remainder alone for null host", () => {
+    expect(joinImageRef(null, "nginx:latest")).toBe("nginx:latest");
+  });
+  it("does not double-slash an empty remainder", () => {
+    expect(joinImageRef("ghcr.io", "")).toBe("ghcr.io/");
+  });
+});
+
+describe("dockerHostsEqual", () => {
+  it("treats Docker Hub aliases as equal", () => {
+    expect(dockerHostsEqual("docker.io", "index.docker.io")).toBe(true);
+    expect(dockerHostsEqual("registry-1.docker.io", "docker.io")).toBe(true);
+  });
+  it("compares other hosts case-insensitively", () => {
+    expect(dockerHostsEqual("GHCR.IO", "ghcr.io")).toBe(true);
+    expect(dockerHostsEqual("ghcr.io", "quay.io")).toBe(false);
+  });
+});

--- a/frontend/src/pages/stacks/schemas/form-schema.ts
+++ b/frontend/src/pages/stacks/schemas/form-schema.ts
@@ -15,6 +15,7 @@ import type { StackUpdateRequest, StackResourceUpdateRequest, VolumeUpdateReques
 import { ADDON_OUTPUT_FIELDS } from "@/pages/stacks/lib/addon-presets";
 import { buildDesiredConnections, mountsToConnections } from "@/pages/stacks/lib/connection-mapping";
 import type { FormEnvRow, FormMountRow } from "@/pages/stacks/lib/connection-mapping";
+import { splitImageRef } from "@/pages/stacks/lib/image-ref";
 
 /**
  * Form-specific UI schema additions
@@ -114,7 +115,11 @@ const FormStackResourceSchema = ApiStackResourceSchema.extend({
       });
     }
   } else if (data.source?.image) {
-    if (!data.source.image.ref) {
+    // A ref like "ghcr.io/" (host picked, no repo typed) is non-empty but has
+    // no actual image identity once the host segment is split off — reject
+    // that the same as a fully empty ref.
+    const { remainder } = splitImageRef(data.source.image.ref ?? "");
+    if (!data.source.image.ref || !remainder) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "Container image reference is required",
@@ -407,7 +412,10 @@ function prepareFormResourceForApi(resource: FormStackResourceData): StackResour
     };
   } else if (resource.sourceType === 'image') {
     prepared.source = {
-      image: { ref: resource.source?.image?.ref ?? '' },
+      image: {
+        ref: resource.source?.image?.ref ?? '',
+        registry_credentials_id: resource.source?.image?.registry_credentials_id,
+      },
     };
   }
 

--- a/frontend/src/pages/stacks/schemas/form-schema.ts
+++ b/frontend/src/pages/stacks/schemas/form-schema.ts
@@ -10,6 +10,8 @@ import {
   ApiVolumeSpecSchema,
   ApiVolumeSchema,
   ApiStackSchema,
+  ApiGitSourceSchema,
+  ApiImageSourceSchema,
 } from "./api-schema";
 import type { StackUpdateRequest, StackResourceUpdateRequest, VolumeUpdateRequest } from "@/api/stacks";
 import { ADDON_OUTPUT_FIELDS } from "@/pages/stacks/lib/addon-presets";
@@ -82,6 +84,12 @@ const FormStackResourceSchema = ApiStackResourceSchema.extend({
   // UI helper fields for git revision, not part of API spec StackResource
   gitRevisionType: FormGitRevisionTypeSchema.optional(),
   gitRevisionValue: z.string().optional(),
+  // UI-only stash for the "Build from" toggle: the API rejects a source with
+  // both `git` and `image` set (source_conflict), so we cannot keep both
+  // subtrees live in `source`. Toggling away from a branch stashes it here so
+  // toggling back restores it instead of resetting to blank defaults.
+  stashedGitSource: ApiGitSourceSchema.optional(),
+  stashedImageSource: ApiImageSourceSchema.optional(),
   // Port name is optional in the form — the API requires it, so we auto-derive
   // `port-<number>` on save rather than asking the user for it.
   ports: z.array(ApiPortSchema.extend({ name: z.string().optional() })).optional(),
@@ -239,6 +247,8 @@ function convertFormResourceToApiResource(
     sourceType,
     gitRevisionType,
     gitRevisionValue,
+    stashedGitSource,
+    stashedImageSource,
     outputs,
     ...rest
   } = resource;

--- a/frontend/src/pages/stacks/schemas/form-schema.ts
+++ b/frontend/src/pages/stacks/schemas/form-schema.ts
@@ -97,7 +97,7 @@ const FormStackResourceSchema = ApiStackResourceSchema.extend({
   // Drive validation off the actual `source` union (same discriminant the canvas
   // node card uses) rather than the `sourceType` UI helper, which can desync.
   if (data.source?.git) {
-    if (!data.source.git.repo_url) {
+    if (!data.source.git.repo_url?.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "Git repository URL is required",
@@ -117,9 +117,12 @@ const FormStackResourceSchema = ApiStackResourceSchema.extend({
   } else if (data.source?.image) {
     // A ref like "ghcr.io/" (host picked, no repo typed) is non-empty but has
     // no actual image identity once the host segment is split off — reject
-    // that the same as a fully empty ref.
-    const { remainder } = splitImageRef(data.source.image.ref ?? "");
-    if (!data.source.image.ref || !remainder) {
+    // that the same as a fully empty ref. Whitespace-only refs/remainders are
+    // rejected the same way (a ref of "  " round-trips through splitImageRef
+    // untouched, so it must be checked explicitly, not just falsiness).
+    const ref = data.source.image.ref ?? "";
+    const { remainder } = splitImageRef(ref);
+    if (!ref.trim() || !remainder.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "Container image reference is required",

--- a/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
+++ b/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
@@ -279,6 +279,56 @@ describe("FormStackResourceSchema — image ref validation", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("rejects a whitespace-only ref", async () => {
+    const { FormStackResourceSchema } = await import("../form-schema");
+    const result = FormStackResourceSchema.safeParse({
+      name: "web",
+      sourceType: "image",
+      source: { image: { ref: "  " } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path.join(".") === "source.image.ref",
+      );
+      expect(issue?.message).toBe("Container image reference is required");
+    }
+  });
+
+  it("rejects a host with a whitespace-only remainder", async () => {
+    const { FormStackResourceSchema } = await import("../form-schema");
+    const result = FormStackResourceSchema.safeParse({
+      name: "web",
+      sourceType: "image",
+      source: { image: { ref: "ghcr.io/  " } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path.join(".") === "source.image.ref",
+      );
+      expect(issue?.message).toBe("Container image reference is required");
+    }
+  });
+});
+
+describe("FormStackResourceSchema — git repo_url validation", () => {
+  it("rejects a whitespace-only repo_url", async () => {
+    const { FormStackResourceSchema } = await import("../form-schema");
+    const result = FormStackResourceSchema.safeParse({
+      name: "web",
+      sourceType: "git",
+      source: { git: { repo_url: "   ", dockerfile_path: "Dockerfile", build_context: "." } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path.join(".") === "source.git.repo_url",
+      );
+      expect(issue?.message).toBe("Git repository URL is required");
+    }
+  });
 });
 
 describe("FormEnvVarSchema (addon variant) — refines", () => {

--- a/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
+++ b/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
@@ -243,6 +243,42 @@ describe("convertFormStackToApiStack — image source credential passthrough", (
   });
 });
 
+describe("stashed source fields — stripped before the API payload", () => {
+  it("strips stashedGitSource and stashedImageSource via convertFormResourceToApiResource", () => {
+    const form = {
+      name: "web",
+      sourceType: "image" as const,
+      source: { image: { ref: "ghcr.io/acme/api:1" } },
+      stashedGitSource: { repo_url: "https://github.com/acme/api.git", dockerfile_path: "Dockerfile", build_context: "." },
+      stashedImageSource: { ref: "old-ref" },
+    };
+    const api = convertFormResourceToApiResource(form as never);
+    expect(api).not.toHaveProperty("stashedGitSource");
+    expect(api).not.toHaveProperty("stashedImageSource");
+  });
+
+  it("strips stashedGitSource and stashedImageSource via convertFormStackToApiStack", () => {
+    const form = {
+      name: "tooljet",
+      labels: [],
+      spec: {
+        stack_resources: [
+          {
+            name: "web",
+            sourceType: "git" as const,
+            source: { git: { repo_url: "https://github.com/acme/api.git", dockerfile_path: "Dockerfile", build_context: "." } },
+            stashedGitSource: { repo_url: "https://github.com/acme/old.git", dockerfile_path: "Dockerfile", build_context: "." },
+            stashedImageSource: { ref: "ghcr.io/acme/api:1", registry_credentials_id: "cred-1" },
+          },
+        ],
+      },
+    };
+    const api = convertFormStackToApiStack(form as never);
+    expect(api.spec.stack_resources[0]).not.toHaveProperty("stashedGitSource");
+    expect(api.spec.stack_resources[0]).not.toHaveProperty("stashedImageSource");
+  });
+});
+
 describe("FormStackResourceSchema — image ref validation", () => {
   it("rejects a ref with a host but an empty remainder", async () => {
     const { FormStackResourceSchema } = await import("../form-schema");

--- a/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
+++ b/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
@@ -218,6 +218,69 @@ describe("convertFormStackToApiStack — git source credential passthrough", () 
   });
 });
 
+describe("convertFormStackToApiStack — image source credential passthrough", () => {
+  it("preserves source.image.registry_credentials_id through the API-prep transform", () => {
+    const form = {
+      name: "tooljet",
+      labels: [],
+      spec: {
+        stack_resources: [
+          {
+            name: "web",
+            sourceType: "image" as const,
+            source: {
+              image: {
+                ref: "ghcr.io/acme/api:1",
+                registry_credentials_id: "cred-1",
+              },
+            },
+          },
+        ],
+      },
+    };
+    const api = convertFormStackToApiStack(form as never);
+    expect(api.spec.stack_resources[0].source?.image?.registry_credentials_id).toBe("cred-1");
+  });
+});
+
+describe("FormStackResourceSchema — image ref validation", () => {
+  it("rejects a ref with a host but an empty remainder", async () => {
+    const { FormStackResourceSchema } = await import("../form-schema");
+    const result = FormStackResourceSchema.safeParse({
+      name: "web",
+      sourceType: "image",
+      source: { image: { ref: "ghcr.io/" } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path.join(".") === "source.image.ref",
+      );
+      expect(issue?.message).toBe("Container image reference is required");
+    }
+  });
+
+  it("accepts a fully-qualified ref with host, repo, and tag", async () => {
+    const { FormStackResourceSchema } = await import("../form-schema");
+    const result = FormStackResourceSchema.safeParse({
+      name: "web",
+      sourceType: "image",
+      source: { image: { ref: "ghcr.io/acme/api:1" } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a hostless ref", async () => {
+    const { FormStackResourceSchema } = await import("../form-schema");
+    const result = FormStackResourceSchema.safeParse({
+      name: "web",
+      sourceType: "image",
+      source: { image: { ref: "nginx:latest" } },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("FormEnvVarSchema (addon variant) — refines", () => {
   it("requires database when superuser is false", async () => {
     const { FormEnvVarSchema } = await import("../form-schema");


### PR DESCRIPTION
## 📝 What this does
Makes the stack drawer's Source section aware of the new git-integration and image-registry features: repositories are picked from connected integrations instead of pasted as bare URLs, image refs get a registry credential picker, and previously hidden build fields (Dockerfile path, build context) are now editable.

## 🔀 Changes
- Added a repository combobox to the git source row — searches repos across usable git integrations, accepts pasted URLs (https/ssh/scp-style), and stores the clone URL together with its integration id
- Added a registry picker to the image source row — lists org registry credentials, prefixes the ref with the chosen host behind a chip, and keeps the pull credential id in sync (including through save and dirty-field discard)
- Exposed Dockerfile path and build context inputs under the git Advanced disclosure, with blank values restoring the API defaults
- Rejected host-only image refs (e.g. `ghcr.io/`) in form validation and handled full-ref paste without doubling the host
- Fixed combobox popover width under Tailwind v4 by wrapping the Radix trigger-width custom property in `var()`

## 🧪 How to test
- [x] Open a stack, select a service, switch Build from to Git repository
- [x] Pick a repo from the combobox — repository shows as `owner/name`; paste an `https://` or `git@` URL via the "Use as repository URL" item
- [x] Expand Advanced — edit Dockerfile path and build context, clear them, blur, defaults restore
- [x] Switch to Container image — pick a registry credential, confirm the host chip prefixes the ref and the ref input keeps only `repo:tag`
- [x] Save the stack and confirm the PUT payload carries `integration_id`, `registry_credentials_id`, `dockerfile_path`, `build_context`
