### PR TITLE
Fix: Canvas click lock after delete + ToolJet template migration race

### DIFF
--- a/frontend/src/data/templates/tests/template-conversion.test.ts
+++ b/frontend/src/data/templates/tests/template-conversion.test.ts
@@ -62,12 +62,19 @@ describe("template conversion round-trip", () => {
     const tooljet = getTemplateById("tooljet")!;
     const { data } = templateToFormData(tooljet);
 
-    for (const name of ["tooljet", "tooljet-worker"]) {
-      const resource = data.spec.stack_resources.find((r) => r.name === name)!;
-      expect(resource.execution_config?.command).toEqual([
-        "./server/ee-entrypoint.sh", "npm", "run", "start:prod",
-      ]);
-    }
+    // Only the server runs the migration entrypoint. The worker must start
+    // with worker:prod — two containers running db:setup:prod concurrently
+    // block each other's migrations until statement_timeout kills one
+    // (pg error 57014).
+    const server = data.spec.stack_resources.find((r) => r.name === "tooljet")!;
+    expect(server.execution_config?.command).toEqual([
+      "./server/ee-entrypoint.sh", "npm", "run", "start:prod",
+    ]);
+    const worker = data.spec.stack_resources.find((r) => r.name === "tooljet-worker")!;
+    expect(worker.execution_config?.command).toEqual([
+      "npm", "--prefix", "server", "run", "worker:prod",
+    ]);
+    expect(worker.depends_on).toContain("tooljet");
 
     const otelStack = data.spec.stack_resources.find((r) => r.name === "otel-stack")!;
     const ports = (otelStack.ports ?? [])

--- a/frontend/src/data/templates/tooljet/stack.yaml
+++ b/frontend/src/data/templates/tooljet/stack.yaml
@@ -100,9 +100,7 @@ services:
       - "6379"
 
   postgresql:
-    # Pinned to match upstream ToolJet's own compose; newer majors are untested
-    # against this ToolJet release.
-    image: postgres:13
+    image: postgres:16
     expose:
       - "5432"
     volumes:

--- a/frontend/src/data/templates/tooljet/stack.yaml
+++ b/frontend/src/data/templates/tooljet/stack.yaml
@@ -54,10 +54,18 @@ services:
 
   tooljet-worker:
     image: tooljet/tooljet:v3.20.189-lts
-    command: ./server/ee-entrypoint.sh npm run start:prod
+    # Unlike the server, the worker must NOT run ee-entrypoint.sh: the
+    # entrypoint runs db:setup:prod, and two containers migrating the same
+    # database concurrently deadlock each other until statement_timeout kills
+    # one of them (pg error 57014, "canceling statement due to statement
+    # timeout"). Upstream runs workers with worker:prod, which just starts the
+    # process. Depending on tooljet guarantees the schema is fully migrated
+    # before the worker boots.
+    command: npm --prefix server run worker:prod
     depends_on:
       - postgresql
       - redis
+      - tooljet
     environment:
       WORKER: "true"
       TOOLJET_HOST: "${tooljet.public_url}"

--- a/frontend/src/pages/secrets/components/secret-list.tsx
+++ b/frontend/src/pages/secrets/components/secret-list.tsx
@@ -104,13 +104,17 @@ export function SecretList({ secrets, onEdit, onDelete, canWrite }: SecretListPr
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" className="w-[160px]">
-                        <DropdownMenuItem onClick={() => onEdit(secret)}>
+                        {/* Both items open dialogs; deferred so the dialog
+                            mounts only after the menu has closed and released
+                            its body pointer-events lock.
+                            See https://github.com/radix-ui/primitives/issues/1836 */}
+                        <DropdownMenuItem onSelect={() => setTimeout(() => onEdit(secret), 0)}>
                           <Edit className="h-4 w-4" />
                         Edit
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           className="text-danger focus:text-danger"
-                          onClick={() => onDelete(secret)}
+                          onSelect={() => setTimeout(() => onDelete(secret), 0)}
                         >
                           <Trash2 className="h-4 w-4" />
                         Delete

--- a/frontend/src/pages/stacks/components/editor/canvas-editor-shell.tsx
+++ b/frontend/src/pages/stacks/components/editor/canvas-editor-shell.tsx
@@ -205,9 +205,15 @@ export function CanvasEditorShell({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-[180px]">
+        {/* Defer the dialog-opening callback until after the menu has fully
+            closed. Radix's DropdownMenu→Dialog composition races the menu's
+            close (which resets document.body.style.pointerEvents) against the
+            dialog's mount, and can leave pointer-events "none" on body forever
+            once the dialog unmounts.
+            See https://github.com/radix-ui/primitives/issues/1836 */}
         <DropdownMenuItem
           className="text-danger focus:text-danger"
-          onClick={onDelete}
+          onSelect={() => setTimeout(() => onDelete(), 0)}
           disabled={!canDeleteStack}
         >
           <Trash2 className="size-4 text-danger" />

--- a/frontend/src/pages/stacks/components/editor/deploy-pill.tsx
+++ b/frontend/src/pages/stacks/components/editor/deploy-pill.tsx
@@ -116,7 +116,10 @@ export function DeployPill({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-[200px]">
-            <DropdownMenuItem onClick={onDiscardDraft}>
+            {/* Deferred so the confirm dialog mounts only after the menu has
+                closed and released its body pointer-events lock.
+                See https://github.com/radix-ui/primitives/issues/1836 */}
+            <DropdownMenuItem onSelect={() => setTimeout(() => onDiscardDraft(), 0)}>
               <Undo2 className="size-4" />
               Discard draft changes
             </DropdownMenuItem>

--- a/frontend/src/pages/stacks/components/editor/tests/canvas-editor-shell.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tests/canvas-editor-shell.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { render, screen, within, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, within, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { CanvasEditorShell } from "../canvas-editor-shell";
 import { SYNC_STATUS } from "@/pages/stacks/lib/draft-sync/constants";
 import { EDITOR_TABS } from "../editor-tabs";
@@ -142,6 +143,28 @@ describe("CanvasEditorShell actions menu", () => {
     render(<CanvasEditorShell {...base} nameEditable={false} stackName="api" isActive dirtyTotal={2} />);
     expect(screen.getByLabelText("Stack actions")).toBeInTheDocument();
     expect(screen.queryByText("Discard all changes")).toBeNull();
+  });
+
+  it("defers onDelete until after the menu has closed, avoiding the Radix pointer-events lock", async () => {
+    // Regression test for a Radix DropdownMenu -> AlertDialog composition bug:
+    // if the dialog-opening callback fires synchronously from the menu item,
+    // the menu's close and the dialog's mount race and can leave
+    // document.body.style.pointerEvents stuck at "none" forever (the dialog
+    // captures "none" as the value to restore on unmount). Deferring the
+    // callback lets the menu finish closing (and reset pointer-events) before
+    // the dialog mounts. See https://github.com/radix-ui/primitives/issues/1836
+    const user = userEvent.setup();
+    const pointerEventsAtCall: string[] = [];
+    const onDelete = vi.fn(() => {
+      pointerEventsAtCall.push(document.body.style.pointerEvents);
+    });
+    render(<CanvasEditorShell {...base} nameEditable={false} stackName="api" isActive onDelete={onDelete} />);
+    await user.click(screen.getByLabelText("Stack actions"), { pointerEventsCheck: 0 });
+    await user.click(await screen.findByText("Delete stack"), { pointerEventsCheck: 0 });
+    await waitFor(() => expect(onDelete).toHaveBeenCalled());
+    // At the moment the dialog-opening callback runs, the menu must already
+    // have released its body pointer-events lock.
+    expect(pointerEventsAtCall[0]).not.toBe("none");
   });
 });
 


### PR DESCRIPTION
## 📝 What this does
Fixes two bugs hit when creating a stack from the ToolJet template and deleting it: the whole app became unclickable after deleting a stack, and the ToolJet template's first deploy crash-looped with Postgres `57014` migration errors. Also bumps the template's Postgres to 16.

## 🔀 Changes
- Deferred dialog-opening dropdown menu items (stack delete, discard draft, secret edit/delete) so the Radix menu fully closes before the dialog mounts — the synchronous path left `document.body` stuck at `pointer-events: none` after the dialog unmounted (radix-ui/primitives#1836), killing all clicks until reload.
- Added a regression test asserting the menu has released its pointer-events lock by the time the deferred callback fires.
- Stopped the ToolJet template's worker from running the migration entrypoint; it now starts with `worker:prod` like upstream and depends on the server, so migrations run exactly once instead of two concurrent runs cancelling each other via `statement_timeout`.
- Updated the template conversion test to pin the split server/worker commands and the new worker dependency.
- Bumped the template's Postgres from 13 to 16 (fresh stacks only; existing stacks keep their volume).

## 🧪 How to test
- [ ] Create a stack from the ToolJet template, deploy, then delete it — after the toast, clicks still register everywhere.
- [ ] Discard draft changes via the deploy pill menu and cancel the dialog — page stays clickable.
- [ ] Deploy the ToolJet template fresh — `tooljet` runs migrations once, `tooljet-worker` waits for it and boots without pg `57014` errors, postgres runs 16.