### PR TITLE
Fix: terminal-style command inputs, clearable port field

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "react-dom": "^19.1.0",
     "react-lazylog": "^4.5.3",
     "react-router-dom": "^7.5.3",
+    "shlex": "^3.0.0",
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.5",
     "use-debounce": "^10.0.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       react-router-dom:
         specifier: ^7.5.3
         version: 7.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      shlex:
+        specifier: ^3.0.0
+        version: 3.0.0
       tailwind-merge:
         specifier: ^3.2.0
         version: 3.2.0
@@ -3063,6 +3066,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shlex@3.0.0:
+    resolution: {integrity: sha512-jHPXQQk9d/QXCvJuLPYMOYWez3c43sORAgcIEoV7bFv5AJSJRAOyw5lQO12PMfd385qiLRCaDt7OtEzgrIGZUA==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -6346,6 +6352,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shlex@3.0.0: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/frontend/src/data/templates/tests/template-conversion.test.ts
+++ b/frontend/src/data/templates/tests/template-conversion.test.ts
@@ -67,13 +67,13 @@ describe("template conversion round-trip", () => {
     // block each other's migrations until statement_timeout kills one
     // (pg error 57014).
     const server = data.spec.stack_resources.find((r) => r.name === "tooljet")!;
-    expect(server.execution_config?.command).toEqual([
-      "./server/ee-entrypoint.sh", "npm", "run", "start:prod",
-    ]);
+    expect(server.execution_config?.command).toBe(
+      "./server/ee-entrypoint.sh npm run start:prod",
+    );
     const worker = data.spec.stack_resources.find((r) => r.name === "tooljet-worker")!;
-    expect(worker.execution_config?.command).toEqual([
-      "npm", "--prefix", "server", "run", "worker:prod",
-    ]);
+    expect(worker.execution_config?.command).toBe(
+      "npm --prefix server run worker:prod",
+    );
     expect(worker.depends_on).toContain("tooljet");
 
     const otelStack = data.spec.stack_resources.find((r) => r.name === "otel-stack")!;

--- a/frontend/src/lib/docker-compose-converter.ts
+++ b/frontend/src/lib/docker-compose-converter.ts
@@ -7,11 +7,12 @@ import type {
   DockerComposeService,
   DockerComposeVolume,
 } from "@/types/docker-compose";
-import type {
-  FormEnvVarData,
-  FormStackData,
-  FormStackResourceData,
-  FormVolumeExtendedData,
+import {
+  argvToText,
+  type FormEnvVarData,
+  type FormStackData,
+  type FormStackResourceData,
+  type FormVolumeExtendedData,
 } from "@/pages/stacks/schemas/form-schema";
 
 export interface ConversionResult {
@@ -719,21 +720,22 @@ function convertEnvironmentVariables(
 function convertCommand(
   command: DockerComposeService['command'],
   warnings: ConversionWarning[]
-): string[] {
-  if (!command) return [];
+): string | undefined {
+  if (!command) return undefined;
 
   if (typeof command === 'string') {
-    // Split string command into array
-    return command.split(' ').filter(part => part.length > 0);
+    // Compose shell-form string is already the form's terminal-style text.
+    return command.trim() || undefined;
   } else if (Array.isArray(command)) {
-    return command;
+    // Compose exec-form array → quote-aware text (form field format).
+    return argvToText(command);
   } else {
     warnings.push({
       type: 'partial',
       message: 'Invalid command format. Please review and set manually.',
       dockerComposeField: 'command',
     });
-    return [];
+    return undefined;
   }
 }
 

--- a/frontend/src/lib/docker-compose-converter.ts
+++ b/frontend/src/lib/docker-compose-converter.ts
@@ -727,7 +727,6 @@ function convertCommand(
     // Compose shell-form string is already the form's terminal-style text.
     return command.trim() || undefined;
   } else if (Array.isArray(command)) {
-    // Compose exec-form array → quote-aware text (form field format).
     return argvToText(command);
   } else {
     warnings.push({

--- a/frontend/src/lib/tests/docker-compose-converter.test.ts
+++ b/frontend/src/lib/tests/docker-compose-converter.test.ts
@@ -126,7 +126,7 @@ describe('convertDockerComposeToStackData', () => {
     expect(resource.source?.git).toBeDefined();
     expect(resource.source!.git!.build_context).toBe('./api');
     expect(resource.source!.git!.dockerfile_path).toBe('Dockerfile.prod');
-    expect(resource.execution_config.command).toEqual(['npm', 'start']);
+    expect(resource.execution_config.command).toBe('npm start');
     expect(resource.execution_config.environment_variables).toHaveLength(2);
 
     // Should have warnings about build args and placeholders
@@ -337,7 +337,7 @@ describe('convertServiceToStackResource', () => {
     expect(result.data!.sourceType).toBe('git');
     expect(result.data!.source?.git).toBeDefined();
     expect(result.data!.source!.git!.build_context).toBe('./backend');
-    expect(result.data!.execution_config.command).toEqual(['npm', 'run', 'start:prod']);
+    expect(result.data!.execution_config.command).toBe('npm run start:prod');
   });
 
   it('should fail when neither image nor build is specified', () => {
@@ -493,10 +493,10 @@ describe('convertServiceToStackResource', () => {
     const resultArray = convertServiceToStackResource('app2', serviceArray);
 
     expect(resultString.success).toBe(true);
-    expect(resultString.data!.execution_config.command).toEqual(['npm', 'start']);
+    expect(resultString.data!.execution_config.command).toBe('npm start');
 
     expect(resultArray.success).toBe(true);
-    expect(resultArray.data!.execution_config.command).toEqual(['npm', 'run', 'start:prod']);
+    expect(resultArray.data!.execution_config.command).toBe('npm run start:prod');
   });
 
   it('should map internal ports as exposed when external mapping exists', () => {

--- a/frontend/src/pages/stacks/components/editor/canvas-editor-shell.tsx
+++ b/frontend/src/pages/stacks/components/editor/canvas-editor-shell.tsx
@@ -145,7 +145,16 @@ export function CanvasEditorShell({
   // floating drawer stack; header rows and the canvas shift left by this much
   // so the drawer pushes content instead of covering it.
   const [drawerInset, setDrawerInset] = useState(0);
-  const drawerInsetCtx = useMemo(() => ({ setInset: setDrawerInset }), []);
+  // Ops views overlay the (always-mounted) canvas, but the drawer stack renders
+  // position:fixed above that overlay — so on non-architecture tabs it must hide
+  // itself instead. The stored inset survives suppression, so switching back to
+  // Architecture restores both the drawer and the pushed-left chrome.
+  const drawerSuppressed = activeTab !== EDITOR_TABS.architecture;
+  const drawerInsetCtx = useMemo(
+    () => ({ setInset: setDrawerInset, suppressed: drawerSuppressed }),
+    [drawerSuppressed],
+  );
+  const effectiveDrawerInset = drawerSuppressed ? 0 : drawerInset;
 
   // Header status pill: "Deleting" overrides everything, "Not deployed" covers a
   // stack that has never completed a release, otherwise health drives the pill.
@@ -240,7 +249,7 @@ export function CanvasEditorShell({
       {collapsed && (
         <div
           className="flex h-11 flex-none items-center gap-3 border-b border-border px-4 transition-[margin] duration-[260ms] animate-in fade-in slide-in-from-top-1"
-          style={{ marginRight: drawerInset }}
+          style={{ marginRight: effectiveDrawerInset }}
         >
           <span className="truncate text-[14px] font-medium text-foreground">{stackName}</span>
           {pillLabel && (
@@ -292,7 +301,7 @@ export function CanvasEditorShell({
           {/* Stack-title header — identity only (fade/translate on expand per design sd-fade) */}
           <div
             className="flex-none px-7 pt-6 transition-[margin] duration-[260ms] animate-in fade-in slide-in-from-top-1"
-            style={{ marginRight: drawerInset }}
+            style={{ marginRight: effectiveDrawerInset }}
           >
             {/* Chevron sits at the row's right so the title stays flush-left with
                 the subtitle + endpoints below it (no collapse-toggle indent). */}
@@ -349,7 +358,7 @@ export function CanvasEditorShell({
           {/* Tab + action rail */}
           <div
             className="flex-none flex items-center gap-2 border-b border-border px-7 py-[18px] transition-[margin] duration-[260ms] animate-in fade-in slide-in-from-top-1"
-            style={{ marginRight: drawerInset }}
+            style={{ marginRight: effectiveDrawerInset }}
           >
             {TAB_ITEMS.map(({ id, label, Icon }) => {
               const active = activeTab === id;
@@ -386,7 +395,7 @@ export function CanvasEditorShell({
       {/* Mode body. The canvas is always mounted (keeps its drawer/selection);
           ops views overlay it. Ops views own their own max-width + padding. */}
       <div className="relative min-h-0 flex-1 overflow-hidden">
-        <div className="absolute inset-y-0 left-0 transition-[right] duration-[260ms]" style={{ right: drawerInset }}>
+        <div className="absolute inset-y-0 left-0 transition-[right] duration-[260ms]" style={{ right: effectiveDrawerInset }}>
           <DrawerInsetContext.Provider value={drawerInsetCtx}>{architecture}</DrawerInsetContext.Provider>
           {activeTab === EDITOR_TABS.architecture && (
             <DeployPill

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-stack.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-stack.tsx
@@ -83,9 +83,8 @@ export function DrawerStack({ panels, front, onTruncate, onPop, onCloseAll }: Dr
             data-testid={`drawer-panel-${i}`}
             className={cn(
               "fixed flex w-[680px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg animate-in slide-in-from-right-8 fade-in duration-[260ms]",
-              // Panels are position:fixed, so the ops-view overlay can't cover
-              // them — hide (not unmount) while an ops tab is active so the
-              // stack and its state survive the round trip.
+              // position:fixed escapes the ops-view overlay — hide (not
+              // unmount) so the stack's state survives the tab round trip.
               suppressed && "hidden",
             )}
             style={{

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-stack.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-stack.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
 import { entryKey, type DrawerEntry } from "@/pages/stacks/lib/canvas/drawer-stack";
 import {
   computeDrawerInset,
@@ -40,7 +41,7 @@ interface DrawerStackProps {
  */
 export function DrawerStack({ panels, front, onTruncate, onPop, onCloseAll }: DrawerStackProps) {
   const open = panels.length > 0;
-  const { setInset } = useDrawerInset();
+  const { setInset, suppressed } = useDrawerInset();
 
   // Report the occupied width (front panel + back-panel stagger, clamped like
   // max-w-[calc(100vw-24px)]) so the shell can push canvas + rail actions left.
@@ -58,7 +59,7 @@ export function DrawerStack({ panels, front, onTruncate, onPop, onCloseAll }: Dr
   useEffect(() => () => setInset(0), [setInset]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || suppressed) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Escape" || e.defaultPrevented) return;
       if (e.shiftKey) onCloseAll();
@@ -66,7 +67,7 @@ export function DrawerStack({ panels, front, onTruncate, onPop, onCloseAll }: Dr
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, onPop, onCloseAll]);
+  }, [open, suppressed, onPop, onCloseAll]);
 
   if (!open) return null;
   const frontIdx = panels.length - 1;
@@ -80,7 +81,13 @@ export function DrawerStack({ panels, front, onTruncate, onPop, onCloseAll }: Dr
           <aside
             key={entryKey(entry)}
             data-testid={`drawer-panel-${i}`}
-            className="fixed flex w-[680px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg animate-in slide-in-from-right-8 fade-in duration-[260ms]"
+            className={cn(
+              "fixed flex w-[680px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg animate-in slide-in-from-right-8 fade-in duration-[260ms]",
+              // Panels are position:fixed, so the ops-view overlay can't cover
+              // them — hide (not unmount) while an ops tab is active so the
+              // stack and its state survive the round trip.
+              suppressed && "hidden",
+            )}
             style={{
               top: BASE_INSET_PX + STAGGER_Y_PX * depth,
               bottom: BASE_INSET_PX + STAGGER_Y_PX * depth,

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -215,8 +215,11 @@ function StackResourceConfigurationTabImpl({
         const next = { ...port, ...patch };
         // Keep the auto-derived name tracking the number so the output key stays
         // meaningful (url.port-8080). Only re-derive while the name is still the
-        // auto value; a name the user set by hand is left untouched.
-        if (patch.number !== undefined && (!port.name || port.name === `port-${port.number}`)) {
+        // auto value; a name the user set by hand is left untouched. Matching the
+        // auto PATTERN (not `port-${port.number}`) keeps re-derivation working
+        // after the number was cleared — the old name no longer matches the
+        // (now-undefined) number but is still ours to overwrite.
+        if (patch.number !== undefined && (!port.name || /^port-(\d+|undefined)$/.test(port.name))) {
           next.name = `port-${patch.number}`;
         }
         return next;

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -627,10 +627,11 @@ function StackResourceConfigurationTabImpl({
                 <Input
                   id={`port-number-${index}-${pidx}`}
                   inputMode="numeric"
-                  value={port.number?.toString() || ""}
-                  onChange={(e) =>
-                    updatePort(pidx, { number: parseInt(e.target.value.replace(/\D/g, "")) || 0 })
-                  }
+                  value={port.number?.toString() ?? ""}
+                  onChange={(e) => {
+                    const digits = e.target.value.replace(/\D/g, "");
+                    updatePort(pidx, { number: digits === "" ? undefined : parseInt(digits, 10) });
+                  }}
                   className={`h-9 w-[84px] shrink-0 font-mono text-[13px] ${getError(errors, `ports.${pidx}.number`) ? "border-danger" : ""}`}
                   required
                 />

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab.tsx
@@ -213,12 +213,9 @@ function StackResourceConfigurationTabImpl({
       ports: (draft.ports || []).map((port: Port, i: number) => {
         if (i !== pidx) return port;
         const next = { ...port, ...patch };
-        // Keep the auto-derived name tracking the number so the output key stays
-        // meaningful (url.port-8080). Only re-derive while the name is still the
-        // auto value; a name the user set by hand is left untouched. Matching the
-        // auto PATTERN (not `port-${port.number}`) keeps re-derivation working
-        // after the number was cleared — the old name no longer matches the
-        // (now-undefined) number but is still ours to overwrite.
+        // Re-derive the auto name (url.port-8080) only while it still matches the
+        // auto PATTERN — not the current number, which a cleared field desyncs —
+        // so a hand-set name is never overwritten.
         if (patch.number !== undefined && (!port.name || /^port-(\d+|undefined)$/.test(port.name))) {
           next.name = `port-${patch.number}`;
         }

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/deployment-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/deployment-tab.tsx
@@ -20,7 +20,7 @@ interface StackResourceDeploymentTabProps {
   onPatchInitSpec: (patch: Partial<NonNullable<FormStackResourceData["init_spec"]>>) => void;
   /** Patch the command/args fields of `execution_config`, preserving other
    *  nested keys (notably `environment_variables`). Identity must be stable. */
-  onPatchExecCommandArgs: (patch: { command?: string[]; args?: string[] }) => void;
+  onPatchExecCommandArgs: (patch: { command?: string; args?: string }) => void;
   onDiscardField?: (path: string) => void;
 }
 
@@ -61,7 +61,7 @@ function StackResourceDeploymentTabImpl({
           label="Init command"
           htmlFor={`init-command-${index}`}
           alignTop
-          hint="Comma-separate the executable and its segments."
+          hint="Type as in a terminal; quotes group arguments. Not run in a shell — $VARS won't expand."
         >
           <DirtyField
             draft={draft}
@@ -72,13 +72,9 @@ function StackResourceDeploymentTabImpl({
           >
             <Input
               id={`init-command-${index}`}
-              value={draft.init_spec?.command?.join(",") || ""}
-              onChange={(e) =>
-                onPatchInitSpec({
-                  command: e.target.value.split(",").map((s) => s.trim()).filter(Boolean),
-                })
-              }
-              placeholder="e.g., sh,/scripts/init.sh"
+              value={draft.init_spec?.command ?? ""}
+              onChange={(e) => onPatchInitSpec({ command: e.target.value })}
+              placeholder="e.g., sh /scripts/init.sh"
               className="h-9 font-mono text-[12.5px]"
             />
           </DirtyField>
@@ -93,13 +89,9 @@ function StackResourceDeploymentTabImpl({
           >
             <Input
               id={`init-args-${index}`}
-              value={draft.init_spec?.args?.join(",") || ""}
-              onChange={(e) =>
-                onPatchInitSpec({
-                  args: e.target.value.split(",").map((s) => s.trim()).filter(Boolean),
-                })
-              }
-              placeholder="e.g., arg1,arg2,arg3"
+              value={draft.init_spec?.args ?? ""}
+              onChange={(e) => onPatchInitSpec({ args: e.target.value })}
+              placeholder="e.g., arg1 arg2 arg3"
               className="h-9 font-mono text-[12.5px]"
             />
           </DirtyField>
@@ -111,7 +103,7 @@ function StackResourceDeploymentTabImpl({
           label="Command"
           htmlFor={`exec-command-${index}`}
           alignTop
-          hint="Overrides the container's default ENTRYPOINT."
+          hint="Overrides the container's default ENTRYPOINT. Type as in a terminal; quotes group arguments."
         >
           <DirtyField
             draft={draft}
@@ -122,13 +114,9 @@ function StackResourceDeploymentTabImpl({
           >
             <Input
               id={`exec-command-${index}`}
-              value={draft.execution_config?.command?.join(",") || ""}
-              onChange={(e) =>
-                onPatchExecCommandArgs({
-                  command: e.target.value.split(",").map((s) => s.trim()).filter(Boolean),
-                })
-              }
-              placeholder="e.g., node,server.js"
+              value={draft.execution_config?.command ?? ""}
+              onChange={(e) => onPatchExecCommandArgs({ command: e.target.value })}
+              placeholder="e.g., node server.js"
               className="h-9 font-mono text-[12.5px]"
             />
           </DirtyField>
@@ -143,13 +131,9 @@ function StackResourceDeploymentTabImpl({
           >
             <Input
               id={`exec-args-${index}`}
-              value={draft.execution_config?.args?.join(",") || ""}
-              onChange={(e) =>
-                onPatchExecCommandArgs({
-                  args: e.target.value.split(",").map((s) => s.trim()).filter(Boolean),
-                })
-              }
-              placeholder="e.g., --port=3000,--verbose"
+              value={draft.execution_config?.args ?? ""}
+              onChange={(e) => onPatchExecCommandArgs({ args: e.target.value })}
+              placeholder="e.g., --port=3000 --verbose"
               className="h-9 font-mono text-[12.5px]"
             />
           </DirtyField>

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/dirty-field.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/dirty-field.tsx
@@ -59,13 +59,15 @@ export function DirtyField({
   // 4px brand stripe aligns with the accordion border. Padding pushes children
   // back to the original FieldShell edge, so labels and inputs stay flush.
   // Compact mode (ledger rows) skips the stripe entirely — the brand tint and
-  // reset arrow already mark the row, and rows sit flush against hairlines.
+  // reset arrow already mark the row, and rows sit flush against hairlines. Its
+  // own pl/-ml pair bleeds the tint slightly past the control's left edge so
+  // the wash doesn't look cut off flush against the input border.
   return (
     <div
       className={cn(
         "transition-colors",
         compact
-          ? "rounded-md py-1 pr-1"
+          ? "rounded-md py-1 pr-1 pl-1.5 -ml-1.5"
           : cn(
             "border-l-4 -ml-5 pl-4 py-1 pr-2",
             dirty ? "border-l-brand" : "border-l-transparent",

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/ledger.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/ledger.tsx
@@ -126,7 +126,7 @@ export function LedgerRow({
     <div className={cn("border-b border-secondary/80 py-1", className)}>
       <div
         className={cn(
-          "flex gap-4 rounded-md px-1.5 py-1.5 transition-colors hover:bg-muted/20",
+          "flex gap-4 rounded-md px-1.5 py-1.5",
           alignTop ? "items-start" : "items-center",
         )}
       >

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/use-resource-tab-props.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/use-resource-tab-props.ts
@@ -104,7 +104,7 @@ export function useResourceTabProps(args: {
     onChangeRef.current(indexRef.current, { ...r, init_spec: { ...r.init_spec, ...patch } });
   }, []);
 
-  const onPatchExecCommandArgs = useCallback((patch: { command?: string[]; args?: string[] }) => {
+  const onPatchExecCommandArgs = useCallback((patch: { command?: string; args?: string }) => {
     const r = resourceRef.current;
     onChangeRef.current(indexRef.current, { ...r, execution_config: { ...r.execution_config, ...patch } });
   }, []);

--- a/frontend/src/pages/stacks/lib/canvas/drawer-inset.ts
+++ b/frontend/src/pages/stacks/lib/canvas/drawer-inset.ts
@@ -8,9 +8,12 @@ import { createContext, useContext } from "react";
  */
 export interface DrawerInset {
   setInset: (px: number) => void;
+  /** True while an ops view (Deployments/Logs/Metrics) overlays the canvas —
+   *  the drawer stack stays mounted but hides itself and mutes its hotkeys. */
+  suppressed: boolean;
 }
 
-export const DrawerInsetContext = createContext<DrawerInset>({ setInset: () => {} });
+export const DrawerInsetContext = createContext<DrawerInset>({ setInset: () => {}, suppressed: false });
 
 export function useDrawerInset(): DrawerInset {
   return useContext(DrawerInsetContext);

--- a/frontend/src/pages/stacks/schemas/form-schema.ts
+++ b/frontend/src/pages/stacks/schemas/form-schema.ts
@@ -40,6 +40,13 @@ export function textToArgv(text: string | undefined): string[] | undefined {
   return trimmed ? shlexSplit(trimmed) : undefined;
 }
 
+/** Save-path variant: an emptied field must serialize as an EXPLICIT empty
+ *  array — gorm's Updates() skips absent fields, so `undefined` would make a
+ *  cleared command impossible to remove server-side. */
+function textToArgvExplicit(text: string | undefined): string[] {
+  return textToArgv(text) ?? [];
+}
+
 /** Zod-level check that a command text field will shlex-split cleanly. */
 function refineArgvText(text: string | undefined, ctx: z.RefinementCtx, path: (string | number)[]) {
   if (!text?.trim()) return;
@@ -48,7 +55,7 @@ function refineArgvText(text: string | undefined, ctx: z.RefinementCtx, path: (s
   } catch {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "Unbalanced quotes",
+      message: "Unclosed quote or trailing backslash",
       path,
     });
   }
@@ -133,7 +140,7 @@ const FormStackResourceSchema = ApiStackResourceSchema.extend({
   // enforced in superRefine below.
   ports: z.array(ApiPortSchema.extend({
     name: z.string().optional(),
-    number: z.number().optional(),
+    number: z.number().int().optional(),
   })).optional(),
   // Command/args as terminal-style text (see argvToText/textToArgv).
   init_spec: z.object({
@@ -344,25 +351,31 @@ function convertFormResourceToApiResource(
   const processedExecutionConfig = rest.execution_config
     ? {
       ...rest.execution_config,
-      command: textToArgv(rest.execution_config.command),
-      args: textToArgv(rest.execution_config.args),
+      command: textToArgvExplicit(rest.execution_config.command),
+      args: textToArgvExplicit(rest.execution_config.args),
       environment_variables: apiEnvVars,
     }
     : undefined;
 
-  // Empty init command AND args → drop init_spec entirely rather than sending
-  // an empty object.
-  const initCommand = textToArgv(rest.init_spec?.command);
-  const initArgs = textToArgv(rest.init_spec?.args);
-  const processedInitSpec = initCommand || initArgs
-    ? { command: initCommand, args: initArgs }
+  // A form init_spec exists once loaded from the server or touched in the
+  // drawer — keep sending it (with explicit empty arrays) so clearing the
+  // fields actually clears them server-side. Only a resource that never had
+  // an init_spec omits it.
+  const processedInitSpec = rest.init_spec
+    ? {
+      command: textToArgvExplicit(rest.init_spec.command),
+      args: textToArgvExplicit(rest.init_spec.args),
+    }
     : undefined;
 
   // The API requires a port name; derive `port-<number>` when the form left it
   // blank (k8s port names must contain a letter, so a bare number won't do).
   const apiPorts = rest.ports?.map((port) => ({
     ...port,
-    name: port.name && port.name.trim() !== "" ? port.name : `port-${port.number}`,
+    // A null number can't produce a meaningful auto-name ("port-undefined");
+    // validation requires the number before save, so this only guards direct
+    // callers of the exported converter.
+    name: port.name && port.name.trim() !== "" ? port.name : port.number != null ? `port-${port.number}` : undefined,
   }));
 
   return {

--- a/frontend/src/pages/stacks/schemas/form-schema.ts
+++ b/frontend/src/pages/stacks/schemas/form-schema.ts
@@ -3,6 +3,7 @@
  * These extend the API schemas with additional UI-specific fields and validations
  */
 import { z } from "zod";
+import { join as shlexJoin, split as shlexSplit } from "shlex";
 import {
   ApiStackResourceSchema,
   ApiPortSchema,
@@ -23,6 +24,35 @@ import { splitImageRef } from "@/pages/stacks/lib/image-ref";
  * Form-specific UI schema additions
  */
 const FormGitRevisionTypeSchema = z.enum(["commit", "branch", "tag"]);
+
+/**
+ * Command/args are argv arrays in the API (K8s exec form). The form holds them
+ * as a single terminal-style string so typing is never re-parsed per keystroke;
+ * conversion happens only here, at the load/save boundary. shlex keeps the
+ * round-trip lossless for quoted arguments (e.g. `sh -c 'a && b'`).
+ */
+export function argvToText(argv: string[] | undefined): string | undefined {
+  return argv && argv.length > 0 ? shlexJoin(argv) : undefined;
+}
+
+export function textToArgv(text: string | undefined): string[] | undefined {
+  const trimmed = text?.trim();
+  return trimmed ? shlexSplit(trimmed) : undefined;
+}
+
+/** Zod-level check that a command text field will shlex-split cleanly. */
+function refineArgvText(text: string | undefined, ctx: z.RefinementCtx, path: (string | number)[]) {
+  if (!text?.trim()) return;
+  try {
+    shlexSplit(text);
+  } catch {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Unbalanced quotes",
+      path,
+    });
+  }
+}
 
 const FormEnvVarSchema = z.union([
   z.object({
@@ -98,17 +128,43 @@ const FormStackResourceSchema = ApiStackResourceSchema.extend({
   stashedGitSource: ApiGitSourceSchema.optional(),
   stashedImageSource: ApiImageSourceSchema.optional(),
   // Port name is optional in the form — the API requires it, so we auto-derive
-  // `port-<number>` on save rather than asking the user for it.
-  ports: z.array(ApiPortSchema.extend({ name: z.string().optional() })).optional(),
+  // `port-<number>` on save rather than asking the user for it. Number is
+  // optional in the form so the field can be cleared while typing; presence is
+  // enforced in superRefine below.
+  ports: z.array(ApiPortSchema.extend({
+    name: z.string().optional(),
+    number: z.number().optional(),
+  })).optional(),
+  // Command/args as terminal-style text (see argvToText/textToArgv).
+  init_spec: z.object({
+    command: z.string().optional(),
+    args: z.string().optional(),
+  }).optional(),
   // Override execution_config to use our form env var schema. The
   // environment_variables list holds literal env-var rows (`from: "stack"`);
-  // the API array is reconstructed in the converter on save.
+  // the API array is reconstructed in the converter on save. Command/args as
+  // terminal-style text, same as init_spec.
   execution_config: z.object({
-    command: z.array(z.string()).optional(),
-    args: z.array(z.string()).optional(),
+    command: z.string().optional(),
+    args: z.string().optional(),
     environment_variables: z.array(FormEnvVarSchema).optional(),
   }).optional(),
 }).superRefine((data, ctx) => {
+  refineArgvText(data.init_spec?.command, ctx, ["init_spec", "command"]);
+  refineArgvText(data.init_spec?.args, ctx, ["init_spec", "args"]);
+  refineArgvText(data.execution_config?.command, ctx, ["execution_config", "command"]);
+  refineArgvText(data.execution_config?.args, ctx, ["execution_config", "args"]);
+
+  (data.ports ?? []).forEach((port, i) => {
+    if (port.number == null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Port number is required",
+        path: ["ports", i, "number"],
+      });
+    }
+  });
+
   // Drive validation off the actual `source` union (same discriminant the canvas
   // node card uses) rather than the `sourceType` UI helper, which can desync.
   if (data.source?.git) {
@@ -288,8 +344,18 @@ function convertFormResourceToApiResource(
   const processedExecutionConfig = rest.execution_config
     ? {
       ...rest.execution_config,
+      command: textToArgv(rest.execution_config.command),
+      args: textToArgv(rest.execution_config.args),
       environment_variables: apiEnvVars,
     }
+    : undefined;
+
+  // Empty init command AND args → drop init_spec entirely rather than sending
+  // an empty object.
+  const initCommand = textToArgv(rest.init_spec?.command);
+  const initArgs = textToArgv(rest.init_spec?.args);
+  const processedInitSpec = initCommand || initArgs
+    ? { command: initCommand, args: initArgs }
     : undefined;
 
   // The API requires a port name; derive `port-<number>` when the form left it
@@ -303,6 +369,7 @@ function convertFormResourceToApiResource(
     ...rest,
     ports: apiPorts,
     volume_mounts: cleanedVolumeMounts,
+    init_spec: processedInitSpec,
     execution_config: processedExecutionConfig,
   } as StackResourceUpdateRequest;
 }
@@ -381,8 +448,14 @@ function convertApiResourceToFormResource(
     sourceType,
     gitRevisionType,
     gitRevisionValue,
+    init_spec: resource.init_spec ? {
+      command: argvToText(resource.init_spec.command),
+      args: argvToText(resource.init_spec.args),
+    } : undefined,
     execution_config: resource.execution_config ? {
       ...resource.execution_config,
+      command: argvToText(resource.execution_config.command),
+      args: argvToText(resource.execution_config.args),
       environment_variables: processedEnvVars,
     } : undefined,
   };

--- a/frontend/src/pages/stacks/schemas/form-schema.ts
+++ b/frontend/src/pages/stacks/schemas/form-schema.ts
@@ -47,7 +47,6 @@ function textToArgvExplicit(text: string | undefined): string[] {
   return textToArgv(text) ?? [];
 }
 
-/** Zod-level check that a command text field will shlex-split cleanly. */
 function refineArgvText(text: string | undefined, ctx: z.RefinementCtx, path: (string | number)[]) {
   if (!text?.trim()) return;
   try {
@@ -372,9 +371,7 @@ function convertFormResourceToApiResource(
   // blank (k8s port names must contain a letter, so a bare number won't do).
   const apiPorts = rest.ports?.map((port) => ({
     ...port,
-    // A null number can't produce a meaningful auto-name ("port-undefined");
-    // validation requires the number before save, so this only guards direct
-    // callers of the exported converter.
+    // Null number → no auto-name ("port-undefined"); presence is validated before save.
     name: port.name && port.name.trim() !== "" ? port.name : port.number != null ? `port-${port.number}` : undefined,
   }));
 

--- a/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
+++ b/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
@@ -511,3 +511,100 @@ describe("FormStackSchema — depends_on cross-validation", () => {
     }
   });
 });
+
+describe("command/args text ↔ argv round-trip", () => {
+  it("loads argv arrays as terminal-style text", () => {
+    const api = baseResource({ command: ["npm", "run", "start:prod"] });
+    const form = convertApiResourceToFormResource(api as unknown as ApiResourceArg);
+    expect(form.execution_config?.command).toBe("npm run start:prod");
+    expect(form.execution_config?.args).toBe("npm run start:prod");
+  });
+
+  it("quotes argv elements containing spaces on load, losslessly", () => {
+    const api = baseResource({
+      command: ["sh", "-c", "npm run migrate && npm start"],
+      args: [],
+    });
+    const form = convertApiResourceToFormResource(api as unknown as ApiResourceArg);
+    expect(form.execution_config?.command).toBe("sh -c 'npm run migrate && npm start'");
+
+    const back = convertFormResourceToApiResource(form);
+    expect(back.execution_config?.command).toEqual(["sh", "-c", "npm run migrate && npm start"]);
+  });
+
+  it("saves quoted text as a single argv element", () => {
+    const api = baseResource({});
+    const form = convertApiResourceToFormResource(api as unknown as ApiResourceArg);
+    const edited = {
+      ...form,
+      init_spec: { command: 'node -e "console.log(1)"', args: "" },
+    };
+    const back = convertFormResourceToApiResource(edited);
+    expect(back.init_spec?.command).toEqual(["node", "-e", "console.log(1)"]);
+  });
+
+  it("drops init_spec entirely when command and args are empty", () => {
+    const api = baseResource({});
+    const form = convertApiResourceToFormResource(api as unknown as ApiResourceArg);
+    const edited = { ...form, init_spec: { command: "  ", args: "" } };
+    const back = convertFormResourceToApiResource(edited);
+    expect(back.init_spec).toBeUndefined();
+  });
+
+  it("loads an absent init_spec as undefined", () => {
+    const api = baseResource({});
+    const form = convertApiResourceToFormResource(api as unknown as ApiResourceArg);
+    expect(form.init_spec).toBeUndefined();
+  });
+});
+
+describe("FormStackResourceSchema — command text validation", () => {
+  const valid = {
+    name: "web",
+    sourceType: "image",
+    source: { image: { ref: "nginx:latest" } },
+  };
+
+  it("rejects unbalanced quotes in a command field", async () => {
+    const { FormStackResourceSchema } = await import("../form-schema");
+    const result = FormStackResourceSchema.safeParse({
+      ...valid,
+      init_spec: { command: "sh -c 'npm start" },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path.join(".") === "init_spec.command",
+      );
+      expect(issue?.message).toBe("Unbalanced quotes");
+    }
+  });
+
+  it("accepts balanced quoted command text", async () => {
+    const { FormStackResourceSchema } = await import("../form-schema");
+    const result = FormStackResourceSchema.safeParse({
+      ...valid,
+      execution_config: { command: "sh -c 'npm run migrate && npm start'" },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("FormStackResourceSchema — port number validation", () => {
+  it("rejects a port with no number (cleared field)", async () => {
+    const { FormStackResourceSchema } = await import("../form-schema");
+    const result = FormStackResourceSchema.safeParse({
+      name: "web",
+      sourceType: "image",
+      source: { image: { ref: "nginx:latest" } },
+      ports: [{ protocol: "tcp", exposed_to_public: false }],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path.join(".") === "ports.0.number",
+      );
+      expect(issue?.message).toBe("Port number is required");
+    }
+  });
+});

--- a/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
+++ b/frontend/src/pages/stacks/schemas/tests/form-schema.test.ts
@@ -543,18 +543,32 @@ describe("command/args text ↔ argv round-trip", () => {
     expect(back.init_spec?.command).toEqual(["node", "-e", "console.log(1)"]);
   });
 
-  it("drops init_spec entirely when command and args are empty", () => {
+  it("serializes a cleared init_spec as explicit empty arrays (gorm skips absent fields)", () => {
     const api = baseResource({});
     const form = convertApiResourceToFormResource(api as unknown as ApiResourceArg);
     const edited = { ...form, init_spec: { command: "  ", args: "" } };
     const back = convertFormResourceToApiResource(edited);
-    expect(back.init_spec).toBeUndefined();
+    expect(back.init_spec).toEqual({ command: [], args: [] });
   });
 
-  it("loads an absent init_spec as undefined", () => {
+  it("serializes cleared exec command/args as explicit empty arrays", () => {
+    const api = baseResource({ command: ["npm", "start"] });
+    const form = convertApiResourceToFormResource(api as unknown as ApiResourceArg);
+    const edited = {
+      ...form,
+      execution_config: { ...form.execution_config, command: "", args: "" },
+    };
+    const back = convertFormResourceToApiResource(edited);
+    expect(back.execution_config?.command).toEqual([]);
+    expect(back.execution_config?.args).toEqual([]);
+  });
+
+  it("omits init_spec for a resource that never had one", () => {
     const api = baseResource({});
     const form = convertApiResourceToFormResource(api as unknown as ApiResourceArg);
     expect(form.init_spec).toBeUndefined();
+    const back = convertFormResourceToApiResource(form);
+    expect(back.init_spec).toBeUndefined();
   });
 });
 
@@ -576,7 +590,7 @@ describe("FormStackResourceSchema — command text validation", () => {
       const issue = result.error.issues.find(
         (i) => i.path.join(".") === "init_spec.command",
       );
-      expect(issue?.message).toBe("Unbalanced quotes");
+      expect(issue?.message).toBe("Unclosed quote or trailing backslash");
     }
   });
 


### PR DESCRIPTION
## 📝 What this does
Typing a comma or space in the deployment drawer's command/args fields was impossible — every keystroke was re-parsed into an argv array and normalized, eating the character as you typed it. This replaces the comma-separated input convention with standard terminal-style text (the model every major PaaS uses), parsing to the API's argv arrays only at the load/save boundary. Also picks up a batch of drawer polish fixes found along the way.

## 🔀 Changes
- Command/args form state now holds the raw typed string; conversion to/from `string[]` happens once on load and once on save via `shlex`, so quoted arguments (`sh -c 'npm run migrate && npm start'`) round-trip losslessly
- Dropped the comma-separation convention: placeholders and hints now show terminal syntax, with a note that commands run exec-form (no shell, no `$VAR` expansion); unbalanced quotes are rejected at submit validation
- Port number field is now clearable — previously `parseInt(...) || 0` snapped an emptied field back to `0`; presence is enforced at submit instead
- Docker-compose import emits the new text form (string commands pass through verbatim, exec-form arrays are shlex-joined), fixing its naive space-split on the way
- Drawer polish: the resource drawer now hides (state preserved) while Deployments/Logs/Metrics are active instead of floating over them, form rows lost their non-interactive hover wash, and the dirty-field highlight no longer looks clipped at its left edge

## 🧪 How to test
- [x] Open a stack resource drawer → Deployment tab
- [x] Type a command with spaces, commas, and quotes into Init command — every character should land
- [x] Save, reload the page — the field should render back exactly what you typed, with no dirty indicator
- [x] Enter `sh -c 'unbalanced` and save — expect an "Unbalanced quotes" field error
- [x] Clear the Port field in Configuration — expect "Port number is required" instead of a forced 0
- [x] Open a stack whose command was saved before this change — it should render as terminal-style text
- [x] With the drawer open, switch to Deployments and back — the drawer should vanish and return with its tab/scroll state intact
- [x] Edit any field — the change highlight should wrap the control without looking cut off, and hovering rows should no longer tint them