### PR TITLE
feat(git-integrations): list repos across all installations, key on our UUID

### DIFF
--- a/config/openapi/stackdome_api.yaml
+++ b/config/openapi/stackdome_api.yaml
@@ -728,19 +728,16 @@ paths:
         - $ref: '#/components/parameters/org_id'
         - $ref: '#/components/parameters/id'
         - in: query
-          name: query
-          schema:
-            type: string
-          description: Substring filter on the repository full name
-        - in: query
           name: page
           schema:
             type: integer
         - in: query
           name: installation_id
+          description: >-
+            Our GitInstallation id (UUID). When omitted, repositories are
+            aggregated across every installation of the integration.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         '200':
           description: Successful operation

--- a/frontend/src/api/git-integrations.ts
+++ b/frontend/src/api/git-integrations.ts
@@ -47,15 +47,15 @@ export async function listInstallations(orgId: string, integrationId: string, re
   return res.data as GitInstallationList;
 }
 
-export interface RepoSearchOpts {
-  query?: string;
+export interface RepoListOpts {
   page?: number;
-  installationId?: number;
+  // Our GitInstallation id (UUID). When omitted, repositories are aggregated
+  // across every installation of the integration.
+  installationId?: string;
 }
 
-export async function searchRepositories(orgId: string, integrationId: string, opts: RepoSearchOpts = {}): Promise<GitRepositoryPage> {
+export async function listRepositories(orgId: string, integrationId: string, opts: RepoListOpts = {}): Promise<GitRepositoryPage> {
   const params: Record<string, string | number> = {};
-  if (opts.query) params.query = opts.query;
   if (opts.page) params.page = opts.page;
   if (opts.installationId) params.installation_id = opts.installationId;
   const res = await api.get(`${base(orgId)}/${integrationId}/repositories`, { params });

--- a/frontend/src/api/tests/git-integrations.test.ts
+++ b/frontend/src/api/tests/git-integrations.test.ts
@@ -11,7 +11,7 @@ import {
   verifyGitIntegration,
   createGitHubAppManifest,
   listInstallations,
-  searchRepositories,
+  listRepositories,
   getRepository,
   listRepositoryBranches,
 } from "../git-integrations";
@@ -56,10 +56,10 @@ describe("git-integrations api", () => {
     expect(api.get).toHaveBeenCalledWith(`${BASE}/gi1/installations`, { params: { refresh: true } });
   });
 
-  it("searches repositories with query and page", async () => {
+  it("lists repositories by installation and page", async () => {
     (api.get as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { items: [], page: 1, total_count: 0, has_next: false } });
-    await searchRepositories(ORG, "gi1", { query: "web", page: 2 });
-    expect(api.get).toHaveBeenCalledWith(`${BASE}/gi1/repositories`, { params: { query: "web", page: 2 } });
+    await listRepositories(ORG, "gi1", { installationId: "inst-uuid", page: 2 });
+    expect(api.get).toHaveBeenCalledWith(`${BASE}/gi1/repositories`, { params: { page: 2, installation_id: "inst-uuid" } });
   });
 
   it("gets a repository", async () => {

--- a/frontend/src/api/types/openapi.d.ts
+++ b/frontend/src/api/types/openapi.d.ts
@@ -1628,10 +1628,9 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description Substring filter on the repository full name */
-                    query?: string;
                     page?: number;
-                    installation_id?: number;
+                    /** @description Our GitInstallation id (UUID). When omitted, repositories are aggregated across every installation of the integration. */
+                    installation_id?: string;
                 };
                 header?: never;
                 path: {

--- a/frontend/src/api/zod-schemas.ts
+++ b/frontend/src/api/zod-schemas.ts
@@ -2901,11 +2901,6 @@ const endpoints = makeApi([
         schema: z.string(),
       },
       {
-        name: "query",
-        type: "Query",
-        schema: z.string().optional(),
-      },
-      {
         name: "page",
         type: "Query",
         schema: z.number().int().optional(),
@@ -2913,7 +2908,7 @@ const endpoints = makeApi([
       {
         name: "installation_id",
         type: "Query",
-        schema: z.number().int().optional(),
+        schema: z.string().optional(),
       },
     ],
     response: GitRepositoryPage,

--- a/frontend/src/components/git-source-picker/git-source-picker.tsx
+++ b/frontend/src/components/git-source-picker/git-source-picker.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import {
   listGitIntegrations,
-  searchRepositories,
+  listRepositories,
   getRepository,
   type GitIntegration,
   type GitRepository,
@@ -85,32 +85,29 @@ export function GitSourcePicker({ value, onChange, publicUrlHint }: GitSourcePic
     void loadIntegrations();
   }, [loadIntegrations]);
 
-  // Debounced repo search — only meaningful for GitHub App integrations.
+  // Repos load once per integration; the query filters them client-side.
   useEffect(() => {
     if (tab !== "provider" || selected?.type !== GIT_INTEGRATION_TYPE_GITHUB_APP) return;
     const orgId = getCurrentOrganizationId();
     if (!orgId || !selected.id) return;
     let cancelled = false;
     setSearching(true);
-    const t = setTimeout(() => {
-      searchRepositories(orgId, selected.id!, { query: query || undefined })
-        .then((page) => {
-          if (cancelled) return;
-          setRepos(page.items ?? []);
-          setError(null);
-        })
-        .catch((e) => {
-          if (!cancelled) setError(getErrorMessage(e));
-        })
-        .finally(() => {
-          if (!cancelled) setSearching(false);
-        });
-    }, 300);
+    listRepositories(orgId, selected.id!)
+      .then((page) => {
+        if (cancelled) return;
+        setRepos(page.items ?? []);
+        setError(null);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(getErrorMessage(e));
+      })
+      .finally(() => {
+        if (!cancelled) setSearching(false);
+      });
     return () => {
       cancelled = true;
-      clearTimeout(t);
     };
-  }, [tab, selected?.id, selected?.type, query]);
+  }, [tab, selected?.id, selected?.type]);
 
   const pickRepo = async (repo: GitRepository) => {
     const orgId = getCurrentOrganizationId();
@@ -183,6 +180,11 @@ export function GitSourcePicker({ value, onChange, publicUrlHint }: GitSourcePic
     hostUrl.trim() !== "" &&
     hostOf(hostUrl.trim()) !== (selected.host ?? "").toLowerCase();
 
+  const needle = query.trim().toLowerCase();
+  const filteredRepos = needle
+    ? repos.filter((r) => r.full_name?.toLowerCase().includes(needle))
+    : repos;
+
   return (
     <div className="space-y-4">
       <div role="tablist" className="flex gap-6 border-b border-border">
@@ -249,7 +251,7 @@ export function GitSourcePicker({ value, onChange, publicUrlHint }: GitSourcePic
             <>
               {searching && <p className="text-sm text-muted-foreground">Searching…</p>}
               <ul className="divide-y rounded-md border">
-                {repos.map((r) => (
+                {filteredRepos.map((r) => (
                   <li key={r.full_name}>
                     <button
                       type="button"
@@ -269,7 +271,7 @@ export function GitSourcePicker({ value, onChange, publicUrlHint }: GitSourcePic
                     </button>
                   </li>
                 ))}
-                {!searching && repos.length === 0 && (
+                {!searching && filteredRepos.length === 0 && (
                   <li className="space-y-2 px-3 py-6 text-center text-sm text-muted-foreground">
                     <p>No repositories found.</p>
                     {configureUrl && (

--- a/frontend/src/components/git-source-picker/repo-combobox.tsx
+++ b/frontend/src/components/git-source-picker/repo-combobox.tsx
@@ -17,7 +17,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
   listGitIntegrations,
-  searchRepositories,
+  listRepositories,
   getRepository,
   type GitIntegration,
   type GitRepository,
@@ -82,7 +82,7 @@ export function RepoCombobox({ id, value, integrationId, onChange, hasError }: R
       .finally(() => setLoaded(true));
   }, [open, loaded]);
 
-  // Debounced repo search — only GitHub App integrations can list repos.
+  // Repos load once per integration; the query filters them client-side.
   useEffect(() => {
     if (!open || selected?.type !== GIT_INTEGRATION_TYPE_GITHUB_APP) {
       setRepos([]);
@@ -92,25 +92,22 @@ export function RepoCombobox({ id, value, integrationId, onChange, hasError }: R
     if (!orgId || !selected.id) return;
     let cancelled = false;
     setSearching(true);
-    const t = setTimeout(() => {
-      searchRepositories(orgId, selected.id!, { query: query || undefined })
-        .then((page) => {
-          if (cancelled) return;
-          setRepos(page.items ?? []);
-          setError(null);
-        })
-        .catch((e) => {
-          if (!cancelled) setError(getErrorMessage(e));
-        })
-        .finally(() => {
-          if (!cancelled) setSearching(false);
-        });
-    }, 300);
+    listRepositories(orgId, selected.id!)
+      .then((page) => {
+        if (cancelled) return;
+        setRepos(page.items ?? []);
+        setError(null);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(getErrorMessage(e));
+      })
+      .finally(() => {
+        if (!cancelled) setSearching(false);
+      });
     return () => {
       cancelled = true;
-      clearTimeout(t);
     };
-  }, [open, selected?.id, selected?.type, query]);
+  }, [open, selected?.id, selected?.type]);
 
   const pickRepo = async (repo: GitRepository) => {
     const orgId = getCurrentOrganizationId();
@@ -160,6 +157,10 @@ export function RepoCombobox({ id, value, integrationId, onChange, hasError }: R
   // aren't limited to a "git" user, so match the general `user@host:` shape.
   const looksLikeUrl =
     /^(https?|ssh|git):\/\//i.test(trimmedQuery) || /^[\w.-]+@[\w.-]+:/.test(trimmedQuery);
+  const needle = trimmedQuery.toLowerCase();
+  const filteredRepos = needle
+    ? repos.filter((r) => r.full_name?.toLowerCase().includes(needle))
+    : repos;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -207,7 +208,7 @@ export function RepoCombobox({ id, value, integrationId, onChange, hasError }: R
             {error && <div className="px-3 py-2 text-xs text-danger">{error}</div>}
             {selected?.type === GIT_INTEGRATION_TYPE_GITHUB_APP && (
               <CommandGroup>
-                {repos.map((repo) => (
+                {filteredRepos.map((repo) => (
                   <CommandItem
                     key={repo.full_name}
                     value={repo.full_name!}
@@ -224,7 +225,7 @@ export function RepoCombobox({ id, value, integrationId, onChange, hasError }: R
                     )}
                   </CommandItem>
                 ))}
-                {!searching && repos.length === 0 && (
+                {!searching && filteredRepos.length === 0 && (
                   <CommandEmpty>No repositories found.</CommandEmpty>
                 )}
               </CommandGroup>

--- a/frontend/src/components/git-source-picker/tests/git-source-picker.test.tsx
+++ b/frontend/src/components/git-source-picker/tests/git-source-picker.test.tsx
@@ -16,7 +16,7 @@ afterEach(cleanup);
 vi.mock("@/api/git-integrations", async (importOriginal) => ({
   ...(await importOriginal<object>()),
   listGitIntegrations: vi.fn(),
-  searchRepositories: vi.fn(),
+  listRepositories: vi.fn(),
   getRepository: vi.fn(),
 }));
 vi.mock("@/helpers/common", () => ({ getCurrentOrganizationId: () => "org-1" }));
@@ -27,7 +27,7 @@ vi.mock("@/pages/git-integrations/add-integration-wizard", () => ({
     open ? <div data-testid="add-integration-wizard" /> : null,
 }));
 
-import { listGitIntegrations, searchRepositories, getRepository } from "@/api/git-integrations";
+import { listGitIntegrations, listRepositories, getRepository } from "@/api/git-integrations";
 
 const app = {
   id: "int-app",
@@ -51,7 +51,7 @@ function renderPicker(props: Partial<Parameters<typeof GitSourcePicker>[0]> = {}
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(listGitIntegrations).mockResolvedValue({ items: [app, creds] });
-  vi.mocked(searchRepositories).mockResolvedValue({ items: [] });
+  vi.mocked(listRepositories).mockResolvedValue({ items: [] });
 });
 
 describe("repoTail", () => {
@@ -65,7 +65,7 @@ describe("GitSourcePicker", () => {
   it("searches repos for the auto-selected GitHub App and emits the picked repo with fetched detail", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    vi.mocked(searchRepositories).mockResolvedValue({
+    vi.mocked(listRepositories).mockResolvedValue({
       items: [{ full_name: "acme/webapp", clone_url: "https://github.com/acme/webapp.git", private: false }],
     });
     vi.mocked(getRepository).mockResolvedValue({

--- a/frontend/src/components/git-source-picker/tests/repo-combobox.test.tsx
+++ b/frontend/src/components/git-source-picker/tests/repo-combobox.test.tsx
@@ -40,12 +40,12 @@ afterEach(cleanup);
 vi.mock("@/api/git-integrations", async (importOriginal) => ({
   ...(await importOriginal<object>()),
   listGitIntegrations: vi.fn(),
-  searchRepositories: vi.fn(),
+  listRepositories: vi.fn(),
   getRepository: vi.fn(),
 }));
 vi.mock("@/helpers/common", () => ({ getCurrentOrganizationId: () => "org-1" }));
 
-import { listGitIntegrations, searchRepositories, getRepository } from "@/api/git-integrations";
+import { listGitIntegrations, listRepositories, getRepository } from "@/api/git-integrations";
 
 const app = {
   id: "int-app",
@@ -64,7 +64,7 @@ const creds = {
 
 beforeEach(() => {
   vi.mocked(listGitIntegrations).mockResolvedValue({ items: [app, creds] });
-  vi.mocked(searchRepositories).mockResolvedValue({
+  vi.mocked(listRepositories).mockResolvedValue({
     items: [{ full_name: "acme/api", private: true, default_branch: "main" }],
   });
   vi.mocked(getRepository).mockResolvedValue({

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/time v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/postgres v1.5.9
@@ -175,7 +176,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/pkg/api/openapi/api/openapi.yaml
+++ b/pkg/api/openapi/api/openapi.yaml
@@ -895,14 +895,6 @@ paths:
         schema:
           type: string
         style: simple
-      - description: Substring filter on the repository full name
-        explode: true
-        in: query
-        name: query
-        required: false
-        schema:
-          type: string
-        style: form
       - explode: true
         in: query
         name: page
@@ -910,13 +902,14 @@ paths:
         schema:
           type: integer
         style: form
-      - explode: true
+      - description: "Our GitInstallation id (UUID). When omitted, repositories are\
+          \ aggregated across every installation of the integration."
+        explode: true
         in: query
         name: installation_id
         required: false
         schema:
-          format: int64
-          type: integer
+          type: string
         style: form
       responses:
         "200":

--- a/pkg/api/openapi/api_default.go
+++ b/pkg/api/openapi/api_default.go
@@ -3461,15 +3461,8 @@ type ApiApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGetRequest struct {
 	ApiService     *DefaultApiService
 	orgId          string
 	id             string
-	query          *string
 	page           *int32
-	installationId *int64
-}
-
-// Substring filter on the repository full name
-func (r ApiApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGetRequest) Query(query string) ApiApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGetRequest {
-	r.query = &query
-	return r
+	installationId *string
 }
 
 func (r ApiApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGetRequest) Page(page int32) ApiApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGetRequest {
@@ -3477,7 +3470,8 @@ func (r ApiApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGetRequest) Page(
 	return r
 }
 
-func (r ApiApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGetRequest) InstallationId(installationId int64) ApiApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGetRequest {
+// Our GitInstallation id (UUID). When omitted, repositories are aggregated across every installation of the integration.
+func (r ApiApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGetRequest) InstallationId(installationId string) ApiApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGetRequest {
 	r.installationId = &installationId
 	return r
 }
@@ -3527,9 +3521,6 @@ func (a *DefaultApiService) ApiV1OrganizationsOrgIdGitIntegrationsIdRepositories
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	if r.query != nil {
-		localVarQueryParams.Add("query", parameterToString(*r.query, ""))
-	}
 	if r.page != nil {
 		localVarQueryParams.Add("page", parameterToString(*r.page, ""))
 	}

--- a/pkg/api/openapi/docs/DefaultApi.md
+++ b/pkg/api/openapi/docs/DefaultApi.md
@@ -2236,7 +2236,7 @@ Name | Type | Description  | Notes
 
 ## ApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGet
 
-> GitRepositoryPage ApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGet(ctx, orgId, id).Query(query).Page(page).InstallationId(installationId).Execute()
+> GitRepositoryPage ApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGet(ctx, orgId, id).Page(page).InstallationId(installationId).Execute()
 
 List repositories visible to the GitHub App installation
 
@@ -2255,13 +2255,12 @@ import (
 func main() {
     orgId := "orgId_example" // string | The ID of the organization
     id := "id_example" // string | The id of record
-    query := "query_example" // string | Substring filter on the repository full name (optional)
     page := int32(56) // int32 |  (optional)
-    installationId := int64(789) // int64 |  (optional)
+    installationId := "installationId_example" // string | Our GitInstallation id (UUID). When omitted, repositories are aggregated across every installation of the integration. (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.DefaultApi.ApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGet(context.Background(), orgId, id).Query(query).Page(page).InstallationId(installationId).Execute()
+    resp, r, err := apiClient.DefaultApi.ApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGet(context.Background(), orgId, id).Page(page).InstallationId(installationId).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ApiV1OrganizationsOrgIdGitIntegrationsIdRepositoriesGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -2289,9 +2288,8 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
 
- **query** | **string** | Substring filter on the repository full name | 
  **page** | **int32** |  | 
- **installationId** | **int64** |  | 
+ **installationId** | **string** | Our GitInstallation id (UUID). When omitted, repositories are aggregated across every installation of the integration. | 
 
 ### Return type
 

--- a/pkg/clients/githubapp/client.go
+++ b/pkg/clients/githubapp/client.go
@@ -23,6 +23,9 @@ const DefaultAPIBaseURL = "https://api.github.com"
 // token for git-over-HTTPS operations.
 const CloneUsername = "x-access-token"
 
+// reposPerPage bounds how many repositories are fetched per installation page.
+const reposPerPage = 100
+
 // AppCredentials are the app-level credentials produced by the manifest flow.
 // Every field is a secret; the PEM in particular is the app's RSA private key
 // used to sign app JWTs.
@@ -82,8 +85,8 @@ type Client interface {
 	// MintInstallationToken creates a short-lived installation access token.
 	MintInstallationToken(ctx context.Context, creds *AppCredentials, installationID int64) (*Token, error)
 	// ListInstallationRepos lists one page of repositories the installation
-	// can access, optionally filtered by a substring query.
-	ListInstallationRepos(ctx context.Context, creds *AppCredentials, installationID int64, query string, page int) (*RepoPage, error)
+	// can access.
+	ListInstallationRepos(ctx context.Context, creds *AppCredentials, installationID int64, page int) (*RepoPage, error)
 	// GetRepo fetches repository details through the installation.
 	GetRepo(ctx context.Context, creds *AppCredentials, installationID int64, owner, repo string) (*Repo, error)
 	// ListBranches lists branch names through the installation.
@@ -231,7 +234,7 @@ func (c *client) MintInstallationToken(ctx context.Context, creds *AppCredential
 	return &Token{Value: tok.GetToken(), ExpiresAt: tok.GetExpiresAt().Time}, nil
 }
 
-func (c *client) ListInstallationRepos(ctx context.Context, creds *AppCredentials, installationID int64, query string, page int) (*RepoPage, error) {
+func (c *client) ListInstallationRepos(ctx context.Context, creds *AppCredentials, installationID int64, page int) (*RepoPage, error) {
 	gh, err := c.installationClient(creds, installationID)
 	if err != nil {
 		return nil, err
@@ -239,7 +242,7 @@ func (c *client) ListInstallationRepos(ctx context.Context, creds *AppCredential
 	if page <= 0 {
 		page = 1
 	}
-	list, resp, err := gh.Apps.ListRepos(ctx, &github.ListOptions{Page: page, PerPage: 100})
+	list, resp, err := gh.Apps.ListRepos(ctx, &github.ListOptions{Page: page, PerPage: reposPerPage})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list installation repositories: %w", err)
 	}
@@ -248,14 +251,7 @@ func (c *client) ListInstallationRepos(ctx context.Context, creds *AppCredential
 		TotalCount: list.GetTotalCount(),
 		HasNext:    resp.NextPage != 0,
 	}
-	// The installation-repositories endpoint has no server-side search, so the
-	// query is applied client-side over the fetched page; TotalCount and HasNext
-	// still reflect the unfiltered listing.
-	query = strings.ToLower(strings.TrimSpace(query))
 	for _, r := range list.Repositories {
-		if query != "" && !strings.Contains(strings.ToLower(r.GetFullName()), query) {
-			continue
-		}
 		result.Repos = append(result.Repos, repoFrom(r))
 	}
 	return result, nil

--- a/pkg/clients/githubapp/client_test.go
+++ b/pkg/clients/githubapp/client_test.go
@@ -175,7 +175,7 @@ func TestMintInstallationToken(t *testing.T) {
 	}
 }
 
-func TestListInstallationReposFiltersByQuery(t *testing.T) {
+func TestListInstallationReposReturnsPage(t *testing.T) {
 	creds, _ := testAppCredentials(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -204,12 +204,15 @@ func TestListInstallationReposFiltersByQuery(t *testing.T) {
 	defer srv.Close()
 
 	client := NewClient(ClientSpec{BaseURL: srv.URL})
-	page, err := client.ListInstallationRepos(context.Background(), creds, 77, "api", 1)
+	page, err := client.ListInstallationRepos(context.Background(), creds, 77, 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(page.Repos) != 1 || page.Repos[0].FullName != "acme/api" || !page.Repos[0].Private {
+	if len(page.Repos) != 2 || page.Repos[0].FullName != "acme/api" || !page.Repos[0].Private {
 		t.Fatalf("unexpected repos %+v", page.Repos)
+	}
+	if page.Repos[1].FullName != "acme/web" {
+		t.Fatalf("unexpected second repo %+v", page.Repos)
 	}
 	if page.TotalCount != 2 || page.HasNext {
 		t.Fatalf("unexpected paging %+v", page)

--- a/pkg/handlers/git_integration_handler.go
+++ b/pkg/handlers/git_integration_handler.go
@@ -202,11 +202,10 @@ func (h *gitIntegrationHandler) ListRepositories(w http.ResponseWriter, r *http.
 	cfg := &handlerConfig{
 		Action: func() (interface{}, *errors.ServiceError) {
 			id := mux.Vars(r)["id"]
-			query := r.URL.Query().Get("query")
 			page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-			installationID, _ := strconv.ParseInt(r.URL.Query().Get("installation_id"), 10, 64)
+			installationID := r.URL.Query().Get("installation_id")
 
-			repoPage, serr := h.gitIntegrationService.ListRepositories(r.Context(), id, query, page, installationID)
+			repoPage, serr := h.gitIntegrationService.ListRepositories(r.Context(), id, page, installationID)
 			if serr != nil {
 				return nil, serr
 			}

--- a/pkg/mocks/mock_git_installation_store.go
+++ b/pkg/mocks/mock_git_installation_store.go
@@ -71,6 +71,21 @@ func (mr *MockGitInstallationStoreMockRecorder) GetByIntegrationAndAccount(ctx, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByIntegrationAndAccount", reflect.TypeOf((*MockGitInstallationStore)(nil).GetByIntegrationAndAccount), ctx, integrationID, accountLogin)
 }
 
+// GetByIntegrationAndID mocks base method.
+func (m *MockGitInstallationStore) GetByIntegrationAndID(ctx context.Context, integrationID, id string) (*models.GitInstallation, *errors.ServiceError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByIntegrationAndID", ctx, integrationID, id)
+	ret0, _ := ret[0].(*models.GitInstallation)
+	ret1, _ := ret[1].(*errors.ServiceError)
+	return ret0, ret1
+}
+
+// GetByIntegrationAndID indicates an expected call of GetByIntegrationAndID.
+func (mr *MockGitInstallationStoreMockRecorder) GetByIntegrationAndID(ctx, integrationID, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByIntegrationAndID", reflect.TypeOf((*MockGitInstallationStore)(nil).GetByIntegrationAndID), ctx, integrationID, id)
+}
+
 // ListByIntegrationID mocks base method.
 func (m *MockGitInstallationStore) ListByIntegrationID(ctx context.Context, integrationID string) ([]*models.GitInstallation, *errors.ServiceError) {
 	m.ctrl.T.Helper()

--- a/pkg/mocks/mock_git_integration_service.go
+++ b/pkg/mocks/mock_git_integration_service.go
@@ -223,18 +223,18 @@ func (mr *MockGitIntegrationServiceMockRecorder) ListInstallations(ctx, integrat
 }
 
 // ListRepositories mocks base method.
-func (m *MockGitIntegrationService) ListRepositories(ctx context.Context, integrationID, query string, page int, installationID int64) (*githubapp.RepoPage, *errors.ServiceError) {
+func (m *MockGitIntegrationService) ListRepositories(ctx context.Context, integrationID string, page int, installationUUID string) (*githubapp.RepoPage, *errors.ServiceError) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRepositories", ctx, integrationID, query, page, installationID)
+	ret := m.ctrl.Call(m, "ListRepositories", ctx, integrationID, page, installationUUID)
 	ret0, _ := ret[0].(*githubapp.RepoPage)
 	ret1, _ := ret[1].(*errors.ServiceError)
 	return ret0, ret1
 }
 
 // ListRepositories indicates an expected call of ListRepositories.
-func (mr *MockGitIntegrationServiceMockRecorder) ListRepositories(ctx, integrationID, query, page, installationID any) *gomock.Call {
+func (mr *MockGitIntegrationServiceMockRecorder) ListRepositories(ctx, integrationID, page, installationUUID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositories", reflect.TypeOf((*MockGitIntegrationService)(nil).ListRepositories), ctx, integrationID, query, page, installationID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositories", reflect.TypeOf((*MockGitIntegrationService)(nil).ListRepositories), ctx, integrationID, page, installationUUID)
 }
 
 // ListRepositoryBranches mocks base method.

--- a/pkg/mocks/mock_githubapp_client.go
+++ b/pkg/mocks/mock_githubapp_client.go
@@ -87,18 +87,18 @@ func (mr *MockGitHubAppClientMockRecorder) ListBranches(ctx, creds, installation
 }
 
 // ListInstallationRepos mocks base method.
-func (m *MockGitHubAppClient) ListInstallationRepos(ctx context.Context, creds *githubapp.AppCredentials, installationID int64, query string, page int) (*githubapp.RepoPage, error) {
+func (m *MockGitHubAppClient) ListInstallationRepos(ctx context.Context, creds *githubapp.AppCredentials, installationID int64, page int) (*githubapp.RepoPage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListInstallationRepos", ctx, creds, installationID, query, page)
+	ret := m.ctrl.Call(m, "ListInstallationRepos", ctx, creds, installationID, page)
 	ret0, _ := ret[0].(*githubapp.RepoPage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListInstallationRepos indicates an expected call of ListInstallationRepos.
-func (mr *MockGitHubAppClientMockRecorder) ListInstallationRepos(ctx, creds, installationID, query, page any) *gomock.Call {
+func (mr *MockGitHubAppClientMockRecorder) ListInstallationRepos(ctx, creds, installationID, page any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstallationRepos", reflect.TypeOf((*MockGitHubAppClient)(nil).ListInstallationRepos), ctx, creds, installationID, query, page)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstallationRepos", reflect.TypeOf((*MockGitHubAppClient)(nil).ListInstallationRepos), ctx, creds, installationID, page)
 }
 
 // ListInstallations mocks base method.

--- a/pkg/services/git_integration_github_app.go
+++ b/pkg/services/git_integration_github_app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-github/v88/github"
 	"github.com/google/uuid"
 	"github.com/gosimple/slug"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -230,29 +231,68 @@ func (s *gitIntegrationService) ListInstallations(ctx context.Context, integrati
 }
 
 // ListRepositories proxies repository discovery through the installation,
-// minting a token per call.
-func (s *gitIntegrationService) ListRepositories(ctx context.Context, integrationID, query string, page int, installationID int64) (*githubapp.RepoPage, *errors.ServiceError) {
+// minting a token per call. When installationUUID is set it lists that one
+// installation's page; when empty it aggregates page N across every
+// installation of the integration.
+func (s *gitIntegrationService) ListRepositories(ctx context.Context, integrationID string, page int, installationUUID string) (*githubapp.RepoPage, *errors.ServiceError) {
 	integration, creds, serr := s.installedApp(ctx, integrationID, auth.ActionRead)
 	if serr != nil {
 		return nil, serr
 	}
 
-	if installationID == 0 {
-		installations, serr := s.installations.ListByIntegrationID(ctx, integration.ID)
+	if installationUUID != "" {
+		installation, serr := s.installations.GetByIntegrationAndID(ctx, integration.ID, installationUUID)
 		if serr != nil {
 			return nil, serr
 		}
-		if len(installations) == 0 {
-			return nil, errors.BadRequest("the GitHub App has no installations yet")
+		pageResult, err := s.githubApp.ListInstallationRepos(ctx, creds, installation.InstallationID, page)
+		if err != nil {
+			return nil, errors.BadRequest("failed to list repositories: %s", err.Error())
 		}
-		installationID = installations[0].InstallationID
+		return pageResult, nil
 	}
 
-	pageResult, err := s.githubApp.ListInstallationRepos(ctx, creds, installationID, query, page)
-	if err != nil {
+	installations, serr := s.installations.ListByIntegrationID(ctx, integration.ID)
+	if serr != nil {
+		return nil, serr
+	}
+	return s.aggregateRepos(ctx, creds, installations, page)
+}
+
+// aggregateRepos fetches page N from every installation concurrently and merges
+// the results in stable installation order.
+func (s *gitIntegrationService) aggregateRepos(ctx context.Context, creds *githubapp.AppCredentials, installations []*models.GitInstallation, page int) (*githubapp.RepoPage, *errors.ServiceError) {
+	if page <= 0 {
+		page = 1
+	}
+	merged := &githubapp.RepoPage{Page: page, Repos: []githubapp.Repo{}}
+	if len(installations) == 0 {
+		return merged, nil
+	}
+
+	pages := make([]*githubapp.RepoPage, len(installations))
+	group, ctx := errgroup.WithContext(ctx)
+	for i, installation := range installations {
+		i, installation := i, installation
+		group.Go(func() error {
+			result, err := s.githubApp.ListInstallationRepos(ctx, creds, installation.InstallationID, page)
+			if err != nil {
+				return err
+			}
+			pages[i] = result
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
 		return nil, errors.BadRequest("failed to list repositories: %s", err.Error())
 	}
-	return pageResult, nil
+
+	for _, p := range pages {
+		merged.Repos = append(merged.Repos, p.Repos...)
+		merged.TotalCount += p.TotalCount
+		merged.HasNext = merged.HasNext || p.HasNext
+	}
+	return merged, nil
 }
 
 func (s *gitIntegrationService) GetRepository(ctx context.Context, integrationID, owner, repo string) (*githubapp.Repo, *errors.ServiceError) {

--- a/pkg/services/git_integration_repositories_test.go
+++ b/pkg/services/git_integration_repositories_test.go
@@ -1,0 +1,149 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Stackdome/stackdome/pkg/clients/githubapp"
+	svcerrors "github.com/Stackdome/stackdome/pkg/errors"
+	"github.com/Stackdome/stackdome/pkg/mocks"
+	"github.com/Stackdome/stackdome/pkg/models"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("GitIntegrationService.ListRepositories", func() {
+	var (
+		ctrl          *gomock.Controller
+		store         *mocks.MockGitIntegrationStore
+		installations *mocks.MockGitInstallationStore
+		appClient     *mocks.MockGitHubAppClient
+		svc           GitIntegrationService
+		ctx           context.Context
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		ctx = context.Background()
+
+		encryption, err := NewAESEncryptionService(EncryptionServiceSpec{Masterkey: strings.Repeat("k", 64)})
+		Expect(err).ToNot(HaveOccurred())
+
+		store = mocks.NewMockGitIntegrationStore(ctrl)
+		installations = mocks.NewMockGitInstallationStore(ctrl)
+		appClient = mocks.NewMockGitHubAppClient(ctrl)
+
+		permissions := mocks.NewMockPermissionService(ctrl)
+		permissions.EXPECT().Check(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		organisations := mocks.NewMockOrganisationStore(ctrl)
+		organisations.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&models.Organisation{ID: "org-1"}, nil).AnyTimes()
+		atomic := mocks.NewMockAtomicExecutor(ctrl)
+		atomic.EXPECT().WithTransaction(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, fn func(context.Context) *svcerrors.ServiceError) *svcerrors.ServiceError {
+				return fn(ctx)
+			}).AnyTimes()
+
+		// A sealed, installed GitHub App integration the service can unseal.
+		app := models.GitHubAppCredentials{AppID: 4242, Slug: "stackdome-test", PEM: "PEM"}
+		authBlob, mErr := (models.GitIntegrationAuth{GitHubApp: &app}).Marshal()
+		Expect(mErr).ToNot(HaveOccurred())
+		encrypted, eErr := encryption.EncryptData(authBlob)
+		Expect(eErr).ToNot(HaveOccurred())
+		integration := &models.GitIntegration{
+			ID:             "gi-app",
+			OrganisationID: "org-1",
+			Type:           models.GitIntegrationTypeGitHubApp,
+			Host:           "github.com",
+			Status:         models.GitIntegrationStatusInstalled,
+			EncryptedAuth:  encrypted,
+			DataHash:       gitIntegrationDataHash(authBlob),
+		}
+		store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(integration, nil).AnyTimes()
+
+		svc = NewGitIntegrationService(GitIntegrationServiceSpec{
+			Store:             store,
+			InstallationStore: installations,
+			OAuthStateStore:   mocks.NewMockOAuthStateStore(ctrl),
+			OrganisationStore: organisations,
+			AtomicExecutor:    atomic,
+			GitHubAppClient:   appClient,
+			EncryptionService: encryption,
+			Permissions:       permissions,
+			ExternalURL:       "https://hub.example.com",
+		})
+	})
+
+	Context("when an installation UUID is given", func() {
+		It("resolves the UUID and lists that installation's page", func() {
+			installations.EXPECT().GetByIntegrationAndID(gomock.Any(), "gi-app", "inst-uuid-1").
+				Return(&models.GitInstallation{ID: "inst-uuid-1", InstallationID: 77}, nil)
+			appClient.EXPECT().ListInstallationRepos(gomock.Any(), gomock.Any(), int64(77), 2).
+				Return(&githubapp.RepoPage{Page: 2, TotalCount: 3, HasNext: true, Repos: []githubapp.Repo{{FullName: "acme/a"}}}, nil)
+
+			page, serr := svc.ListRepositories(ctx, "gi-app", 2, "inst-uuid-1")
+			Expect(serr).To(BeNil())
+			Expect(page.Repos).To(HaveLen(1))
+			Expect(page.TotalCount).To(Equal(3))
+			Expect(page.HasNext).To(BeTrue())
+		})
+
+		It("returns NotFound when the UUID does not belong to the integration", func() {
+			installations.EXPECT().GetByIntegrationAndID(gomock.Any(), "gi-app", "missing").
+				Return(nil, svcerrors.NotFound("no installation 'missing' for this integration"))
+
+			page, serr := svc.ListRepositories(ctx, "gi-app", 1, "missing")
+			Expect(page).To(BeNil())
+			Expect(serr).ToNot(BeNil())
+			Expect(serr.Is404()).To(BeTrue())
+		})
+	})
+
+	Context("when no installation UUID is given", func() {
+		It("aggregates page N across every installation in order", func() {
+			installations.EXPECT().ListByIntegrationID(gomock.Any(), "gi-app").Return([]*models.GitInstallation{
+				{ID: "u-a", InstallationID: 11},
+				{ID: "u-b", InstallationID: 22},
+			}, nil)
+			appClient.EXPECT().ListInstallationRepos(gomock.Any(), gomock.Any(), int64(11), 1).
+				Return(&githubapp.RepoPage{TotalCount: 5, HasNext: true, Repos: []githubapp.Repo{{FullName: "acme/a"}}}, nil)
+			appClient.EXPECT().ListInstallationRepos(gomock.Any(), gomock.Any(), int64(22), 1).
+				Return(&githubapp.RepoPage{TotalCount: 2, HasNext: false, Repos: []githubapp.Repo{{FullName: "bob/b"}}}, nil)
+
+			page, serr := svc.ListRepositories(ctx, "gi-app", 1, "")
+			Expect(serr).To(BeNil())
+			Expect([]string{page.Repos[0].FullName, page.Repos[1].FullName}).To(Equal([]string{"acme/a", "bob/b"}))
+			Expect(page.TotalCount).To(Equal(7))
+			Expect(page.HasNext).To(BeTrue())
+			Expect(page.Page).To(Equal(1))
+		})
+
+		It("returns an empty page when there are no installations", func() {
+			installations.EXPECT().ListByIntegrationID(gomock.Any(), "gi-app").Return(nil, nil)
+
+			page, serr := svc.ListRepositories(ctx, "gi-app", 1, "")
+			Expect(serr).To(BeNil())
+			Expect(page.Repos).To(BeEmpty())
+			Expect(page.TotalCount).To(BeZero())
+			Expect(page.HasNext).To(BeFalse())
+		})
+
+		It("propagates an error when one installation fetch fails", func() {
+			installations.EXPECT().ListByIntegrationID(gomock.Any(), "gi-app").Return([]*models.GitInstallation{
+				{ID: "u-a", InstallationID: 11},
+				{ID: "u-b", InstallationID: 22},
+			}, nil)
+			appClient.EXPECT().ListInstallationRepos(gomock.Any(), gomock.Any(), int64(11), 1).
+				Return(&githubapp.RepoPage{Repos: []githubapp.Repo{{FullName: "acme/a"}}}, nil).AnyTimes()
+			appClient.EXPECT().ListInstallationRepos(gomock.Any(), gomock.Any(), int64(22), 1).
+				Return(nil, errors.New("github boom")).AnyTimes()
+
+			page, serr := svc.ListRepositories(ctx, "gi-app", 1, "")
+			Expect(page).To(BeNil())
+			Expect(serr).ToNot(BeNil())
+			Expect(serr.Code).To(Equal(svcerrors.ErrorBadRequest))
+		})
+	})
+})

--- a/pkg/services/git_integration_service.go
+++ b/pkg/services/git_integration_service.go
@@ -47,7 +47,7 @@ type GitIntegrationService interface {
 	CreateGitHubAppManifest(ctx context.Context, organisationID string) (*models.GitHubAppManifestFlow, *errors.ServiceError)
 	HandleGitHubManifestCallback(ctx context.Context, code, state string) (string, *errors.ServiceError)
 	ListInstallations(ctx context.Context, integrationID string, refresh bool) ([]*models.GitInstallation, *errors.ServiceError)
-	ListRepositories(ctx context.Context, integrationID, query string, page int, installationID int64) (*githubapp.RepoPage, *errors.ServiceError)
+	ListRepositories(ctx context.Context, integrationID string, page int, installationUUID string) (*githubapp.RepoPage, *errors.ServiceError)
 	GetRepository(ctx context.Context, integrationID, owner, repo string) (*githubapp.Repo, *errors.ServiceError)
 	ListRepositoryBranches(ctx context.Context, integrationID, owner, repo string) ([]string, *errors.ServiceError)
 	ProcessGitHubWebhook(ctx context.Context, event string, payload []byte, signature string) *errors.ServiceError

--- a/pkg/stores/git_installation.go
+++ b/pkg/stores/git_installation.go
@@ -13,6 +13,7 @@ type GitInstallationStore interface {
 	// (git_integration_id, installation_id).
 	Upsert(ctx context.Context, installation *models.GitInstallation) (*models.GitInstallation, *errors.ServiceError)
 	ListByIntegrationID(ctx context.Context, integrationID string) ([]*models.GitInstallation, *errors.ServiceError)
+	GetByIntegrationAndID(ctx context.Context, integrationID, id string) (*models.GitInstallation, *errors.ServiceError)
 	GetByIntegrationAndAccount(ctx context.Context, integrationID, accountLogin string) (*models.GitInstallation, *errors.ServiceError)
 	DeleteByInstallationID(ctx context.Context, integrationID string, installationID int64) *errors.ServiceError
 }

--- a/pkg/stores/pgstore/git_installation.go
+++ b/pkg/stores/pgstore/git_installation.go
@@ -51,6 +51,19 @@ func (s *gitInstallationStore) ListByIntegrationID(ctx context.Context, integrat
 	return installations, nil
 }
 
+func (s *gitInstallationStore) GetByIntegrationAndID(ctx context.Context, integrationID, id string) (*models.GitInstallation, *errors.ServiceError) {
+	var installation models.GitInstallation
+	if err := s.sessionFactory.New(ctx).
+		Where("git_integration_id = ? AND id = ?", integrationID, id).
+		First(&installation).Error; err != nil {
+		if stderrors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.NotFound("no installation '%s' for this integration", id)
+		}
+		return nil, errors.GeneralError("failed to get git installation: %s", err.Error())
+	}
+	return &installation, nil
+}
+
 func (s *gitInstallationStore) GetByIntegrationAndAccount(ctx context.Context, integrationID, accountLogin string) (*models.GitInstallation, *errors.ServiceError) {
 	var installation models.GitInstallation
 	if err := s.sessionFactory.New(ctx).

--- a/pkg/stores/pgstore/git_installation_test.go
+++ b/pkg/stores/pgstore/git_installation_test.go
@@ -66,6 +66,25 @@ var _ = Describe("GitInstallationStore", func() {
 		Expect(installation.InstallationID).To(Equal(int64(77)))
 	})
 
+	It("gets an installation by its own id, scoped to the integration", func() {
+		installations, err := store.ListByIntegrationID(ctx, "gi-1")
+		Expect(err).To(BeNil())
+		Expect(installations).To(HaveLen(1))
+		id := installations[0].ID
+
+		got, err := store.GetByIntegrationAndID(ctx, "gi-1", id)
+		Expect(err).To(BeNil())
+		Expect(got.InstallationID).To(Equal(int64(77)))
+
+		_, err = store.GetByIntegrationAndID(ctx, "gi-1", "does-not-exist")
+		Expect(err).ToNot(BeNil())
+		Expect(err.Is404()).To(BeTrue())
+
+		_, err = store.GetByIntegrationAndID(ctx, "other-integration", id)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Is404()).To(BeTrue())
+	})
+
 	It("deletes by installation id", func() {
 		Expect(store.DeleteByInstallationID(ctx, "gi-1", 77)).To(BeNil())
 		installations, err := store.ListByIntegrationID(ctx, "gi-1")


### PR DESCRIPTION
## What

`GET .../git-integrations/{id}/repositories` reworked so it lists repositories across **every** installation of an integration, and keys on our own id instead of GitHub's.

## Why

Two defects:
1. **Only one installation was ever listed.** When `installation_id` was omitted the service silently used `installations[0]`, so an integration with multiple installations (e.g. a personal account + an org) could never see the rest of its repos.
2. **GitHub's number leaked into the API contract.** The `installation_id` param was GitHub's `int64`. Clients already receive our `GitInstallation.ID` (UUID) in the installations list, so the API should key on the id we own.

## Changes

- `installation_id` query param: GitHub `int64` → our `GitInstallation.ID` UUID. **Breaking** — callers passing the int must switch to the UUID.
- Dropped the server-side `query` param. GitHub's installation-repos endpoint has no server-side search; clients now filter client-side (the pickers already do).
- **UUID given** → resolve via new `GitInstallationStore.GetByIntegrationAndID` (scoped to the integration) → that installation's page; miss → `NotFound`.
- **UUID empty** → fetch page N from every installation concurrently (`errgroup`), merged in stable installation order; `TotalCount` summed, `HasNext` OR'd. Zero installations → empty page instead of an error.
- Client `ListInstallationRepos` drops `query`; page size constant 100.
- Regenerated OpenAPI Go client + frontend types/zod. Frontend pickers fetch once per integration and filter locally.

## Tests

- Service (Ginkgo): UUID-given happy + not-found; aggregate merge (order / sum / OR); zero-install empty page; errgroup error propagation.
- Store: `GetByIntegrationAndID` found / not-found / wrong-integration.
- Client: paging without `query`.
- Verified live against a 2-installation GitHub App integration: aggregate returns both accounts' repos in one page; per-UUID returns that installation only; bogus UUID → 404.