### PR TITLE
Feature: ToolJet template v2 with observability and deploy-time env references

### DIFF
--- a/frontend/src/data/templates/tests/template-conversion.test.ts
+++ b/frontend/src/data/templates/tests/template-conversion.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { templates, getTemplateById } from "@/data/templates/registry";
+import { templateToFormData } from "@/data/templates/template-to-form";
+
+describe("template conversion round-trip", () => {
+  it.each(templates.map((t) => [t.id, t] as const))(
+    "template %s converts without errors",
+    (_id, template) => {
+      const { data } = templateToFormData(template);
+      expect(data.spec.stack_resources.length).toBeGreaterThan(0);
+    },
+  );
+
+  it("tooljet template produces the full 6-service stack", () => {
+    const tooljet = getTemplateById("tooljet")!;
+    const { data } = templateToFormData(tooljet);
+
+    const names = data.spec.stack_resources.map((r) => r.name).sort();
+    expect(names).toEqual(
+      ["lgtm", "postgresql", "postgrest", "redis", "tooljet", "tooljet-worker"].sort(),
+    );
+
+    const volumeNames = (data.spec.volumes ?? []).map((v) => v.name).sort();
+    expect(volumeNames).toEqual(["grafana-data", "postgres-data"].sort());
+
+    const app = data.spec.stack_resources.find((r) => r.name === "tooljet")!;
+    const env = Object.fromEntries(
+      (app.environment_variables ?? []).map((e: { name: string; value: string }) => [e.name, e.value]),
+    );
+    expect(env.ENABLE_OTEL).toBe("true");
+    expect(env.OTEL_EXPORTER_OTLP_TRACES).toBe("http://lgtm:4318/v1/traces");
+    expect(env.WORKER).toBeUndefined();
+
+    const worker = data.spec.stack_resources.find((r) => r.name === "tooljet-worker")!;
+    const workerEnv = Object.fromEntries(
+      (worker.environment_variables ?? []).map((e: { name: string; value: string }) => [e.name, e.value]),
+    );
+    expect(workerEnv.WORKER).toBe("true");
+  });
+});

--- a/frontend/src/data/templates/tests/template-conversion.test.ts
+++ b/frontend/src/data/templates/tests/template-conversion.test.ts
@@ -25,7 +25,7 @@ describe("template conversion round-trip", () => {
 
     const app = data.spec.stack_resources.find((r) => r.name === "tooljet")!;
     const env = Object.fromEntries(
-      (app.environment_variables ?? []).map((e: { name: string; value: string }) => [e.name, e.value]),
+      (app.execution_config?.environment_variables ?? []).map((e: { name: string; value: string }) => [e.name, e.value]),
     );
     expect(env.ENABLE_OTEL).toBe("true");
     expect(env.OTEL_EXPORTER_OTLP_TRACES).toBe("http://lgtm:4318/v1/traces");
@@ -33,7 +33,7 @@ describe("template conversion round-trip", () => {
 
     const worker = data.spec.stack_resources.find((r) => r.name === "tooljet-worker")!;
     const workerEnv = Object.fromEntries(
-      (worker.environment_variables ?? []).map((e: { name: string; value: string }) => [e.name, e.value]),
+      (worker.execution_config?.environment_variables ?? []).map((e: { name: string; value: string }) => [e.name, e.value]),
     );
     expect(workerEnv.WORKER).toBe("true");
   });

--- a/frontend/src/data/templates/tests/template-conversion.test.ts
+++ b/frontend/src/data/templates/tests/template-conversion.test.ts
@@ -27,9 +27,11 @@ describe("template conversion round-trip", () => {
     const env = envByName(app);
     expect(env.ENABLE_OTEL).toEqual({ from: "stack", name: "ENABLE_OTEL", value: "true" });
     expect(env.OTEL_EXPORTER_OTLP_TRACES).toEqual({
-      from: "stack",
+      from: "resourceTemplate",
       name: "OTEL_EXPORTER_OTLP_TRACES",
-      value: "http://otel-stack:4318/v1/traces",
+      resourceName: "otel-stack",
+      template: "http://{{host}}:4318/v1/traces",
+      values: { host: "host" },
     });
     expect(env.WORKER).toBeUndefined();
 

--- a/frontend/src/data/templates/tests/template-conversion.test.ts
+++ b/frontend/src/data/templates/tests/template-conversion.test.ts
@@ -24,17 +24,64 @@ describe("template conversion round-trip", () => {
     expect(volumeNames).toEqual(["grafana-data", "postgres-data"].sort());
 
     const app = data.spec.stack_resources.find((r) => r.name === "tooljet")!;
-    const env = Object.fromEntries(
-      (app.execution_config?.environment_variables ?? []).map((e: { name: string; value: string }) => [e.name, e.value]),
-    );
-    expect(env.ENABLE_OTEL).toBe("true");
-    expect(env.OTEL_EXPORTER_OTLP_TRACES).toBe("http://lgtm:4318/v1/traces");
+    const env = envByName(app);
+    expect(env.ENABLE_OTEL).toEqual({ from: "stack", name: "ENABLE_OTEL", value: "true" });
+    expect(env.OTEL_EXPORTER_OTLP_TRACES).toEqual({
+      from: "stack",
+      name: "OTEL_EXPORTER_OTLP_TRACES",
+      value: "http://lgtm:4318/v1/traces",
+    });
     expect(env.WORKER).toBeUndefined();
 
     const worker = data.spec.stack_resources.find((r) => r.name === "tooljet-worker")!;
-    const workerEnv = Object.fromEntries(
-      (worker.execution_config?.environment_variables ?? []).map((e: { name: string; value: string }) => [e.name, e.value]),
-    );
-    expect(workerEnv.WORKER).toBe("true");
+    const workerEnv = envByName(worker);
+    expect(workerEnv.WORKER).toEqual({ from: "stack", name: "WORKER", value: "true" });
+  });
+
+  it("tooljet template resolves referential env vars at deploy time", () => {
+    const tooljet = getTemplateById("tooljet")!;
+    const { data } = templateToFormData(tooljet);
+
+    const app = data.spec.stack_resources.find((r) => r.name === "tooljet")!;
+    const env = envByName(app);
+    expect(env.TOOLJET_HOST).toEqual({ from: "self", name: "TOOLJET_HOST", selfOutput: "public_url" });
+    expect(env.PG_HOST).toEqual({ from: "resource", name: "PG_HOST", resourceName: "postgresql", output: "host" });
+    expect(env.TOOLJET_DB_HOST).toEqual({ from: "resource", name: "TOOLJET_DB_HOST", resourceName: "postgresql", output: "host" });
+    expect(env.PGRST_HOST).toEqual({ from: "resource", name: "PGRST_HOST", resourceName: "postgrest", output: "host" });
+    expect(env.REDIS_HOST).toEqual({ from: "resource", name: "REDIS_HOST", resourceName: "redis", output: "host" });
+
+    const worker = data.spec.stack_resources.find((r) => r.name === "tooljet-worker")!;
+    const workerEnv = envByName(worker);
+    expect(workerEnv.TOOLJET_HOST).toEqual({ from: "resource", name: "TOOLJET_HOST", resourceName: "tooljet", output: "public_url" });
+    expect(workerEnv.REDIS_HOST).toEqual({ from: "resource", name: "REDIS_HOST", resourceName: "redis", output: "host" });
+  });
+
+  it("tooljet template runs the image entrypoint and exposes the OTLP port", () => {
+    const tooljet = getTemplateById("tooljet")!;
+    const { data } = templateToFormData(tooljet);
+
+    for (const name of ["tooljet", "tooljet-worker"]) {
+      const resource = data.spec.stack_resources.find((r) => r.name === name)!;
+      expect(resource.execution_config?.command).toEqual([
+        "./server/ee-entrypoint.sh", "npm", "run", "start:prod",
+      ]);
+    }
+
+    const lgtm = data.spec.stack_resources.find((r) => r.name === "lgtm")!;
+    const ports = (lgtm.ports ?? [])
+      .map((p) => ({ number: p.number, public: p.exposed_to_public }))
+      .sort((a, b) => (a.number ?? 0) - (b.number ?? 0));
+    expect(ports).toEqual([
+      { number: 3000, public: true },
+      { number: 4318, public: false },
+    ]);
   });
 });
+
+type ConvertedResource = ReturnType<typeof templateToFormData>["data"]["spec"]["stack_resources"][number];
+
+function envByName(resource: ConvertedResource) {
+  return Object.fromEntries(
+    (resource.execution_config?.environment_variables ?? []).map((e) => [e.name, e]),
+  );
+}

--- a/frontend/src/data/templates/tests/template-conversion.test.ts
+++ b/frontend/src/data/templates/tests/template-conversion.test.ts
@@ -17,11 +17,11 @@ describe("template conversion round-trip", () => {
 
     const names = data.spec.stack_resources.map((r) => r.name).sort();
     expect(names).toEqual(
-      ["lgtm", "postgresql", "postgrest", "redis", "tooljet", "tooljet-worker"].sort(),
+      ["otel-stack", "postgresql", "postgrest", "redis", "tooljet", "tooljet-worker"].sort(),
     );
 
     const volumeNames = (data.spec.volumes ?? []).map((v) => v.name).sort();
-    expect(volumeNames).toEqual(["grafana-data", "postgres-data"].sort());
+    expect(volumeNames).toEqual(["otel-stack-data", "postgres-data"].sort());
 
     const app = data.spec.stack_resources.find((r) => r.name === "tooljet")!;
     const env = envByName(app);
@@ -29,7 +29,7 @@ describe("template conversion round-trip", () => {
     expect(env.OTEL_EXPORTER_OTLP_TRACES).toEqual({
       from: "stack",
       name: "OTEL_EXPORTER_OTLP_TRACES",
-      value: "http://lgtm:4318/v1/traces",
+      value: "http://otel-stack:4318/v1/traces",
     });
     expect(env.WORKER).toBeUndefined();
 
@@ -67,8 +67,8 @@ describe("template conversion round-trip", () => {
       ]);
     }
 
-    const lgtm = data.spec.stack_resources.find((r) => r.name === "lgtm")!;
-    const ports = (lgtm.ports ?? [])
+    const otelStack = data.spec.stack_resources.find((r) => r.name === "otel-stack")!;
+    const ports = (otelStack.ports ?? [])
       .map((p) => ({ number: p.number, public: p.exposed_to_public }))
       .sort((a, b) => (a.number ?? 0) - (b.number ?? 0));
     expect(ports).toEqual([

--- a/frontend/src/data/templates/tooljet/dashboards/tooljet-monitoring.json
+++ b/frontend/src/data/templates/tooljet/dashboards/tooljet-monitoring.json
@@ -4118,7 +4118,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "Asia/Calcutta",
+  "timezone": "browser",
   "title": "Tooljet Monitoring",
   "uid": "tooljet-monitoring",
   "version": 46,

--- a/frontend/src/data/templates/tooljet/dashboards/tooljet-monitoring.json
+++ b/frontend/src/data/templates/tooljet/dashboards/tooljet-monitoring.json
@@ -1,0 +1,4126 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_TEMPO",
+      "label": "Tempo",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "tempo",
+      "pluginName": "Tempo"
+    },
+    {
+      "name": "VAR_SLO_P95_MS",
+      "type": "constant",
+      "label": "SLO p95 (ms)",
+      "value": "500",
+      "description": ""
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.4.0"
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "tempo",
+      "name": "Tempo",
+      "version": "11.3.1"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "🚦 Service health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · slowest-5% response time. `p95` = 95% of requests finished faster than this; only the slowest 5% were worse. One ranked cut-off across all routes.\n\n**READ** · <500ms green · <1s yellow · >1s red.\n\n**INFER** · red + Saturation tile high → app is CPU / event-loop bound. Red + Saturation low → the DB or an outbound call is the cause. Buckets are pooled across pods first, then the cut-off taken — never an average of per-pod numbers.\n\nSource: `http_server_duration_milliseconds_bucket`",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "noValue": "no recent traffic",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_duration_milliseconds_bucket{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__range])))",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · share of responses that were `5xx` (server's fault). `4xx` (caller's fault — bad input, expired login) is excluded; it does not mean the server is broken.\n\n**READ** · <1% green · <5% yellow · >5% red.\n\n**INFER** · sudden spike → open Failing routes to see which endpoint. Stays high → a dependency is down or a recent deploy broke something.\n\nSource: `http_server_duration_milliseconds_count` filtered on `http_status_code`",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "(100 * (sum(rate(http_server_duration_milliseconds_count{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\", http_status_code=~\"5..\",host_name=~\"$host\"}[$__range])) or vector(0)) / clamp_min(sum(rate(http_server_duration_milliseconds_count{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__range])), 0.001)) or vector(0)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Error rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · total requests per second hitting the service.\n\n**READ** · the trend matters more than the number. A sudden drop to near-zero = traffic is not reaching the app (load balancer, DNS, or routing problem). No colour — busy is normal.\n\n**INFER** · compare against a normal day (shift the time picker back 1 day). Read it next to Saturation — high traffic with low Saturation = healthy headroom.\n\nSource: `http_server_duration_milliseconds_count`",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "(sum(rate(http_server_duration_milliseconds_count{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__range]))) or vector(0)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Traffic",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · how full Node's event loop is (its single work queue — while it is busy, nothing else runs). `0` = idle, `1` = no spare capacity. Live, refreshed every ~5s.\n\n**READ** · <0.7 green · 0.7–0.85 yellow · >0.85 red.\n\n**INFER** · the headline 'is Node overloaded' number. High = heavy JavaScript work, blocking I/O, or long garbage-collection pauses. When it is red, new requests wait in line.\n\nSource: `nodejs_eventloop_utilization_ratio`",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.85
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max(nodejs_eventloop_utilization_ratio{job=~\"$service\",host_name=~\"$host\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Saturation",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · `App` = the ToolJet build version · `Node` = the Node.js runtime version.\n\n**READ** · `App: unknown` = the build did not stamp a version number. Two rows for one = a rollout in progress, pods still on different versions.\n\n**INFER** · always check this first when triaging a bug — 'did it start after a deploy?'. A stuck two-version state means a rollout never finished.\n\nSource: `service_version`, `process_runtime_version` labels",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 200,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "group by (service_version, process_runtime_version) (nodejs_eventloop_utilization_ratio{job=~\"$service\"})",
+          "instant": true,
+          "legendFormat": "App: {{service_version}}   ·   Node: {{process_runtime_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Versions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · which deployment this dashboard is showing — e.g. `production`, `staging`.\n\n**READ** · one word. Confirms you are looking at the environment you think you are.\n\n**INFER** · sanity check before acting. Never debug prod on a staging dashboard, or vice-versa.\n\nSource: `deployment_environment` label",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "displayName": "${__field.labels.deployment_environment}",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 6,
+        "y": 4
+      },
+      "id": 201,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "group by (deployment_environment) (nodejs_eventloop_utilization_ratio{job=~\"$service\"})",
+          "instant": true,
+          "legendFormat": "{{deployment_environment}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Environment",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · how many ToolJet pods (app copies) are currently running and reporting.\n\n**READ** · a steady number = stable. It follows the Pod filter at the top — pick one pod and this reads `1`.\n\n**INFER** · fewer than expected = pods crashed or were evicted. A number that keeps changing = pods restarting in a loop (check Restarts).\n\nSource: count of distinct `host_name`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "id": 202,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "count(count by (host_name) (nodejs_eventloop_utilization_ratio{job=~\"$service\",host_name=~\"$host\"}))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Instances",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · how many times the ToolJet process restarted inside the selected time range.\n\n**READ** · `0` is what you want. Any non-zero = the app died and came back.\n\n**INFER** · restarts mean crashes — usually an out-of-memory kill or an unhandled error. Pair with the Memory panel; if memory climbed to the limit just before a restart, it is an OOM. Repeated restarts = a crash loop.\n\nSource: resets of `nodejs_eventloop_time_seconds_total`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 307,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(resets(nodejs_eventloop_time_seconds_total{job=~\"$service\",host_name=~\"$host\"}[$__range])) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Restarts",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 8,
+      "panels": [],
+      "title": "📍 Endpoints",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · every route's RED numbers in one sortable table. RED = Rate (req/s), Errors (5xx %), Duration (latency). Range follows the time picker.\n\n**COLUMNS** · req/s · p50 / p95 / p99 latency (p95 = 95% of requests were faster) · 5xx % · samples (how many requests — how trustworthy the row is).\n\n**READ** · click any header to sort. High p95 = optimisation targets · high 5xx % = failing routes · high req/s = hot endpoints.\n\n**INFER** · high p95 + low samples = too few requests to trust the number, ignore it. High p95 + high samples = a real bottleneck. Click a route name to drill into its latency.\n\nSource: `http_server_duration_milliseconds_count` / `_bucket` by `http_route`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "right",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_route"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "left"
+              },
+              {
+                "id": "displayName",
+                "value": "Route"
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Drill into this route",
+                    "url": "/d/${__dashboard.uid}/${__dashboard.uid}?${__url_time_range}&var-service=${service:queryparam}&var-route=${__value.text}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #rate"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "req/s"
+              },
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #p50"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "p50"
+              },
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 200
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 10000,
+                      "result": {
+                        "index": 0,
+                        "text": "≥10s ⚠"
+                      },
+                      "to": 1000000000000
+                    },
+                    "type": "range"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #p95"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "p95"
+              },
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 500
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 10000,
+                      "result": {
+                        "index": 0,
+                        "text": "≥10s ⚠"
+                      },
+                      "to": 1000000000000
+                    },
+                    "type": "range"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #p99"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "p99"
+              },
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1000
+                    },
+                    {
+                      "color": "red",
+                      "value": 2000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 10000,
+                      "result": {
+                        "index": 0,
+                        "text": "≥10s ⚠"
+                      },
+                      "to": 1000000000000
+                    },
+                    "type": "range"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #err"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "5xx %"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 5
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #count"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "samples"
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #mean"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "mean"
+              },
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 500
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "p95"
+          }
+        ]
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (http_route) (rate(http_server_duration_milliseconds_count{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "rate"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, http_route) (rate(http_server_duration_milliseconds_bucket{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__range])))",
+          "format": "table",
+          "instant": true,
+          "refId": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, http_route) (rate(http_server_duration_milliseconds_bucket{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__range])))",
+          "format": "table",
+          "instant": true,
+          "refId": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, http_route) (rate(http_server_duration_milliseconds_bucket{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__range])))",
+          "format": "table",
+          "instant": true,
+          "refId": "p99"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "100 * sum by (http_route) (rate(http_server_duration_milliseconds_count{job=~\"$service\", http_status_code=~\"5..\",host_name=~\"$host\"}[$__range])) / clamp_min(sum by (http_route) (rate(http_server_duration_milliseconds_count{job=~\"$service\",host_name=~\"$host\"}[$__range])), 0.001)",
+          "format": "table",
+          "instant": true,
+          "refId": "err"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (http_route) (increase(http_server_duration_milliseconds_count{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "count"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (http_route) (rate(http_server_duration_milliseconds_sum{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__range])) / sum by (http_route) (rate(http_server_duration_milliseconds_count{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{http_route}}",
+          "refId": "mean"
+        }
+      ],
+      "title": "Route health",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "job": true
+            },
+            "indexByName": {
+              "Value #count": 7,
+              "Value #err": 5,
+              "Value #mean": 4,
+              "Value #p50": 1,
+              "Value #p95": 2,
+              "Value #p99": 3,
+              "Value #rate": 6,
+              "http_route": 0
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · service-wide latency over time at four cut-offs. `p50` = the typical request, `p99` = near-worst. A percentile is a ranked cut-off, not an average — one outlier cannot drag it.\n\n**LINES** · p50 green · p90 yellow dashed · p95 orange · p99 red dotted.\n\n**READ** · all four rising together = the whole service got slower. p99 rising while p50 stays flat = a slow tail, one rare slow path. A wide p50→p99 gap = inconsistent latency.\n\n**INFER** · this answers 'is the service getting slower?'. Route health tells you which endpoint; this tells you whether to worry at all.\n\nSource: `http_server_duration_milliseconds_bucket`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p50.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p90.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2CC0C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    6,
+                    3
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1.5
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p95.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p99.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2495C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    2,
+                    2
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1.5
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_duration_milliseconds_bucket{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(http_server_duration_milliseconds_bucket{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "p90",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_duration_milliseconds_bucket{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_duration_milliseconds_bucket{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Latency p50 / p90 / p95 / p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · the full spread of response times over time. Each column = a time slice; brightness = how many requests landed in that latency band (bucket). Scoped by the `Route` filter at the top — `All` = whole service.\n\n**READ** · one bright horizontal band = consistent latency. Two bright bands = two modes (e.g. fast cache hits + slow misses). A vertical bright streak = a brief spike.\n\n**INFER** · shows shapes the percentile lines hide. If you see two bands, the 'p95' line is sitting in the empty gap between them and is misleading. Pick one route in the `Route` filter (or click a row in Route health) to drill into a single endpoint.\n\nSource: `http_server_duration_milliseconds_bucket`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 10,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": true,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "decimals": 0,
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (le) (rate(http_server_duration_milliseconds_bucket{job=~\"$service\", http_route=~\"$route\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency distribution heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · requests per second split by response code, stacked.\n\n**BANDS** · 2xx green = ok · 3xx blue = redirect · 4xx yellow = caller's fault · 5xx red = server's fault.\n\n**READ** · red rising = server faults. Yellow rising = bad or unauthorised requests (login issues, or a scanner probing). Green dropping = traffic not arriving.\n\n**INFER** · when red rises, open Failing routes (right) to see which endpoint is throwing.\n\nSource: `http_server_duration_milliseconds_count` by `http_status_code`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "2.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "3.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "4.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "5.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (http_status_code) (rate(http_server_duration_milliseconds_count{job=~\"$service\", http_route!=\"/{*any}\", http_route!=\"\",host_name=~\"$host\"}[$__rate_interval]))",
+          "legendFormat": "{{http_status_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Status code rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · only the routes that returned `4xx` or `5xx` in the time range, sorted worst-5xx first.\n\n**COLUMNS** · 4xx = caller's-fault rejections · 5xx = server faults (red cell).\n\n**READ** · top of the table = the most-failing route. A red 5xx cell is the one to act on.\n\n**INFER** · fix 5xx first — that is the server breaking. 4xx on a known route = expired logins, stale clients, or someone scanning.\n\nSource: `http_server_duration_milliseconds_count` by `http_route`, `http_status_code`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "right",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_route"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "left"
+              },
+              {
+                "id": "displayName",
+                "value": "Route"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #c4"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "4xx"
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #c5"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "5xx"
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "5xx"
+          }
+        ]
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (http_route) (increase(http_server_duration_milliseconds_count{job=~\"$service\", http_status_code=~\"4..\",host_name=~\"$host\"}[$__range])) > 0",
+          "format": "table",
+          "instant": true,
+          "refId": "c4"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (http_route) (increase(http_server_duration_milliseconds_count{job=~\"$service\", http_status_code=~\"5..\",host_name=~\"$host\"}[$__range])) > 0",
+          "format": "table",
+          "instant": true,
+          "refId": "c5"
+        }
+      ],
+      "title": "Failing routes",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 99,
+      "panels": [],
+      "title": "🔎 Traces",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "${DS_TEMPO}"
+      },
+      "description": "**WHAT** · the slowest requests over 5 seconds. A trace = one request followed end-to-end; a span = one step inside it (a DB call, an HTTP call).\n\n**READ** · each row = one slow request. Click the ▸ to see its spans inline.\n\n**INFER** · click the Trace ID to open the full waterfall in Tempo — the request drawn as stacked timed bars, showing exactly which step ate the time.\n\nSource: Tempo · `duration > 5s`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Service"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Duration"
+          }
+        ]
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "${DS_TEMPO}"
+          },
+          "limit": 30,
+          "query": "{ resource.service.name=\"$service\" && duration>5s }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "Slow traces (>5s) · Tempo",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "${DS_TEMPO}"
+      },
+      "description": "**WHAT** · recent requests that failed (an error span anywhere inside). A trace = one request end-to-end; a span = one step inside it.\n\n**READ** · each row = one failed request, newest on top. Click the ▸ to see the failed spans inline.\n\n**INFER** · click the Trace ID for the full waterfall (the request as stacked timed bars) to see which step failed. Common: a DB call timing out, an outbound call returning 5xx, or an app exception.\n\nSource: Tempo · `status = error`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Service"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 15,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Start time"
+          }
+        ]
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "${DS_TEMPO}"
+          },
+          "limit": 50,
+          "query": "{ resource.service.name=\"$service\" && status=error }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "Recent error traces · Tempo",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "${DS_TEMPO}"
+      },
+      "description": "**WHAT** · requests that fired more than 25 database queries each. This is the classic N+1 problem (one request running many tiny queries in a loop instead of one).\n\n**READ** · each row = one N+1-suspect request, longest first. Click the ▸ to see the repeated DB spans.\n\n**INFER** · more round-trips = slower request, so duration ranks them. Open the Trace ID waterfall to see which query repeats — that is the loop to collapse into a single query.\n\nSource: Tempo · postgres spans, `count() > 25`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Service"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 300,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [],
+          "show": false
+        },
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Duration"
+          }
+        ]
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "${DS_TEMPO}"
+          },
+          "limit": 30,
+          "query": "{ resource.service.name=\"$service\" && span.db.system=\"postgresql\" } | count() > 25",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "DB spans > 25",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "${DS_TEMPO}"
+      },
+      "description": "**WHAT** · individual database query spans that took over 5 seconds. A span = one DB call inside a request. Each row = ONE slow span (not the whole request).\n\n**READ** · the Duration column is the SPAN duration (the actual slow query). Click ▸ — the SQL text is in the `db.statement` attribute. The trace ID jumps to the full waterfall.\n\n**INFER** · the 'show me the actual slow query' panel. One genuinely slow query is rarer than N+1 (many fast queries) — that shows in 'DB spans > 25'.\n\nSource: Tempo · postgres spans, `duration > 5s`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Service"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 30,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Duration"
+          }
+        ]
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "${DS_TEMPO}"
+          },
+          "limit": 30,
+          "query": "{ resource.service.name=\"$service\" && span.db.system=\"postgresql\" && duration>5s }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "spans"
+        }
+      ],
+      "title": "Slow DB queries (>5s) · Tempo",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "id": 25,
+      "panels": [],
+      "title": "🗃 Database",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · the database connection pool — a fixed set of reusable DB connections the app shares. `idle` = sitting free, `used` = currently in a query. `idle + used` = total pool size. `pending` (red) = requests waiting in line for a free connection.\n\n**READ** · two lines, not stacked. `used` (orange) climbing toward `idle + used` total = pool getting full. `pending > 0` for any stretch = pool exhausted — requests are queuing for a DB slot before they can even start work.\n\n**INFER** · constant `pending` = pool too small or queries holding connections too long. High DB op latency together with `pending` = slow queries are starving the pool (fix the queries). Normal latency + `pending` = genuinely need a bigger pool. `pending = 0` everywhere = healthy (the pool keeps up).\n\nSource: `db_client_connection_count` by `db_client_connection_state`, `db_client_connection_pending_requests`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pending"
+            },
+            "properties": [
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "idle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "used"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 60
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (db_client_connection_state) (db_client_connection_count{job=~\"$service\",host_name=~\"$host\"})",
+          "legendFormat": "{{db_client_connection_state}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_client_connection_pending_requests{job=~\"$service\",host_name=~\"$host\"})",
+          "legendFormat": "pending",
+          "refId": "B"
+        }
+      ],
+      "title": "DB pool · connections by state · pending requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · how long database queries take, at three cut-offs (p50 typical, p95, p99 near-worst). All query types combined.\n\n**READ** · the p99 line riding above p95 — the gap is the slow tail (one slow query type, or an occasional lock wait: a query stuck waiting for another to release a row).\n\n**INFER** · HTTP latency rising but DB latency flat → the bottleneck is in app code, not the DB. Both rising together → the DB is the bottleneck.\n\nSource: `db_client_operation_duration_seconds_bucket`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p50.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p90.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2CC0C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    6,
+                    3
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1.5
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p95.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p99.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2495C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    2,
+                    2
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1.5
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 60
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(db_client_operation_duration_seconds_bucket{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(db_client_operation_duration_seconds_bucket{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(db_client_operation_duration_seconds_bucket{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "DB op latency · p50 / p95 / p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · database queries per second, split by database (`db_namespace` — e.g. the main app DB vs the metadata DB).\n\n**READ** · compare this to Traffic (HTTP req/s). Queries-per-second ÷ requests-per-second ≈ DB calls per request.\n\n**INFER** · more than ~10 DB calls per request = N+1 territory (a request looping tiny queries). Per-database lines show which schema each workload pressures.\n\nSource: `db_client_operation_duration_seconds_count` by `db_namespace`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (db_namespace) (rate(db_client_operation_duration_seconds_count{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval]))",
+          "legendFormat": "{{db_namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "DB op rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · p95 latency (95% of queries faster than this) for each SQL operation type — SELECT, INSERT, UPDATE, COMMIT, and so on. Top 10.\n\n**READ** · one line per operation. A rising SELECT line = slow reads. Rising UPDATE or COMMIT = slow writes or lock contention (queries waiting on each other).\n\n**INFER** · this groups by operation kind, not by the exact SQL. For a specific slow query, use 'Slow DB queries' — that pulls the real SQL text from traces.\n\nSource: `db_client_operation_duration_seconds_bucket` by `db_operation_name`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 69
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, db_operation_name) (rate(db_client_operation_duration_seconds_bucket{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval]))))",
+          "legendFormat": "{{db_operation_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "DB latency by operation",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 78
+      },
+      "id": 314,
+      "panels": [],
+      "title": "⚙ Node.js",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · how busy Node's event loop is over time, per pod. The event loop is Node's single work queue — while it is busy, nothing else runs. `0` = idle, `1` = no spare capacity. One line per pod.\n\n**READ** · above 0.7 sustained = saturation (requests will queue). Spikes line up with blocking work — large JSON parsing, synchronous file or crypto calls. Counter-rate source integrates active time over each window, so short bursts show up clearly (the gauge version misses them between samples).\n\n**INFER** · the clearest 'Node is overloaded' signal — better than CPU%. One pod spiking while another stays flat = load-balancer imbalance.\n\nSource: `nodejs_eventloop_time_seconds_total`, label `nodejs_eventloop_state = active`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 0.05,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 79
+      },
+      "id": 318,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (host_name) (rate(nodejs_eventloop_time_seconds_total{nodejs_eventloop_state=\"active\",job=~\"$service\",host_name=~\"$host\"}[$__rate_interval]))",
+          "legendFormat": "{{host_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Event-loop utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · CPU used by the ToolJet process only, measured in cores (`1.0` = one full CPU core fully used).\n\n**STATES** · `user` = running JavaScript / app code · `system` = the kernel doing work for the app (network, disk, system calls).\n\n**READ** · this is the app alone — compare it with Host CPU (the whole machine). Sustained high `system` = lots of I/O or system calls.\n\n**INFER** · app CPU and event-loop utilization rising together = the app itself is compute-bound. App CPU low but Host CPU high = a neighbour process (Postgres, a sidecar) is eating the machine.\n\nSource: `process_cpu_time_seconds_total` by `process_cpu_state`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 3,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "user"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "system"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 79
+      },
+      "id": 319,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (process_cpu_state) (rate(process_cpu_time_seconds_total{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval]))",
+          "legendFormat": "{{process_cpu_state}}",
+          "refId": "A"
+        }
+      ],
+      "title": "App CPU · cores by state",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · the app's memory over time. `RSS` = total memory the process holds in RAM (JavaScript objects + buffers + native). `V8 heap used` = memory for JavaScript objects. `V8 heap limit` = the configured ceiling for that heap.\n\n**READ** · the gap between RSS and heap-used = native and buffer memory.\n\n**INFER** · V8 heap used climbing toward the limit and never dropping = a JavaScript memory leak → expect a crash / restart. RSS growing while heap stays flat = a native or buffer leak (rarer).\n\nSource: `process_memory_usage`, `v8js_memory_heap_used_bytes`, `v8js_memory_heap_limit_bytes`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 88
+      },
+      "id": 320,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max by (host_name) (process_memory_usage{job=~\"$service\",host_name=~\"$host\"})",
+          "legendFormat": "RSS · {{host_name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max by (host_name) (v8js_memory_heap_used_bytes{job=~\"$service\",host_name=~\"$host\"})",
+          "legendFormat": "V8 heap used · {{host_name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max by (host_name) (v8js_memory_heap_limit_bytes{job=~\"$service\",host_name=~\"$host\"})",
+          "legendFormat": "V8 heap limit · {{host_name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Memory · RSS · V8 heap used · V8 heap limit",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · the JavaScript heap broken into V8's internal regions. `new_space` = freshly created short-lived objects · `old_space` = objects that survived long enough to be promoted · `code_space` = compiled (JIT) code.\n\n**READ** · `new_space` is small and churns fast · `old_space` is the bulk and should rise then fall as GC reclaims it.\n\n**INFER** · `old_space` climbing steadily and never falling back = a leak: objects kept alive by mistake. Big `new_space` spikes = a hot path allocating heavily.\n\nSource: `v8js_memory_heap_used_bytes` by `v8js_heap_space_name`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 88
+      },
+      "id": 321,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (v8js_heap_space_name) (v8js_memory_heap_used_bytes{job=~\"$service\",host_name=~\"$host\"})",
+          "legendFormat": "{{v8js_heap_space_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "V8 heap by space · used bytes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · how long the app froze for garbage collection (GC = Node automatically freeing unused memory; the app pauses while it runs). Shown by GC type.\n\n**KINDS** · `scavenge` (minor) — fast cleanup of short-lived objects, usually under 1ms · `mark-sweep-compact` (major) — slow full-heap sweep, can be tens of ms · `incremental` — a major GC chopped into small slices so it never freezes the app for long in one go · `weak` — clears weak references, tiny.\n\n**READ** · p99 = the worst 1% of pauses. Major-GC p99 over 50ms = users feel a stutter.\n\n**INFER** · major GC pauses growing = the heap is under pressure → raise the heap limit or allocate less. Lots of incremental GC = V8 working hard to avoid one big freeze — still a pressure signal.\n\n**CAVEAT** · this histogram caps at 100 ms (default OTel bucket boundaries). Pauses longer than 100 ms get reported AS 100 ms — so a `p99 ≈ 100 ms` line probably hides bigger real pauses. Code-side fix is to extend the histogram buckets via an OTel `View` at MeterProvider setup; same fix the HTTP latency histogram needs.\n\nSource: `v8js_gc_duration_seconds_bucket` by `v8js_gc_type`",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p50.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p90.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2CC0C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    6,
+                    3
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1.5
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p95.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^p99.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2495C",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    2,
+                    2
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1.5
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 97
+      },
+      "id": 322,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, v8js_gc_type) (rate(v8js_gc_duration_seconds_bucket{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{v8js_gc_type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, v8js_gc_type) (rate(v8js_gc_duration_seconds_bucket{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{v8js_gc_type}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, v8js_gc_type) (rate(v8js_gc_duration_seconds_bucket{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{v8js_gc_type}}",
+          "refId": "C"
+        }
+      ],
+      "title": "GC pause duration · p50 / p95 / p99 by kind",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 106
+      },
+      "id": 309,
+      "panels": [],
+      "title": "🖥 Host",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · CPU use of the whole machine (every process), averaged across all cores, by category. `idle` is removed so the stack height = real usage.\n\n**STATES** · `user` = application code · `system` = kernel work · `iowait` = cores stalled waiting for disk · `nice` / `softirq` / `steal` = small contributors (`steal` = CPU taken by the cloud host).\n\n**READ** · y-axis fixed 0–100%; the empty gap above the stack is spare capacity. High `user` = compute-bound · high `system` = system-call heavy · high `iowait` = disk-bound.\n\n**INFER** · separates 'the app is busy' from 'the machine is busy on kernel / disk work'. Pair with event-loop utilization — high CPU + high loop = the app itself.\n\nSource: `system_cpu_utilization` by `system_cpu_state`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 15,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 107
+      },
+      "id": 310,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "avg by (system_cpu_state) (system_cpu_utilization{job=~\"$service\",host_name=~\"$host\",system_cpu_state!=\"idle\"})",
+          "legendFormat": "{{system_cpu_state}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Host CPU in use · by state",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · physical RAM of the Kubernetes node (the whole VM) — NOT the pod. `used` (orange fill) vs `total RAM` (grey dashed ceiling).\n\n**WHY ~31 GiB, not 16** · metrics read from inside a container still report the underlying node, not the pod's own cap. This node (~31 GiB) runs ~2 ToolJet pods, each capped at 16 GiB. The per-pod cap is not scraped here.\n\n**READ** · orange fill = every process on the node · the gap up to the dashed line = node headroom · averaged across pods (both observe the same node).\n\n**INFER** · this is node-level pressure. For the ToolJet process's own memory use the Node.js 'Memory' panel.\n\nSource: `system_memory_usage` by `system_memory_state`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 0,
+            "lineWidth": 2
+          },
+          "min": 0,
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "used"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 25
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total RAM"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    6,
+                    4
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 107
+      },
+      "id": 311,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "avg(system_memory_usage{job=~\"$service\",host_name=~\"$host\",system_memory_state=\"used\"})",
+          "legendFormat": "used",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "avg(system_memory_usage{job=~\"$service\",host_name=~\"$host\",system_memory_state=\"used\"}) + avg(system_memory_usage{job=~\"$service\",host_name=~\"$host\",system_memory_state=\"free\"})",
+          "legendFormat": "total RAM",
+          "refId": "B"
+        }
+      ],
+      "title": "Node memory · used vs total",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · network traffic of the machine, split by direction — received vs transmitted bytes per second, across all interfaces.\n\n**READ** · spikes line up with traffic surges, file uploads, or noisy clients. A rate sitting near the network card's line speed = the link is saturated.\n\n**INFER** · read it next to HTTP req/s. Network climbing without matching HTTP load = something else on the wire — log shipping, DB replication, backups.\n\nSource: `system_network_io_total` by `network_io_direction`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 15
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 116
+      },
+      "id": 312,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (network_io_direction) (rate(system_network_io_total{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval]))",
+          "legendFormat": "{{network_io_direction}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Host network IO · rx/tx bytes/sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · bad network packets per second. `dropped` = packets the kernel threw away (buffers full, backpressure). `errors` = hardware-level faults (bad frames, faulty cable or driver).\n\n**READ** · any sustained non-zero rate is abnormal — a healthy machine sits flat at zero.\n\n**INFER** · drop spikes lining up with HTTP 5xx = client connections cut before the app could reply. Errors without drops = a hardware or driver fault, not load.\n\nSource: `system_network_dropped_total`, `system_network_errors_total`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "pps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 116
+      },
+      "id": 313,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(system_network_dropped_total{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval]))",
+          "legendFormat": "dropped",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(system_network_errors_total{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval]))",
+          "legendFormat": "errors",
+          "refId": "B"
+        }
+      ],
+      "title": "Host network errors · drops + errors/sec",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 125
+      },
+      "id": 31,
+      "panels": [],
+      "title": "🌐 Outbound HTTP",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · p95 latency (95% of calls faster than this) of HTTP calls ToolJet makes OUT to other services — Git providers, login providers, the plugin marketplace, S3. Top 8.\n\n**READ** · one line per upstream host. A spike = that dependency slowed down.\n\n**INFER** · if user-facing latency rose and one outbound host's p95 rose at the same time, that host is dragging requests. Common: GitHub rate limits, a slow login provider, a marketplace timeout.\n\nSource: `http_client_duration_milliseconds_bucket` by `net_peer_name`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 126
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(8, histogram_quantile(0.95, sum by (le, net_peer_name) (rate(http_client_duration_milliseconds_bucket{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval]))))",
+          "legendFormat": "{{net_peer_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbound HTTP p95 by host",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · outbound calls per second, split by destination host and response code.\n\n**READ** · a rate spike to one host = a retry storm or a new feature. Mixed 4xx / 5xx = that upstream is returning errors.\n\n**INFER** · pair with the p95 panel. High rate + high p95 = you are overloading that upstream. High rate + low p95 = it is coping. High p95 + flat rate = it slowed down on its own.\n\nSource: `http_client_duration_milliseconds_count` by `net_peer_name`, `http_status_code`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 126
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(http_client_duration_milliseconds_count{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval])) by (net_peer_name, http_status_code)",
+          "legendFormat": "{{net_peer_name}} {{http_status_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbound HTTP rate by host & status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "**WHAT** · outbound calls per second by response code, stacked. These are calls ToolJet makes OUT to other services.\n\n**BANDS** · 2xx green = ok · 3xx blue = redirect · 4xx yellow = upstream rejected us (bad auth, rate limit) · 5xx red = upstream is faulting.\n\n**READ** · yellow rising = a dependency is rejecting us (expired token, quota hit). Red rising = an upstream is down or degraded.\n\n**INFER** · pair with 'Outbound HTTP p95 by host' — errors and latency on the same host together = that upstream is the problem.\n\nSource: `http_client_duration_milliseconds_count` by `http_status_code`",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "2.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "3.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "4.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "5.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 135
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (http_status_code) (rate(http_client_duration_milliseconds_count{job=~\"$service\",host_name=~\"$host\"}[$__rate_interval]))",
+          "legendFormat": "{{http_status_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbound HTTP status code rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": [
+    "tooljet",
+    "nestjs",
+    "postgres",
+    "host"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(http_server_duration_milliseconds_count, job)",
+        "includeAll": false,
+        "label": "Service",
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_duration_milliseconds_count, job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(nodejs_eventloop_utilization_ratio{job=~\"$service\"}, host_name)",
+        "description": "Filter panels by pod (host_name). Select All for fleet view.",
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "host",
+        "options": [],
+        "query": {
+          "query": "label_values(nodejs_eventloop_utilization_ratio{job=~\"$service\"}, host_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(http_server_duration_milliseconds_count{job=~\"$service\", http_route!=\"/{*any}\"}, http_route)",
+        "description": "Filters Row 3 panels only · the latency percentile chart and the distribution heatmap, which need a single route to be readable.",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Route (latency drill)",
+        "multi": true,
+        "name": "route",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_duration_milliseconds_count{job=~\"$service\", http_route!=\"/{*any}\"}, http_route)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "hide": 2,
+        "label": "SLO p95 (ms)",
+        "name": "slo_p95_ms",
+        "query": "${VAR_SLO_P95_MS}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_SLO_P95_MS}",
+          "text": "${VAR_SLO_P95_MS}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_SLO_P95_MS}",
+            "text": "${VAR_SLO_P95_MS}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(target_info{job=~\"$service\",service_version!~\"unknown\"}, service_version)",
+        "hide": 2,
+        "includeAll": true,
+        "label": "tj_version",
+        "multi": true,
+        "name": "tj_version",
+        "options": [],
+        "query": {
+          "query": "label_values(target_info{job=~\"$service\",service_version!~\"unknown\"}, service_version)",
+          "refId": "tj_version-q"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(target_info{job=~\"$service\",deployment_environment!~\"local\"}, deployment_environment)",
+        "hide": 2,
+        "includeAll": true,
+        "label": "tj_environment",
+        "multi": true,
+        "name": "tj_environment",
+        "options": [],
+        "query": {
+          "query": "label_values(target_info{job=~\"$service\",deployment_environment!~\"local\"}, deployment_environment)",
+          "refId": "tj_environment-q"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "Asia/Calcutta",
+  "title": "Tooljet Monitoring",
+  "uid": "tooljet-monitoring",
+  "version": 46,
+  "weekStart": ""
+}

--- a/frontend/src/data/templates/tooljet/stack.yaml
+++ b/frontend/src/data/templates/tooljet/stack.yaml
@@ -1,7 +1,8 @@
 # ToolJet with workflows (worker + redis), ToolJet DB (postgrest), and built-in
 # observability (grafana/otel-lgtm: Grafana + Tempo + Prometheus + OTel collector).
 # 1. Replace every REPLACE_*_VALUE_HERE secret before deploying.
-# 2. Grafana ships on port 3000 (default admin/admin — change it after first login).
+# 2. Grafana ships on port 3000; sign in as admin with the password you set in
+#    GF_SECURITY_ADMIN_PASSWORD.
 # 3. Import the bundled dashboard: dashboards/tooljet-monitoring.json
 #    (Grafana → Dashboards → Import; map DS_PROMETHEUS and DS_TEMPO, and accept
 #    the SLO threshold constant VAR_SLO_P95_MS when asked — default 500).
@@ -89,6 +90,8 @@ services:
     command: redis-server --maxmemory-policy noeviction
 
   postgresql:
+    # Pinned to match upstream ToolJet's own compose; newer majors are untested
+    # against this ToolJet release.
     image: postgres:13
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -103,6 +106,10 @@ services:
       - postgresql
     environment:
       PGRST_SERVER_PORT: "80"
+      # Kept fully literal on purpose: a ${postgresql.host} reference would turn
+      # this into a read-only template row, hiding the password placeholder from
+      # the editor. The literal host works because a resource's service is named
+      # after it.
       PGRST_DB_URI: "postgres://postgres:REPLACE_POSTGRES_PASSWORD_VALUE_HERE@postgresql:5432/tooljet_db"
       PGRST_JWT_SECRET: "REPLACE_PGRST_JWT_SECRET_VALUE_HERE"
       PGRST_DB_PRE_CONFIG: "postgrest.pre_config"
@@ -117,6 +124,7 @@ services:
       - "4318"
     environment:
       PROMETHEUS_EXTRA_ARGS: "--enable-feature=otlp-deltatocumulative"
+      GF_SECURITY_ADMIN_PASSWORD: "REPLACE_GRAFANA_ADMIN_PASSWORD_VALUE_HERE"
     volumes:
       # /data holds every backend's state (grafana, prometheus, tempo, loki),
       # so dashboards AND telemetry history survive restarts.

--- a/frontend/src/data/templates/tooljet/stack.yaml
+++ b/frontend/src/data/templates/tooljet/stack.yaml
@@ -47,8 +47,8 @@ services:
       REDIS_PORT: "6379"
       ENABLE_OTEL: "true"
       OTEL_SERVICE_NAME: "tooljet"
-      OTEL_EXPORTER_OTLP_TRACES: "http://otel-stack:4318/v1/traces"
-      OTEL_EXPORTER_OTLP_METRICS: "http://otel-stack:4318/v1/metrics"
+      OTEL_EXPORTER_OTLP_TRACES: "http://${otel-stack.host}:4318/v1/traces"
+      OTEL_EXPORTER_OTLP_METRICS: "http://${otel-stack.host}:4318/v1/metrics"
       OTEL_METRICS_TEMPORALITY: "cumulative"
 
   tooljet-worker:
@@ -80,8 +80,8 @@ services:
       REDIS_PORT: "6379"
       ENABLE_OTEL: "true"
       OTEL_SERVICE_NAME: "tooljet-worker"
-      OTEL_EXPORTER_OTLP_TRACES: "http://otel-stack:4318/v1/traces"
-      OTEL_EXPORTER_OTLP_METRICS: "http://otel-stack:4318/v1/metrics"
+      OTEL_EXPORTER_OTLP_TRACES: "http://${otel-stack.host}:4318/v1/traces"
+      OTEL_EXPORTER_OTLP_METRICS: "http://${otel-stack.host}:4318/v1/metrics"
       OTEL_METRICS_TEMPORALITY: "cumulative"
 
   redis:

--- a/frontend/src/data/templates/tooljet/stack.yaml
+++ b/frontend/src/data/templates/tooljet/stack.yaml
@@ -6,13 +6,17 @@
 #    (Grafana → Dashboards → Import; map DS_PROMETHEUS and DS_TEMPO, and accept
 #    the SLO threshold constant VAR_SLO_P95_MS when asked — default 500).
 # 4. Services may restart until postgres finishes initializing; that settles itself.
-# 5. Set TOOLJET_HOST (on both tooljet and tooljet-worker) to your deployed URL.
+# 5. ${self.<output>} / ${<service>.<output>} env values resolve at deploy time
+#    (TOOLJET_HOST picks up the public URL automatically — no manual edit needed).
 name: tooljet
 
 services:
   tooljet:
     image: tooljet/tooljet:v3.20.189-lts
-    command: npm run start:prod
+    # The entrypoint script must be invoked explicitly: it waits for postgres,
+    # creates the app + ToolJet DB databases, and runs migrations before
+    # exec-ing the server. Stack commands replace the image entrypoint.
+    command: ./server/ee-entrypoint.sh npm run start:prod
     ports:
       - "80:80"
     depends_on:
@@ -22,24 +26,24 @@ services:
     environment:
       SERVE_CLIENT: "true"
       PORT: "80"
-      TOOLJET_HOST: "http://localhost:80"
+      TOOLJET_HOST: "${self.public_url}"
       NODE_ENV: "production"
       DISABLE_TOOLJET_TELEMETRY: "true"
       LOCKBOX_MASTER_KEY: "REPLACE_LOCKBOX_MASTER_KEY_VALUE_HERE"
       SECRET_KEY_BASE: "REPLACE_SECRET_KEY_BASE_VALUE_HERE"
-      PG_HOST: "postgresql"
+      PG_HOST: "${postgresql.host}"
       PG_PORT: "5432"
       PG_DB: "tooljet_production"
       PG_USER: "postgres"
       PG_PASS: "REPLACE_POSTGRES_PASSWORD_VALUE_HERE"
       ENABLE_TOOLJET_DB: "true"
       TOOLJET_DB: "tooljet_db"
-      TOOLJET_DB_HOST: "postgresql"
+      TOOLJET_DB_HOST: "${postgresql.host}"
       TOOLJET_DB_USER: "postgres"
       TOOLJET_DB_PASS: "REPLACE_POSTGRES_PASSWORD_VALUE_HERE"
-      PGRST_HOST: "postgrest"
+      PGRST_HOST: "${postgrest.host}"
       PGRST_JWT_SECRET: "REPLACE_PGRST_JWT_SECRET_VALUE_HERE"
-      REDIS_HOST: "redis"
+      REDIS_HOST: "${redis.host}"
       REDIS_PORT: "6379"
       ENABLE_OTEL: "true"
       OTEL_SERVICE_NAME: "tooljet"
@@ -49,30 +53,30 @@ services:
 
   tooljet-worker:
     image: tooljet/tooljet:v3.20.189-lts
-    command: npm run start:prod
+    command: ./server/ee-entrypoint.sh npm run start:prod
     depends_on:
       - postgresql
       - redis
     environment:
       WORKER: "true"
-      TOOLJET_HOST: "http://localhost:80"
+      TOOLJET_HOST: "${tooljet.public_url}"
       NODE_ENV: "production"
       DISABLE_TOOLJET_TELEMETRY: "true"
       LOCKBOX_MASTER_KEY: "REPLACE_LOCKBOX_MASTER_KEY_VALUE_HERE"
       SECRET_KEY_BASE: "REPLACE_SECRET_KEY_BASE_VALUE_HERE"
-      PG_HOST: "postgresql"
+      PG_HOST: "${postgresql.host}"
       PG_PORT: "5432"
       PG_DB: "tooljet_production"
       PG_USER: "postgres"
       PG_PASS: "REPLACE_POSTGRES_PASSWORD_VALUE_HERE"
       ENABLE_TOOLJET_DB: "true"
       TOOLJET_DB: "tooljet_db"
-      TOOLJET_DB_HOST: "postgresql"
+      TOOLJET_DB_HOST: "${postgresql.host}"
       TOOLJET_DB_USER: "postgres"
       TOOLJET_DB_PASS: "REPLACE_POSTGRES_PASSWORD_VALUE_HERE"
-      PGRST_HOST: "postgrest"
+      PGRST_HOST: "${postgrest.host}"
       PGRST_JWT_SECRET: "REPLACE_PGRST_JWT_SECRET_VALUE_HERE"
-      REDIS_HOST: "redis"
+      REDIS_HOST: "${redis.host}"
       REDIS_PORT: "6379"
       ENABLE_OTEL: "true"
       OTEL_SERVICE_NAME: "tooljet-worker"
@@ -105,8 +109,12 @@ services:
 
   lgtm:
     image: grafana/otel-lgtm:0.29.1
+    # 4318 must be listed: services only route declared ports, and the app
+    # containers push OTLP metrics/traces to lgtm:4318 (internal only).
     ports:
       - "3000:3000"
+    expose:
+      - "4318"
     environment:
       PROMETHEUS_EXTRA_ARGS: "--enable-feature=otlp-deltatocumulative"
     volumes:

--- a/frontend/src/data/templates/tooljet/stack.yaml
+++ b/frontend/src/data/templates/tooljet/stack.yaml
@@ -6,6 +6,7 @@
 #    (Grafana → Dashboards → Import; map DS_PROMETHEUS and DS_TEMPO, and accept
 #    the SLO threshold constant VAR_SLO_P95_MS when asked — default 500).
 # 4. Services may restart until postgres finishes initializing; that settles itself.
+# 5. Set TOOLJET_HOST (on both tooljet and tooljet-worker) to your deployed URL.
 name: tooljet
 
 services:

--- a/frontend/src/data/templates/tooljet/stack.yaml
+++ b/frontend/src/data/templates/tooljet/stack.yaml
@@ -107,7 +107,6 @@ services:
     ports:
       - "3000:3000"
     environment:
-      ENABLE_LOGS_PROMETHEUS: "true"
       PROMETHEUS_EXTRA_ARGS: "--enable-feature=otlp-deltatocumulative"
     volumes:
       - grafana-data:/data/grafana

--- a/frontend/src/data/templates/tooljet/stack.yaml
+++ b/frontend/src/data/templates/tooljet/stack.yaml
@@ -47,8 +47,8 @@ services:
       REDIS_PORT: "6379"
       ENABLE_OTEL: "true"
       OTEL_SERVICE_NAME: "tooljet"
-      OTEL_EXPORTER_OTLP_TRACES: "http://lgtm:4318/v1/traces"
-      OTEL_EXPORTER_OTLP_METRICS: "http://lgtm:4318/v1/metrics"
+      OTEL_EXPORTER_OTLP_TRACES: "http://otel-stack:4318/v1/traces"
+      OTEL_EXPORTER_OTLP_METRICS: "http://otel-stack:4318/v1/metrics"
       OTEL_METRICS_TEMPORALITY: "cumulative"
 
   tooljet-worker:
@@ -80,8 +80,8 @@ services:
       REDIS_PORT: "6379"
       ENABLE_OTEL: "true"
       OTEL_SERVICE_NAME: "tooljet-worker"
-      OTEL_EXPORTER_OTLP_TRACES: "http://lgtm:4318/v1/traces"
-      OTEL_EXPORTER_OTLP_METRICS: "http://lgtm:4318/v1/metrics"
+      OTEL_EXPORTER_OTLP_TRACES: "http://otel-stack:4318/v1/traces"
+      OTEL_EXPORTER_OTLP_METRICS: "http://otel-stack:4318/v1/metrics"
       OTEL_METRICS_TEMPORALITY: "cumulative"
 
   redis:
@@ -107,10 +107,10 @@ services:
       PGRST_JWT_SECRET: "REPLACE_PGRST_JWT_SECRET_VALUE_HERE"
       PGRST_DB_PRE_CONFIG: "postgrest.pre_config"
 
-  lgtm:
+  otel-stack:
     image: grafana/otel-lgtm:0.29.1
     # 4318 must be listed: services only route declared ports, and the app
-    # containers push OTLP metrics/traces to lgtm:4318 (internal only).
+    # containers push OTLP metrics/traces to otel-stack:4318 (internal only).
     ports:
       - "3000:3000"
     expose:
@@ -118,8 +118,10 @@ services:
     environment:
       PROMETHEUS_EXTRA_ARGS: "--enable-feature=otlp-deltatocumulative"
     volumes:
-      - grafana-data:/data/grafana
+      # /data holds every backend's state (grafana, prometheus, tempo, loki),
+      # so dashboards AND telemetry history survive restarts.
+      - otel-stack-data:/data
 
 volumes:
   postgres-data:
-  grafana-data:
+  otel-stack-data:

--- a/frontend/src/data/templates/tooljet/stack.yaml
+++ b/frontend/src/data/templates/tooljet/stack.yaml
@@ -1,17 +1,29 @@
-# ToolJet + PostgreSQL. Replace every REPLACE_*_VALUE_HERE secret.
+# ToolJet with workflows (worker + redis), ToolJet DB (postgrest), and built-in
+# observability (grafana/otel-lgtm: Grafana + Tempo + Prometheus + OTel collector).
+# 1. Replace every REPLACE_*_VALUE_HERE secret before deploying.
+# 2. Grafana ships on port 3000 (default admin/admin — change it after first login).
+# 3. Import the bundled dashboard: dashboards/tooljet-monitoring.json
+#    (Grafana → Dashboards → Import; map DS_PROMETHEUS and DS_TEMPO, and accept
+#    the SLO threshold constant VAR_SLO_P95_MS when asked — default 500).
+# 4. Services may restart until postgres finishes initializing; that settles itself.
 name: tooljet
+
 services:
   tooljet:
-    image: tooljet/tooljet:ee-lts-latest
+    image: tooljet/tooljet:v3.20.189-lts
     command: npm run start:prod
     ports:
       - "80:80"
     depends_on:
       - postgresql
+      - redis
+      - postgrest
     environment:
       SERVE_CLIENT: "true"
       PORT: "80"
       TOOLJET_HOST: "http://localhost:80"
+      NODE_ENV: "production"
+      DISABLE_TOOLJET_TELEMETRY: "true"
       LOCKBOX_MASTER_KEY: "REPLACE_LOCKBOX_MASTER_KEY_VALUE_HERE"
       SECRET_KEY_BASE: "REPLACE_SECRET_KEY_BASE_VALUE_HERE"
       PG_HOST: "postgresql"
@@ -19,9 +31,60 @@ services:
       PG_DB: "tooljet_production"
       PG_USER: "postgres"
       PG_PASS: "REPLACE_POSTGRES_PASSWORD_VALUE_HERE"
+      ENABLE_TOOLJET_DB: "true"
+      TOOLJET_DB: "tooljet_db"
+      TOOLJET_DB_HOST: "postgresql"
+      TOOLJET_DB_USER: "postgres"
+      TOOLJET_DB_PASS: "REPLACE_POSTGRES_PASSWORD_VALUE_HERE"
+      PGRST_HOST: "postgrest"
+      PGRST_JWT_SECRET: "REPLACE_PGRST_JWT_SECRET_VALUE_HERE"
+      REDIS_HOST: "redis"
+      REDIS_PORT: "6379"
+      ENABLE_OTEL: "true"
+      OTEL_SERVICE_NAME: "tooljet"
+      OTEL_EXPORTER_OTLP_TRACES: "http://lgtm:4318/v1/traces"
+      OTEL_EXPORTER_OTLP_METRICS: "http://lgtm:4318/v1/metrics"
+      OTEL_METRICS_TEMPORALITY: "cumulative"
+
+  tooljet-worker:
+    image: tooljet/tooljet:v3.20.189-lts
+    command: npm run start:prod
+    depends_on:
+      - postgresql
+      - redis
+    environment:
+      WORKER: "true"
+      TOOLJET_HOST: "http://localhost:80"
+      NODE_ENV: "production"
+      DISABLE_TOOLJET_TELEMETRY: "true"
+      LOCKBOX_MASTER_KEY: "REPLACE_LOCKBOX_MASTER_KEY_VALUE_HERE"
+      SECRET_KEY_BASE: "REPLACE_SECRET_KEY_BASE_VALUE_HERE"
+      PG_HOST: "postgresql"
+      PG_PORT: "5432"
+      PG_DB: "tooljet_production"
+      PG_USER: "postgres"
+      PG_PASS: "REPLACE_POSTGRES_PASSWORD_VALUE_HERE"
+      ENABLE_TOOLJET_DB: "true"
+      TOOLJET_DB: "tooljet_db"
+      TOOLJET_DB_HOST: "postgresql"
+      TOOLJET_DB_USER: "postgres"
+      TOOLJET_DB_PASS: "REPLACE_POSTGRES_PASSWORD_VALUE_HERE"
+      PGRST_HOST: "postgrest"
+      PGRST_JWT_SECRET: "REPLACE_PGRST_JWT_SECRET_VALUE_HERE"
+      REDIS_HOST: "redis"
+      REDIS_PORT: "6379"
+      ENABLE_OTEL: "true"
+      OTEL_SERVICE_NAME: "tooljet-worker"
+      OTEL_EXPORTER_OTLP_TRACES: "http://lgtm:4318/v1/traces"
+      OTEL_EXPORTER_OTLP_METRICS: "http://lgtm:4318/v1/metrics"
+      OTEL_METRICS_TEMPORALITY: "cumulative"
+
+  redis:
+    image: redis:7
+    command: redis-server --maxmemory-policy noeviction
 
   postgresql:
-    image: postgres:16
+    image: postgres:13
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
@@ -29,5 +92,26 @@ services:
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "REPLACE_POSTGRES_PASSWORD_VALUE_HERE"
 
+  postgrest:
+    image: postgrest/postgrest:v12.2.0
+    depends_on:
+      - postgresql
+    environment:
+      PGRST_SERVER_PORT: "80"
+      PGRST_DB_URI: "postgres://postgres:REPLACE_POSTGRES_PASSWORD_VALUE_HERE@postgresql:5432/tooljet_db"
+      PGRST_JWT_SECRET: "REPLACE_PGRST_JWT_SECRET_VALUE_HERE"
+      PGRST_DB_PRE_CONFIG: "postgrest.pre_config"
+
+  lgtm:
+    image: grafana/otel-lgtm:0.29.1
+    ports:
+      - "3000:3000"
+    environment:
+      ENABLE_LOGS_PROMETHEUS: "true"
+      PROMETHEUS_EXTRA_ARGS: "--enable-feature=otlp-deltatocumulative"
+    volumes:
+      - grafana-data:/data/grafana
+
 volumes:
   postgres-data:
+  grafana-data:

--- a/frontend/src/data/templates/tooljet/template.ts
+++ b/frontend/src/data/templates/tooljet/template.ts
@@ -11,9 +11,9 @@ export const tooljet: Template = {
   shortDescription:
     "Low-code platform for building internal tools and dashboards.",
   longDescription:
-    "Build enterprise apps, AI agents, and workflows in minutes, not months. Just describe what you need in natural language.",
+    "Build enterprise apps, AI agents, and workflows in minutes, not months. Ships with workflow workers, the built-in ToolJet Database, and an observability stack (Grafana, Tempo, Prometheus) with a ready-made monitoring dashboard.",
   website: "https://tooljet.com/",
   docs: "https://docs.tooljet.com/",
-  version: "ee-lts-latest",
+  version: "v3.20.189-lts",
   stackYaml,
 };

--- a/frontend/src/lib/docker-compose-converter.ts
+++ b/frontend/src/lib/docker-compose-converter.ts
@@ -574,16 +574,28 @@ function convertVolumeMounts(
 }
 
 /**
- * A whole-value env reference: "${self.public_url}" or "${<service>.<output>}".
+ * An env reference: "${self.public_url}" or "${<service>.<output>}".
  * Output keys follow pkg/models/output_descriptor.go (host, port, url,
  * public_host, public_url, optionally suffixed ".<port-name>").
  */
 const ENV_REFERENCE_PATTERN = /^\$\{([a-z0-9][a-z0-9_-]*)\.([a-z0-9][a-z0-9_.-]*)\}$/;
+const ENV_REFERENCE_GLOBAL = /\$\{([a-z0-9][a-z0-9_-]*)\.([a-z0-9][a-z0-9_.-]*)\}/g;
+
+/** Template keys must be valid Go identifiers (see stackdeploy.ValidateTemplateKeys). */
+function templateKeyForOutput(output: string, taken: Record<string, string>): string {
+  let key = output.replace(/[^a-zA-Z0-9_]/g, "_");
+  if (/^[0-9]/.test(key)) key = `_${key}`;
+  while (key in taken && taken[key] !== output) key = `${key}_`;
+  return key;
+}
 
 /**
- * Classify one env value: reference values become self/resource rows resolved
- * at deploy; everything else stays a literal row. References to unknown
- * services are kept literal with a warning rather than dropped.
+ * Classify one env value: reference values become rows resolved at deploy —
+ * a whole-value reference becomes a self/resource row, and a value embedding
+ * references to a single sibling service becomes a template row (Go template
+ * mapping on the env connection). Everything else stays a literal row.
+ * Unsupported references (unknown service, mixed services, embedded self)
+ * are kept literal with a warning rather than dropped.
  */
 function toEnvRow(
   name: string,
@@ -592,24 +604,50 @@ function toEnvRow(
   allServiceNames: string[],
   warnings: ConversionWarning[]
 ): FormEnvVarData {
-  const match = ENV_REFERENCE_PATTERN.exec(value);
-  if (!match) return { from: "stack", name, value };
+  const keepLiteral = (reason: string): FormEnvVarData => {
+    warnings.push({
+      type: 'partial',
+      message: `Environment variable '${name}' ${reason}. Kept as literal text.`,
+      service: serviceName,
+      dockerComposeField: 'environment',
+    });
+    return { from: "stack", name, value };
+  };
 
-  const [, target, output] = match;
+  const whole = ENV_REFERENCE_PATTERN.exec(value);
+  if (whole) {
+    const [, target, output] = whole;
+    if (target === "self" || target === serviceName) {
+      return { from: "self", name, selfOutput: output };
+    }
+    if (allServiceNames.includes(target)) {
+      return { from: "resource", name, resourceName: target, output };
+    }
+    return keepLiteral(`references unknown service '${target}'`);
+  }
+
+  const refs = [...value.matchAll(ENV_REFERENCE_GLOBAL)];
+  if (refs.length === 0) return { from: "stack", name, value };
+
+  const targets = [...new Set(refs.map((m) => m[1]))];
+  if (targets.length > 1) {
+    return keepLiteral(`embeds references to multiple services (${targets.join(", ")})`);
+  }
+  const target = targets[0];
   if (target === "self" || target === serviceName) {
-    return { from: "self", name, selfOutput: output };
+    return keepLiteral(`embeds a self reference, which is only supported as the whole value`);
   }
-  if (allServiceNames.includes(target)) {
-    return { from: "resource", name, resourceName: target, output };
+  if (!allServiceNames.includes(target)) {
+    return keepLiteral(`references unknown service '${target}'`);
   }
 
-  warnings.push({
-    type: 'partial',
-    message: `Environment variable '${name}' references unknown service '${target}'. Kept as literal text.`,
-    service: serviceName,
-    dockerComposeField: 'environment',
+  const values: Record<string, string> = {};
+  const template = value.replace(ENV_REFERENCE_GLOBAL, (_ref, _target, output: string) => {
+    const key = templateKeyForOutput(output, values);
+    values[key] = output;
+    return `{{${key}}}`;
   });
-  return { from: "stack", name, value };
+  return { from: "resourceTemplate", name, resourceName: target, template, values };
 }
 
 /**

--- a/frontend/src/lib/docker-compose-converter.ts
+++ b/frontend/src/lib/docker-compose-converter.ts
@@ -8,6 +8,7 @@ import type {
   DockerComposeVolume,
 } from "@/types/docker-compose";
 import type {
+  FormEnvVarData,
   FormStackData,
   FormStackResourceData,
   FormVolumeExtendedData,
@@ -78,8 +79,10 @@ export function convertDockerComposeToStackData(
     const services = compose.services || {};
     const stackResources: FormStackResourceData[] = [];
 
+    const serviceNames = Object.keys(services);
+
     for (const [serviceName, serviceConfig] of Object.entries(services)) {
-      const conversionResult = convertServiceToStackResource(serviceName, serviceConfig);
+      const conversionResult = convertServiceToStackResource(serviceName, serviceConfig, serviceNames);
 
       if (conversionResult.success && conversionResult.data) {
         stackResources.push(conversionResult.data);
@@ -175,7 +178,8 @@ export function convertDockerComposeToStackData(
  */
 export function convertServiceToStackResource(
   serviceName: string,
-  service: DockerComposeService
+  service: DockerComposeService,
+  allServiceNames: string[] = []
 ): ServiceConversionResult {
   const warnings: ConversionWarning[] = [];
   const errors: ConversionError[] = [];
@@ -190,10 +194,10 @@ export function convertServiceToStackResource(
       depends_on: Array.isArray(service.depends_on) ? service.depends_on :
         typeof service.depends_on === 'object' && service.depends_on !== null ?
           Object.keys(service.depends_on) : [],
-      ports: convertPorts(service.ports, serviceName, warnings),
+      ports: convertPorts(service.ports, serviceName, warnings, service.expose),
       volume_mounts: convertVolumeMounts(service.volumes, serviceName, warnings),
       execution_config: {
-        environment_variables: convertEnvironmentVariables(service.environment, serviceName, warnings),
+        environment_variables: convertEnvironmentVariables(service.environment, serviceName, allServiceNames, warnings),
         command: convertCommand(service.command, warnings),
       },
       // UI-specific fields
@@ -346,11 +350,33 @@ function convertLabels(
 function convertPorts(
   ports: DockerComposeService['ports'],
   serviceName: string,
-  warnings: ConversionWarning[]
+  warnings: ConversionWarning[],
+  expose?: DockerComposeService['expose']
 ): Array<{ name: string; number: number; protocol: 'tcp' | 'http'; exposed_to_public: boolean }> {
-  if (!ports || !Array.isArray(ports)) return [];
-
   const convertedPorts: Array<{ name: string; number: number; protocol: 'tcp' | 'http'; exposed_to_public: boolean }> = [];
+
+  // Compose `expose` lists container ports reachable by sibling services but
+  // never published on the host — map them to internal (non-public) ports.
+  (expose ?? []).forEach((entry, index) => {
+    const port = parseInt(String(entry).split('/')[0], 10);
+    if (isNaN(port)) {
+      warnings.push({
+        type: 'partial',
+        message: `Invalid expose entry at index ${index}: ${entry}`,
+        service: serviceName,
+        dockerComposeField: 'expose',
+      });
+      return;
+    }
+    convertedPorts.push({
+      name: `tcp-${port}`,
+      number: port,
+      protocol: 'tcp',
+      exposed_to_public: false,
+    });
+  });
+
+  if (!ports || !Array.isArray(ports)) return convertedPorts;
 
   ports.forEach((port, index) => {
     try {
@@ -548,16 +574,56 @@ function convertVolumeMounts(
 }
 
 /**
+ * A whole-value env reference: "${self.public_url}" or "${<service>.<output>}".
+ * Output keys follow pkg/models/output_descriptor.go (host, port, url,
+ * public_host, public_url, optionally suffixed ".<port-name>").
+ */
+const ENV_REFERENCE_PATTERN = /^\$\{([a-z0-9][a-z0-9_-]*)\.([a-z0-9][a-z0-9_.-]*)\}$/;
+
+/**
+ * Classify one env value: reference values become self/resource rows resolved
+ * at deploy; everything else stays a literal row. References to unknown
+ * services are kept literal with a warning rather than dropped.
+ */
+function toEnvRow(
+  name: string,
+  value: string,
+  serviceName: string,
+  allServiceNames: string[],
+  warnings: ConversionWarning[]
+): FormEnvVarData {
+  const match = ENV_REFERENCE_PATTERN.exec(value);
+  if (!match) return { from: "stack", name, value };
+
+  const [, target, output] = match;
+  if (target === "self" || target === serviceName) {
+    return { from: "self", name, selfOutput: output };
+  }
+  if (allServiceNames.includes(target)) {
+    return { from: "resource", name, resourceName: target, output };
+  }
+
+  warnings.push({
+    type: 'partial',
+    message: `Environment variable '${name}' references unknown service '${target}'. Kept as literal text.`,
+    service: serviceName,
+    dockerComposeField: 'environment',
+  });
+  return { from: "stack", name, value };
+}
+
+/**
  * Convert Docker Compose environment variables
  */
 function convertEnvironmentVariables(
   environment: DockerComposeService['environment'],
   serviceName: string,
+  allServiceNames: string[],
   warnings: ConversionWarning[]
-): Array<{ name: string; value: string; from: "stack" }> {
+): FormEnvVarData[] {
   if (!environment) return [];
 
-  const envVars: Array<{ name: string; value: string; from: "stack" }> = [];
+  const envVars: FormEnvVarData[] = [];
 
   try {
     if (Array.isArray(environment)) {
@@ -567,11 +633,7 @@ function convertEnvironmentVariables(
           if (typeof envVar === 'string') {
             const [name, ...valueParts] = envVar.split('=');
             if (name) {
-              envVars.push({
-                name,
-                value: valueParts.join('=') || '',
-                from: "stack",
-              });
+              envVars.push(toEnvRow(name, valueParts.join('=') || '', serviceName, allServiceNames, warnings));
             }
           }
         } catch {
@@ -587,11 +649,7 @@ function convertEnvironmentVariables(
     } else if (typeof environment === 'object' && environment !== null) {
       // Handle object format: { KEY: "value", KEY2: "value2" }
       Object.entries(environment).forEach(([name, value]) => {
-        envVars.push({
-          name,
-          value: String(value ?? ''),
-          from: "stack",
-        });
+        envVars.push(toEnvRow(name, String(value ?? ''), serviceName, allServiceNames, warnings));
       });
     }
 

--- a/frontend/src/lib/tests/docker-compose-converter.test.ts
+++ b/frontend/src/lib/tests/docker-compose-converter.test.ts
@@ -1018,14 +1018,20 @@ describe('referential environment variables', () => {
     expect(env.DB_HOST).toEqual({ from: 'resource', name: 'DB_HOST', resourceName: 'db', output: 'host' });
   });
 
-  it('keeps unknown-service references and partial interpolations literal', () => {
+  it('keeps unknown-service references literal and upgrades partial interpolations to templates', () => {
     const result = convertDockerComposeToStackData(composeWithRefs());
     const app = result.data!.spec.stack_resources.find((r) => r.name === 'app')!;
     const env = Object.fromEntries(
       (app.execution_config?.environment_variables ?? []).map((e) => [e.name, e]),
     );
     expect(env.UNKNOWN_REF).toEqual({ from: 'stack', name: 'UNKNOWN_REF', value: '${ghost.host}' });
-    expect(env.PARTIAL).toEqual({ from: 'stack', name: 'PARTIAL', value: 'prefix-${db.host}' });
+    expect(env.PARTIAL).toEqual({
+      from: 'resourceTemplate',
+      name: 'PARTIAL',
+      resourceName: 'db',
+      template: 'prefix-{{host}}',
+      values: { host: 'host' },
+    });
     expect(env.LITERAL).toEqual({ from: 'stack', name: 'LITERAL', value: 'plain-value' });
 
     expect(result.warnings).toEqual(
@@ -1092,6 +1098,61 @@ describe('expose (internal-only ports)', () => {
     expect(result.warnings).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ dockerComposeField: 'expose' }),
+      ]),
+    );
+  });
+});
+
+describe('composite env values with embedded references', () => {
+  const convert = (environment: Record<string, string>) => {
+    const compose = {
+      services: {
+        app: { image: 'app:1', environment },
+        db: { image: 'postgres:16' },
+        otel: { image: 'otel:1', ports: ['3000:3000'], expose: ['4318'] },
+      },
+    } as unknown as DockerComposeFile;
+    const result = convertDockerComposeToStackData(compose);
+    const app = result.data!.spec.stack_resources.find((r) => r.name === 'app')!;
+    const env = Object.fromEntries(
+      (app.execution_config?.environment_variables ?? []).map((e) => [e.name, e]),
+    );
+    return { env, warnings: result.warnings ?? [] };
+  };
+
+  it('converts a single-service composite into a template row', () => {
+    const { env } = convert({ OTLP: 'http://${otel.host}:4318/v1/traces' });
+    expect(env.OTLP).toEqual({
+      from: 'resourceTemplate',
+      name: 'OTLP',
+      resourceName: 'otel',
+      template: 'http://{{host}}:4318/v1/traces',
+      values: { host: 'host' },
+    });
+  });
+
+  it('supports multiple references to the same service and sanitizes dotted keys', () => {
+    const { env } = convert({ URI: '${db.host}:${db.port.tcp-5432}/app' });
+    expect(env.URI).toEqual({
+      from: 'resourceTemplate',
+      name: 'URI',
+      resourceName: 'db',
+      template: '{{host}}:{{port_tcp_5432}}/app',
+      values: { host: 'host', port_tcp_5432: 'port.tcp-5432' },
+    });
+  });
+
+  it('keeps mixed-service and embedded-self composites literal with a warning', () => {
+    const { env, warnings } = convert({
+      MIXED: '${db.host}-${otel.host}',
+      SELFISH: 'prefix-${app.public_url}',
+    });
+    expect(env.MIXED).toEqual({ from: 'stack', name: 'MIXED', value: '${db.host}-${otel.host}' });
+    expect(env.SELFISH).toEqual({ from: 'stack', name: 'SELFISH', value: 'prefix-${app.public_url}' });
+    expect(warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining('multiple services') }),
+        expect.objectContaining({ message: expect.stringContaining('self reference') }),
       ]),
     );
   });

--- a/frontend/src/lib/tests/docker-compose-converter.test.ts
+++ b/frontend/src/lib/tests/docker-compose-converter.test.ts
@@ -554,9 +554,11 @@ describe('convertServiceToStackResource', () => {
     const result = convertServiceToStackResource('cache', service);
 
     expect(result.success).toBe(true);
-    // Since expose doesn't provide external mapping, no ports should be created
-    // or if ports are created, they should not be exposed to public
-    expect(result.data!.ports).toHaveLength(0);
+    // Exposed ports become service ports that are reachable inside the stack
+    // but are never published on a public ingress.
+    expect(result.data!.ports).toEqual([
+      { name: 'tcp-6379', number: 6379, protocol: 'tcp', exposed_to_public: false },
+    ]);
   });
 
   it('should use internal port when external mapping differs', () => {
@@ -973,5 +975,124 @@ services:
     expect(conversionResult.success).toBe(true); // Partial success
     expect(conversionResult.data!.spec.stack_resources).toHaveLength(1); // Only valid service converted
     expect(conversionResult.errors).toHaveLength(1); // One service failed
+  });
+});
+
+describe('referential environment variables', () => {
+  const composeWithRefs = (): DockerComposeFile => ({
+    services: {
+      app: {
+        image: 'app:1',
+        ports: ['80:80'],
+        environment: {
+          SELF_URL: '${self.public_url}',
+          OWN_NAME_URL: '${app.public_url}',
+          DB_HOST: '${db.host}',
+          UNKNOWN_REF: '${ghost.host}',
+          LITERAL: 'plain-value',
+          PARTIAL: 'prefix-${db.host}',
+        },
+      },
+      db: { image: 'postgres:16' },
+    },
+  } as unknown as DockerComposeFile);
+
+  it('converts ${self.output} and own-service references to self rows', () => {
+    const result = convertDockerComposeToStackData(composeWithRefs());
+    expect(result.success).toBe(true);
+
+    const app = result.data!.spec.stack_resources.find((r) => r.name === 'app')!;
+    const env = Object.fromEntries(
+      (app.execution_config?.environment_variables ?? []).map((e) => [e.name, e]),
+    );
+    expect(env.SELF_URL).toEqual({ from: 'self', name: 'SELF_URL', selfOutput: 'public_url' });
+    expect(env.OWN_NAME_URL).toEqual({ from: 'self', name: 'OWN_NAME_URL', selfOutput: 'public_url' });
+  });
+
+  it('converts ${service.output} to resource rows for known services', () => {
+    const result = convertDockerComposeToStackData(composeWithRefs());
+    const app = result.data!.spec.stack_resources.find((r) => r.name === 'app')!;
+    const env = Object.fromEntries(
+      (app.execution_config?.environment_variables ?? []).map((e) => [e.name, e]),
+    );
+    expect(env.DB_HOST).toEqual({ from: 'resource', name: 'DB_HOST', resourceName: 'db', output: 'host' });
+  });
+
+  it('keeps unknown-service references and partial interpolations literal', () => {
+    const result = convertDockerComposeToStackData(composeWithRefs());
+    const app = result.data!.spec.stack_resources.find((r) => r.name === 'app')!;
+    const env = Object.fromEntries(
+      (app.execution_config?.environment_variables ?? []).map((e) => [e.name, e]),
+    );
+    expect(env.UNKNOWN_REF).toEqual({ from: 'stack', name: 'UNKNOWN_REF', value: '${ghost.host}' });
+    expect(env.PARTIAL).toEqual({ from: 'stack', name: 'PARTIAL', value: 'prefix-${db.host}' });
+    expect(env.LITERAL).toEqual({ from: 'stack', name: 'LITERAL', value: 'plain-value' });
+
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining("references unknown service 'ghost'"),
+        }),
+      ]),
+    );
+  });
+
+  it('supports dotted output keys for multi-port targets', () => {
+    const compose = {
+      services: {
+        app: {
+          image: 'app:1',
+          environment: { OTLP_HOST: '${otel.host}', OTEL_PORT: '${otel.port.tcp-4318}' },
+        },
+        otel: { image: 'otel:1', ports: ['3000:3000'], expose: ['4318'] },
+      },
+    } as unknown as DockerComposeFile;
+
+    const result = convertDockerComposeToStackData(compose);
+    const app = result.data!.spec.stack_resources.find((r) => r.name === 'app')!;
+    const env = Object.fromEntries(
+      (app.execution_config?.environment_variables ?? []).map((e) => [e.name, e]),
+    );
+    expect(env.OTEL_PORT).toEqual({ from: 'resource', name: 'OTEL_PORT', resourceName: 'otel', output: 'port.tcp-4318' });
+  });
+});
+
+describe('expose (internal-only ports)', () => {
+  it('maps expose entries to non-public tcp ports alongside published ports', () => {
+    const service: DockerComposeService = {
+      image: 'grafana/otel-lgtm:0.29.1',
+      ports: ['3000:3000'],
+      expose: ['4318', 4317],
+    } as unknown as DockerComposeService;
+
+    const result = convertServiceToStackResource('lgtm', service, ['lgtm']);
+    expect(result.success).toBe(true);
+
+    const ports = (result.data!.ports ?? [])
+      .map((p) => ({ number: p.number, protocol: p.protocol, public: p.exposed_to_public }))
+      .sort((a, b) => (a.number ?? 0) - (b.number ?? 0));
+    expect(ports).toEqual([
+      { number: 3000, protocol: 'http', public: true },
+      { number: 4317, protocol: 'tcp', public: false },
+      { number: 4318, protocol: 'tcp', public: false },
+    ]);
+  });
+
+  it('warns on unparseable expose entries and keeps the rest', () => {
+    const service = {
+      image: 'app:1',
+      expose: ['not-a-port', '9000/tcp'],
+    } as unknown as DockerComposeService;
+
+    const result = convertServiceToStackResource('app', service, ['app']);
+    expect(result.success).toBe(true);
+    expect(result.data!.ports).toEqual([
+      { name: 'tcp-9000', number: 9000, protocol: 'tcp', exposed_to_public: false },
+    ]);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ dockerComposeField: 'expose' }),
+      ]),
+    );
   });
 });

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/env-row.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/env-row.tsx
@@ -180,6 +180,14 @@ export function EnvRow({
               onChange={(rn, out) => onChangeResource?.(rn, out)}
             />
           )}
+          {row.from === "resourceTemplate" && (
+            <div className="flex h-8 w-full min-w-0 items-center gap-2 rounded-md border border-border bg-muted/40 px-2.5">
+              <code className="truncate font-mono text-xs">{row.template}</code>
+              <span className="ml-auto flex-none text-[10px] italic text-muted-foreground">
+                {row.resourceName} · resolved at deploy
+              </span>
+            </div>
+          )}
           {row.from === "self" && (
             <SelfOutputCell
               outputs={selfOutputs ?? []}
@@ -206,6 +214,12 @@ export function EnvRow({
               <SelectItem value="secret">Secret</SelectItem>
               <SelectItem value="addon">Addon</SelectItem>
               <SelectItem value="resource">Resource</SelectItem>
+              {/* Template rows come from imports (composite values); not hand-authorable yet. */}
+              {row.from === "resourceTemplate" && (
+                <SelectItem value="resourceTemplate" disabled>
+                  Template
+                </SelectItem>
+              )}
               <SelectItem value="self">Self</SelectItem>
             </SelectContent>
           </Select>

--- a/frontend/src/pages/stacks/lib/connection-mapping.ts
+++ b/frontend/src/pages/stacks/lib/connection-mapping.ts
@@ -17,6 +17,14 @@ export type FormEnvRow =
       credField?: AddonOutputField;
     }
   | { from: "resource"; name: string; resourceName: string; output: string }
+  | {
+      from: "resourceTemplate";
+      name: string;
+      resourceName: string;
+      template: string;
+      /** Template key → output name on the source resource. */
+      values: Record<string, string>;
+    }
   | { from: "self"; name: string; selfOutput: string };
 
 const envMapping = (name: string, output: string): ConnectionMapping => ({
@@ -90,6 +98,25 @@ export function splitEnvRows(
         g.mappings.push(envMapping(row.name, row.output));
         break;
       }
+      case "resourceTemplate": {
+        if (!row.resourceName || !row.template) break; // skip in-progress rows
+        const key = `resource::${row.resourceName}`;
+        const g = ensureGroup(key, () => ({
+          kind: "env",
+          from: { type: "stack_resource", name: row.resourceName },
+          to: { type: "stack_resource", name: resourceName },
+        }));
+        g.mappings.push({
+          target: { type: "env", name: row.name },
+          value: {
+            template: row.template,
+            values: Object.fromEntries(
+              Object.entries(row.values).map(([key, output]) => [key, { output }]),
+            ),
+          },
+        });
+        break;
+      }
     }
   }
 
@@ -129,7 +156,19 @@ export function connectionsToEnvRows(
           credField: output as AddonOutputField,
         });
       } else if (c.from?.type === "stack_resource" && c.from?.name) {
-        rows.push({ from: "resource", name: envName, resourceName: c.from.name, output });
+        if (m.value?.template) {
+          rows.push({
+            from: "resourceTemplate",
+            name: envName,
+            resourceName: c.from.name,
+            template: m.value.template,
+            values: Object.fromEntries(
+              Object.entries(m.value.values ?? {}).map(([key, ref]) => [key, ref.output ?? ""]),
+            ),
+          });
+        } else {
+          rows.push({ from: "resource", name: envName, resourceName: c.from.name, output });
+        }
       }
     }
   }

--- a/frontend/src/pages/stacks/lib/tests/connection-mapping.test.ts
+++ b/frontend/src/pages/stacks/lib/tests/connection-mapping.test.ts
@@ -346,3 +346,60 @@ describe("connectionsToMounts", () => {
   });
 });
 
+
+describe("resourceTemplate rows", () => {
+  const templateRow: FormEnvRow = {
+    from: "resourceTemplate",
+    name: "OTEL_EXPORTER_OTLP_TRACES",
+    resourceName: "otel-stack",
+    template: "http://{{host}}:4318/v1/traces",
+    values: { host: "host" },
+  };
+
+  it("persists as a template mapping on the source resource's env connection", () => {
+    const { envVars, connections } = splitEnvRows("tooljet", [templateRow]);
+    expect(envVars).toEqual([]);
+    expect(connections).toEqual([
+      {
+        kind: "env",
+        from: { type: "stack_resource", name: "otel-stack" },
+        to: { type: "stack_resource", name: "tooljet" },
+        mappings: [
+          {
+            target: { type: "env", name: "OTEL_EXPORTER_OTLP_TRACES" },
+            value: {
+              template: "http://{{host}}:4318/v1/traces",
+              values: { host: { output: "host" } },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("shares one connection with plain output rows from the same source", () => {
+    const rows: FormEnvRow[] = [
+      { from: "resource", name: "OTEL_HOST", resourceName: "otel-stack", output: "host" },
+      templateRow,
+    ];
+    const { connections } = splitEnvRows("tooljet", rows);
+    expect(connections).toHaveLength(1);
+    expect(connections[0].mappings).toHaveLength(2);
+  });
+
+  it("round-trips through connectionsToEnvRows", () => {
+    const { connections } = splitEnvRows("tooljet", [templateRow]);
+    const rows = connectionsToEnvRows("tooljet", connections);
+    expect(rows).toEqual([templateRow]);
+  });
+
+  it("skips in-progress rows missing resource or template", () => {
+    const rows: FormEnvRow[] = [
+      { from: "resourceTemplate", name: "X", resourceName: "", template: "{{host}}", values: { host: "host" } },
+      { from: "resourceTemplate", name: "Y", resourceName: "otel-stack", template: "", values: {} },
+    ];
+    const { envVars, connections } = splitEnvRows("tooljet", rows);
+    expect(envVars).toEqual([]);
+    expect(connections).toEqual([]);
+  });
+});

--- a/frontend/src/pages/stacks/schemas/form-schema.ts
+++ b/frontend/src/pages/stacks/schemas/form-schema.ts
@@ -57,6 +57,13 @@ const FormEnvVarSchema = z.union([
     output: z.string().min(1, "Pick an output"),
   }),
   z.object({
+    from: z.literal("resourceTemplate"),
+    name: z.string().min(1, "Required"),
+    resourceName: z.string().min(1, "Pick a resource"),
+    template: z.string().min(1, "Required"),
+    values: z.record(z.string()),
+  }),
+  z.object({
     from: z.literal("self"),
     name: z.string().min(1, "Required"),
     selfOutput: z.string().min(1, "Pick an output"),


### PR DESCRIPTION
## 📝 What this does
Rebuilds the ToolJet template into a full production-shaped stack — app, workflow worker, Redis, Postgres, PostgREST (ToolJet DB), and a bundled observability service (Grafana + Tempo + Prometheus) — and teaches the compose conversion pipeline to resolve environment references at deploy time, so the template works without any manual URL editing after import.

## 🏗️ Architecture
### Deploy-time env references
Template env values can now defer binding until deploy:
- `${self.<output>}` → persists as a `self_output` env var, resolved against the resource's own outputs (e.g. `TOOLJET_HOST` → the generated public ingress URL).
- `${<service>.<output>}` → persists as an `env` stack connection with an output mapping, resolved against the source resource (e.g. `PG_HOST` → `postgresql`'s namespaced service DNS). These references are what the canvas renders as edges.
- Composite values embedding references — `http://${otel-stack.host}:4318/v1/traces` — become Go-template mappings (`{{host}}` + named output refs) on the env connection, which the backend already validates and resolves. They render read-only in the environment drawer.
- Unknown-service references, mixed-service composites, and embedded self references stay literal with a conversion warning.

Compose `expose` entries now map to internal-only (non-public) tcp service ports, so sibling services can reach ports that must never get a public ingress — the app containers push OTLP telemetry to the observability service this way.

## 🔀 Changes
- Rebuilt the ToolJet template: app + worker + redis + postgres + postgrest + `grafana/otel-lgtm` observability service, pinned to `v3.20.189-lts`, with a bundled 40-panel monitoring dashboard asset
- Added `${self.*}` / `${service.*}` env reference syntax to the docker-compose converter, including composite values via connection template mappings
- Added compose `expose` support (internal-only service ports)
- Invoked the ToolJet image entrypoint explicitly so database creation and migrations run (a bare `start:prod` command replaces the entrypoint and crash-loops)
- Named the observability service `otel-stack` and widened its volume to `/data` so Grafana state and all telemetry history survive restarts

## 🧪 How to test
- [x] Create a stack from the ToolJet template, fill the four `REPLACE_*` secrets, deploy
- [x] Check the pod env: `TOOLJET_HOST` is the generated public URL, `PG_HOST`/`REDIS_HOST`/`PGRST_HOST` are namespaced service DNS names, and the OTLP endpoints resolve to the `otel-stack` service DNS
- [x] Open the ToolJet URL, complete setup, create a table in ToolJet Database
- [x] Import `dashboards/tooljet-monitoring.json` in Grafana (map Prometheus + Tempo, SLO constant 500) and confirm metrics and traces arrive from both app and worker