### PR TITLE
Fix: staged-changes staleness and refetch race in the stack editor

### DIFF
--- a/frontend/src/pages/stacks/components/editor/index.tsx
+++ b/frontend/src/pages/stacks/components/editor/index.tsx
@@ -348,9 +348,7 @@ export default function CanvasEditorPage() {
   // Bumped on every autosave refresh to trigger a topology refetch.
   const [topologyRefreshKey, setTopologyRefreshKey] = useState(0);
 
-  // Concurrent refetch writers (autosave, release transitions, revert, volume
-  // delete) all funnel through this gate: a response older than the newest
-  // applied one is dropped instead of clobbering fresher state.
+  // Total order over every stack-refetch writer on this page (see stack-fetch-gate).
   const stackFetchGateRef = useRef(createStackFetchGate());
   // The newest gate-applied payload — handed to callers whose own response was
   // dropped as stale, so downstream consumers (autosave mirror) never diverge
@@ -507,8 +505,6 @@ export default function CanvasEditorPage() {
 
   // Snapshot of the live draft for the lifecycle diff — undefined when no
   // session is active so the server spec stays authoritative on fresh loads.
-  // This is what lets the pill/changes-modal/DRAFT row update on keystroke
-  // instead of after the autosave round-trip.
   const draftSnapshot = useMemo(
     () => (session.isActive && !isNewStack ? draftToSnapshot(session.draft) : undefined),
     [session.isActive, session.draft, isNewStack],
@@ -563,7 +559,6 @@ export default function CanvasEditorPage() {
     liveSnapshot,
     fetchStack: fetchFreshStack,
     onReverted: (fresh) => {
-      // fetchStack already applied the payload to page state (ticket-gated).
       draftSync.notifyExternalUpdate(fresh);
       session.discard(); // auto-start effect restarts the session on the reverted baseline
       toast({ title: "Draft discarded", description: "Stack restored to the last deployment.", variant: "success" });

--- a/frontend/src/pages/stacks/components/editor/index.tsx
+++ b/frontend/src/pages/stacks/components/editor/index.tsx
@@ -127,6 +127,9 @@ export default function CanvasEditorPage() {
       }
       getStackById(orgId, defaultProjectName, id)
         .then((data) => {
+          // Seed the last-applied fallback so a concurrent refetch whose
+          // response the gate drops can fall back to this payload.
+          lastAppliedStackRef.current = data;
           setFetchedStack(data);
           setLoading(false);
           setCustomLabel(path, data.name || 'Stack Details');
@@ -349,29 +352,40 @@ export default function CanvasEditorPage() {
   // delete) all funnel through this gate: a response older than the newest
   // applied one is dropped instead of clobbering fresher state.
   const stackFetchGateRef = useRef(createStackFetchGate());
+  // The newest gate-applied payload — handed to callers whose own response was
+  // dropped as stale, so downstream consumers (autosave mirror) never diverge
+  // from what the UI shows.
+  const lastAppliedStackRef = useRef<Stack | null>(null);
 
   // Server topology may have changed; re-derive edges alongside the fresh stack.
-  const applyStackResponse = useCallback((fresh: Stack, ticket: number) => {
-    if (!stackFetchGateRef.current.shouldApply(ticket)) return;
+  const applyStackResponse = useCallback((fresh: Stack, ticket: number): boolean => {
+    if (!stackFetchGateRef.current.shouldApply(ticket)) return false;
+    lastAppliedStackRef.current = fresh;
     setFetchedStack(fresh);
     // Context write-through: stale currentStack must not win after a remote refresh.
     setStacks((prev) => prev.map((s) => (s.id === fresh.id ? fresh : s)));
     setTopologyRefreshKey((k) => k + 1);
+    return true;
   }, [setStacks]);
 
-  /** Push-style writers (revert, volume-delete refresh) hand over a stack they
-   *  just received; the ticket taken now means "newest at time of arrival". */
+  /** Push-style writer for a stack payload the caller just received from its
+   *  own mutation response (initial load). Fetch-then-apply flows must use
+   *  fetchFreshStack instead — an arrival-time ticket would let a stale GET
+   *  win over a newer applied response. */
   const applyFreshStack = useCallback((fresh: Stack) => {
     applyStackResponse(fresh, stackFetchGateRef.current.begin());
   }, [applyStackResponse]);
 
   /** Pull-style refetch: ticket at REQUEST time, so a slow response loses to
-   *  any fetch started after it. Returns the payload for mirror-healing. */
+   *  any fetch started after it. Returns the newest APPLIED stack — the fresh
+   *  payload normally, or the gate's last-applied one when this response was
+   *  dropped as stale — so callers can heal mirrors without diverging from
+   *  what the UI shows. */
   const fetchFreshStack = useCallback(async (): Promise<Stack> => {
     const ticket = stackFetchGateRef.current.begin();
     const fresh = await getStackById(deployIds.orgId, deployIds.projectName, deployIds.stackId);
-    applyStackResponse(fresh, ticket);
-    return fresh;
+    const applied = applyStackResponse(fresh, ticket);
+    return applied ? fresh : lastAppliedStackRef.current ?? fresh;
   }, [deployIds, applyStackResponse]);
 
   // Volumes that exist server-side; their spec (PVC size) is immutable, so the
@@ -547,9 +561,9 @@ export default function CanvasEditorPage() {
     ids: idsReady ? deployIds : null,
     stack: savedStack ?? undefined,
     liveSnapshot,
+    fetchStack: fetchFreshStack,
     onReverted: (fresh) => {
-      setFetchedStack(fresh);
-      setStacks((prev) => prev.map((s) => (s.id === fresh.id ? fresh : s)));
+      // fetchStack already applied the payload to page state (ticket-gated).
       draftSync.notifyExternalUpdate(fresh);
       session.discard(); // auto-start effect restarts the session on the reverted baseline
       toast({ title: "Draft discarded", description: "Stack restored to the last deployment.", variant: "success" });
@@ -570,7 +584,7 @@ export default function CanvasEditorPage() {
   const volumeDelete = useVolumeDelete({
     ids: idsReady ? deployIds : null,
     draftSync,
-    onServerRefresh: applyFreshStack,
+    fetchStack: fetchFreshStack,
     onRestoreVolume: (vol) => {
       session.updateVolumes((vs) => [...vs, mapVolumeToFormData(vol)]);
     },

--- a/frontend/src/pages/stacks/components/editor/index.tsx
+++ b/frontend/src/pages/stacks/components/editor/index.tsx
@@ -28,6 +28,8 @@ import type { StackResource, Volume, Stack } from "@/pages/stacks/types";
 import type { StackConnection } from "@/api/connections";
 import { alignBaselineToDraft, renameFingerprint } from "@/pages/stacks/lib/stack-diff";
 import { applyStackByName, getStackById, deleteStack } from "@/api/stacks";
+import { createStackFetchGate } from "@/pages/stacks/lib/canvas/stack-fetch-gate";
+import { draftToSnapshot } from "@/pages/stacks/lib/draft-sync/draft-snapshot";
 import { emptyDraftSeed, buildDraftFormData, type DraftSeed } from "@/pages/stacks/lib/canvas/draft-seed";
 import { createRelease, cancelRelease, rollbackRelease } from "@/api/releases";
 import { useReleases } from "@/pages/stacks/components/editor/tabs/deployments/use-releases";
@@ -343,13 +345,34 @@ export default function CanvasEditorPage() {
   // Bumped on every autosave refresh to trigger a topology refetch.
   const [topologyRefreshKey, setTopologyRefreshKey] = useState(0);
 
+  // Concurrent refetch writers (autosave, release transitions, revert, volume
+  // delete) all funnel through this gate: a response older than the newest
+  // applied one is dropped instead of clobbering fresher state.
+  const stackFetchGateRef = useRef(createStackFetchGate());
+
   // Server topology may have changed; re-derive edges alongside the fresh stack.
-  const applyFreshStack = useCallback((fresh: Stack) => {
+  const applyStackResponse = useCallback((fresh: Stack, ticket: number) => {
+    if (!stackFetchGateRef.current.shouldApply(ticket)) return;
     setFetchedStack(fresh);
     // Context write-through: stale currentStack must not win after a remote refresh.
     setStacks((prev) => prev.map((s) => (s.id === fresh.id ? fresh : s)));
     setTopologyRefreshKey((k) => k + 1);
   }, [setStacks]);
+
+  /** Push-style writers (revert, volume-delete refresh) hand over a stack they
+   *  just received; the ticket taken now means "newest at time of arrival". */
+  const applyFreshStack = useCallback((fresh: Stack) => {
+    applyStackResponse(fresh, stackFetchGateRef.current.begin());
+  }, [applyStackResponse]);
+
+  /** Pull-style refetch: ticket at REQUEST time, so a slow response loses to
+   *  any fetch started after it. Returns the payload for mirror-healing. */
+  const fetchFreshStack = useCallback(async (): Promise<Stack> => {
+    const ticket = stackFetchGateRef.current.begin();
+    const fresh = await getStackById(deployIds.orgId, deployIds.projectName, deployIds.stackId);
+    applyStackResponse(fresh, ticket);
+    return fresh;
+  }, [deployIds, applyStackResponse]);
 
   // Volumes that exist server-side; their spec (PVC size) is immutable, so the
   // drawer renders those fields read-only.
@@ -394,6 +417,7 @@ export default function CanvasEditorPage() {
     session,
     ids: idsReady ? deployIds : null,
     onStackRefreshed: (fresh) => applyFreshStack(fresh),
+    refetchStack: fetchFreshStack,
     onSyncError: ({ message, op, fieldErrors }) => {
       // No op → the save actually landed and only the post-save refetch failed;
       // don't alarm the user with a "Save failed" toast or field error.
@@ -467,14 +491,25 @@ export default function CanvasEditorPage() {
     [deployFieldErrors, session.draft.resources],
   );
 
+  // Snapshot of the live draft for the lifecycle diff — undefined when no
+  // session is active so the server spec stays authoritative on fresh loads.
+  // This is what lets the pill/changes-modal/DRAFT row update on keystroke
+  // instead of after the autosave round-trip.
+  const draftSnapshot = useMemo(
+    () => (session.isActive && !isNewStack ? draftToSnapshot(session.draft) : undefined),
+    [session.isActive, session.draft, isNewStack],
+  );
+
   const lifecycle = useDeployLifecycle({
     stack: savedStack ?? undefined,
-    // "Editing" = autosave hasn't landed yet (in flight or retrying). Saved-but-
-    // undeployed content is detected by the staged-phase content diff instead.
-    unsaved: draftSync.status === SYNC_STATUS.saving || draftSync.failureCount > 0,
+    // "Editing" = an edit the server hasn't seen yet: debounce armed, cycle in
+    // flight, or retrying. Saved-but-undeployed content is detected by the
+    // staged-phase content diff instead.
+    unsaved: draftSync.pending || draftSync.status === SYNC_STATUS.saving || draftSync.failureCount > 0,
     releases: releasesResult.releases,
     activeRelease: releasesResult.activeRelease,
     detail: releaseDetail,
+    draftSnapshot,
   });
 
   // When a release settles into ANY terminal state, the stack's converged_release /
@@ -483,12 +518,10 @@ export default function CanvasEditorPage() {
   // keyed on the polled releases list (not on the stack's own pointer).
   const refetchStack = useCallback(() => {
     if (!deployIds.stackId) return;
-    void getStackById(deployIds.orgId, deployIds.projectName, deployIds.stackId).then((fresh) => {
-      applyFreshStack(fresh);
-    }).catch(() => {
+    void fetchFreshStack().catch(() => {
       // Transient fetch failure; the next terminal transition retries.
     });
-  }, [deployIds, applyFreshStack]);
+  }, [deployIds.stackId, fetchFreshStack]);
   const activeRelease = releasesResult.activeRelease;
   const prevActiveReleaseRef = useRef<{ id?: string; state?: string } | undefined>(
     activeRelease && { id: activeRelease.id, state: activeRelease.state },

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/use-deploy-lifecycle.test.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/use-deploy-lifecycle.test.ts
@@ -126,4 +126,41 @@ describe("deriveDeployLifecycle", () => {
     });
     expect(r.phase).toBe("clean");
   });
+
+  it("prefers draftSnapshot over the saved spec for the staged diff", () => {
+    const r = deriveDeployLifecycle({
+      stack: mkStack("nginx:1"), // server hasn't seen the edit yet
+      unsaved: false,
+      activeRelease: mkRelease({ id: "live-1", sequence: 7, state: "Released" }),
+      liveRelease: mkRelease({ id: "live-1", sequence: 7 }),
+      liveSnapshot: snap("nginx:1"),
+      draftSnapshot: snap("nginx:2"), // the live draft carries the edit
+    });
+    expect(r.phase).toBe("staged");
+    expect(r.stagedDiff?.resources).toHaveLength(1);
+  });
+
+  it("falls back to the saved spec when draftSnapshot is undefined", () => {
+    const r = deriveDeployLifecycle({
+      stack: mkStack("nginx:1"),
+      unsaved: false,
+      activeRelease: mkRelease({ id: "live-1", sequence: 7, state: "Released" }),
+      liveRelease: mkRelease({ id: "live-1", sequence: 7 }),
+      liveSnapshot: snap("nginx:1"),
+    });
+    expect(r.phase).toBe("clean");
+  });
+
+  it("uses draftSnapshot on the unsaved/editing path too", () => {
+    const r = deriveDeployLifecycle({
+      stack: mkStack("nginx:1"),
+      unsaved: true,
+      activeRelease: mkRelease({ id: "live-1", sequence: 7, state: "Released" }),
+      liveRelease: mkRelease({ id: "live-1", sequence: 7 }),
+      liveSnapshot: snap("nginx:1"),
+      draftSnapshot: snap("nginx:2"),
+    });
+    expect(r.phase).toBe("editing");
+    expect(r.stagedDiff?.resources).toHaveLength(1);
+  });
 });

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/use-deploy-lifecycle.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/use-deploy-lifecycle.ts
@@ -34,6 +34,11 @@ export interface DeriveDeployLifecycleArgs {
   activeSnapshot?: StackReleaseSnapshot;
   /** Snapshot of the live release — what is actually running. */
   liveSnapshot?: StackReleaseSnapshot;
+  /** Live edit-session draft in snapshot shape. When present it is the "user's
+   *  spec" side of every diff, replacing the server-fetched spec — staged
+   *  surfaces then update on keystroke instead of after the autosave
+   *  round-trip. Absent → server spec (no session, read-only viewers). */
+  draftSnapshot?: StackReleaseSnapshot;
 }
 
 function diffIsEmpty(d: SnapshotDiff): boolean {
@@ -80,7 +85,7 @@ export function deriveDeployLifecycle(args: DeriveDeployLifecycleArgs): DeployLi
     // saved-so-far changes instead of a placeholder. Baseline follows the same rules
     // as the staged path; undefined only while a live snapshot is still loading.
     const base = baselineSnapshot(args);
-    const stagedDiff = base ? diffSnapshots(base, specToSnapshot(stack)) : undefined;
+    const stagedDiff = base ? diffSnapshots(base, args.draftSnapshot ?? specToSnapshot(stack)) : undefined;
     // Mirror the staged path's "vs #N" anchor so the label doesn't vanish while an
     // edit is still autosaving: the in-flight release when deploying, else live.
     const deploying = !!activeRelease && !isTerminal(activeRelease.state);
@@ -88,7 +93,7 @@ export function deriveDeployLifecycle(args: DeriveDeployLifecycleArgs): DeployLi
     return { phase: "editing", stagedDiff, vsSeq, nextSeq };
   }
 
-  const spec = specToSnapshot(stack);
+  const spec = args.draftSnapshot ?? specToSnapshot(stack);
   const deploying = !!activeRelease && !isTerminal(activeRelease.state);
 
   // Deploy in flight: measure the draft against the IN-FLIGHT release, not live. Matches it →
@@ -139,13 +144,15 @@ export interface UseDeployLifecycleArgs {
   releases: StackRelease[];
   activeRelease?: StackRelease;
   detail: ReleaseDetail;
+  /** See DeriveDeployLifecycleArgs.draftSnapshot. */
+  draftSnapshot?: StackReleaseSnapshot;
 }
 
 /**
  * React wrapper: resolves the live + latest-attempt releases, lazily loads both
  * snapshots, and derives the lifecycle phase.
  */
-export function useDeployLifecycle({ stack, unsaved, releases, activeRelease, detail }: UseDeployLifecycleArgs): DeployLifecycle {
+export function useDeployLifecycle({ stack, unsaved, releases, activeRelease, detail, draftSnapshot }: UseDeployLifecycleArgs): DeployLifecycle {
   const liveReleaseId = stack?.converged_release?.id;
   const liveRelease = liveReleaseId ? releases.find((r) => r.id === liveReleaseId) : undefined;
   const activeId = activeRelease?.id;
@@ -158,5 +165,5 @@ export function useDeployLifecycle({ stack, unsaved, releases, activeRelease, de
 
   const liveSnapshot = detail.peek(liveReleaseId).data?.snapshot;
   const activeSnapshot = detail.peek(activeId).data?.snapshot;
-  return deriveDeployLifecycle({ stack, unsaved, activeRelease, liveRelease, activeSnapshot, liveSnapshot });
+  return deriveDeployLifecycle({ stack, unsaved, activeRelease, liveRelease, activeSnapshot, liveSnapshot, draftSnapshot });
 }

--- a/frontend/src/pages/stacks/hooks/tests/use-draft-sync.test.tsx
+++ b/frontend/src/pages/stacks/hooks/tests/use-draft-sync.test.tsx
@@ -43,7 +43,7 @@ const webForm = (image: string) => ({
   source: { image: { ref: image } },
 });
 
-function setup(stack: Stack) {
+function setup(stack: Stack, extra?: { refetchStack?: () => Promise<Stack> }) {
   const onStackRefreshed = vi.fn();
   const hook = renderHook(() => {
     const session = useStackEditSession();
@@ -53,6 +53,7 @@ function setup(stack: Stack) {
       session,
       ids: { orgId: "o", projectName: "t", stackId: "st-1" },
       onStackRefreshed,
+      refetchStack: extra?.refetchStack,
     });
     return { session, sync };
   });
@@ -163,6 +164,35 @@ describe("useDraftSync", () => {
       ok = await hook.result.current.sync.flush();
     });
     expect(ok).toBe(false);
+  });
+
+  it("pending is true while the debounce is armed and false after the cycle settles", async () => {
+    const { hook } = setup(serverStack("nginx:1"));
+    expect(hook.result.current.sync.pending).toBe(false);
+    act(() => hook.result.current.session.updateResources(() => [webForm("nginx:2")]));
+    // Debounce armed, PUT not fired yet: pending must already be true while
+    // status still reads settled — this is the window the lifecycle used to
+    // mis-derive as "clean".
+    await act(() => vi.advanceTimersByTimeAsync(DEBOUNCE_IDLE_MS - 100));
+    expect(updateStackResource).not.toHaveBeenCalled();
+    expect(hook.result.current.sync.pending).toBe(true);
+    await act(() => vi.advanceTimersByTimeAsync(200));
+    await act(() => Promise.resolve());
+    expect(hook.result.current.sync.status).toBe(SYNC_STATUS.saved);
+    expect(hook.result.current.sync.pending).toBe(false);
+  });
+
+  it("uses the injected refetchStack and does not call onStackRefreshed when provided", async () => {
+    const refetchStack = vi.fn().mockResolvedValue(serverStack("nginx:2"));
+    const { hook, onStackRefreshed } = setup(serverStack("nginx:1"), { refetchStack });
+    act(() => hook.result.current.session.updateResources(() => [webForm("nginx:2")]));
+    await act(() => vi.advanceTimersByTimeAsync(DEBOUNCE_IDLE_MS + 100));
+    await act(() => Promise.resolve());
+    expect(updateStackResource).toHaveBeenCalledOnce();
+    expect(refetchStack).toHaveBeenCalledOnce();
+    expect(getStackById).not.toHaveBeenCalled();
+    expect(onStackRefreshed).not.toHaveBeenCalled();
+    expect(hook.result.current.sync.status).toBe(SYNC_STATUS.saved);
   });
 
   it("does nothing when disabled", async () => {

--- a/frontend/src/pages/stacks/hooks/tests/use-draft-sync.test.tsx
+++ b/frontend/src/pages/stacks/hooks/tests/use-draft-sync.test.tsx
@@ -195,6 +195,28 @@ describe("useDraftSync", () => {
     expect(hook.result.current.sync.status).toBe(SYNC_STATUS.saved);
   });
 
+  it("keeps pending true when an edit lands during an in-flight cycle", async () => {
+    const { hook } = setup(serverStack("nginx:1"));
+    let resolveUpdate!: () => void;
+    vi.mocked(updateStackResource).mockImplementationOnce(
+      () => new Promise((resolve) => { resolveUpdate = () => resolve({} as never); }),
+    );
+    act(() => hook.result.current.session.updateResources(() => [webForm("nginx:2")]));
+    // Cycle starts and blocks on the held PUT.
+    await act(() => vi.advanceTimersByTimeAsync(DEBOUNCE_IDLE_MS + 100));
+    // Edit lands mid-cycle: re-arms the debounce but doesn't queue a cycle.
+    act(() => hook.result.current.session.updateResources(() => [webForm("nginx:3")]));
+    resolveUpdate();
+    await act(() => vi.advanceTimersByTimeAsync(1));
+    // The first cycle settled, but the mid-cycle edit hasn't been sent yet —
+    // pending must survive until its own cycle runs.
+    expect(hook.result.current.sync.pending).toBe(true);
+    await act(() => vi.advanceTimersByTimeAsync(DEBOUNCE_IDLE_MS + 100));
+    await act(() => Promise.resolve());
+    expect(hook.result.current.sync.pending).toBe(false);
+    expect(updateStackResource).toHaveBeenCalledTimes(2);
+  });
+
   it("does nothing when disabled", async () => {
     const onStackRefreshed = vi.fn();
     const hook = renderHook(() => {

--- a/frontend/src/pages/stacks/hooks/tests/use-volume-delete.test.ts
+++ b/frontend/src/pages/stacks/hooks/tests/use-volume-delete.test.ts
@@ -7,16 +7,13 @@ import type { Stack, Volume } from "@/api/stacks";
 vi.mock("@/api/volumes", () => ({
   deleteVolume: vi.fn(),
 }));
-vi.mock("@/api/stacks", () => ({
-  getStackById: vi.fn(),
-}));
 
 import { deleteVolume } from "@/api/volumes";
-import { getStackById } from "@/api/stacks";
 import { useVolumeDelete } from "../use-volume-delete";
 
 const mockedDelete = vi.mocked(deleteVolume);
-const mockedGetStack = vi.mocked(getStackById);
+// The hook no longer fetches itself — the page injects a ticket-gated fetch.
+const mockedGetStack = vi.fn<() => Promise<Stack>>();
 
 const ids = { orgId: "org-1", projectName: "alpha", stackId: "stack-1" };
 
@@ -42,21 +39,19 @@ function mkAxiosError(status: number): AxiosError {
 function mkArgs(overrides: Partial<Parameters<typeof useVolumeDelete>[0]> = {}) {
   const flush = vi.fn().mockResolvedValue(true);
   const notifyExternalUpdate = vi.fn();
-  const onServerRefresh = vi.fn();
   const onRestoreVolume = vi.fn();
   const toast = vi.fn();
   return {
     args: {
       ids,
       draftSync: { flush, notifyExternalUpdate },
-      onServerRefresh,
+      fetchStack: mockedGetStack,
       onRestoreVolume,
       toast,
       ...overrides,
     },
     flush,
     notifyExternalUpdate,
-    onServerRefresh,
     onRestoreVolume,
     toast,
   };
@@ -69,7 +64,7 @@ beforeEach(() => {
 
 describe("useVolumeDelete", () => {
   it("happy path: flush -> refetch (id lookup) -> deleteVolume(id) -> refetch -> notify+refresh, true", async () => {
-    const { args, flush, notifyExternalUpdate, onServerRefresh, toast } = mkArgs();
+    const { args, flush, notifyExternalUpdate, toast } = mkArgs();
     mockedGetStack
       .mockResolvedValueOnce(mkStack([{ id: "vol-1", name: "data" }]))
       .mockResolvedValueOnce(mkStack([]));
@@ -86,7 +81,6 @@ describe("useVolumeDelete", () => {
     expect(mockedGetStack).toHaveBeenCalledTimes(2);
     expect(mockedDelete).toHaveBeenCalledWith("org-1", "alpha", "vol-1");
     expect(notifyExternalUpdate).toHaveBeenCalledTimes(1);
-    expect(onServerRefresh).toHaveBeenCalledTimes(1);
     expect(toast).toHaveBeenCalledWith({
       title: "Volume deleted",
       description: '"data" and its data were deleted.',
@@ -128,7 +122,7 @@ describe("useVolumeDelete", () => {
   });
 
   it("volume absent post-flush (never persisted): no delete call, true", async () => {
-    const { args, onServerRefresh, onRestoreVolume } = mkArgs();
+    const { args, onRestoreVolume } = mkArgs();
     mockedGetStack.mockResolvedValueOnce(mkStack([]));
 
     const { result } = renderHook(() => useVolumeDelete(args));
@@ -139,7 +133,6 @@ describe("useVolumeDelete", () => {
 
     expect(ok).toBe(true);
     expect(mockedDelete).not.toHaveBeenCalled();
-    expect(onServerRefresh).not.toHaveBeenCalled();
     expect(onRestoreVolume).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/stacks/hooks/use-draft-sync.ts
+++ b/frontend/src/pages/stacks/hooks/use-draft-sync.ts
@@ -238,12 +238,18 @@ export function useDraftSync({
       runningRef.current = null;
       if (queuedRef.current) {
         queuedRef.current = false;
+        // An edit made mid-cycle may also have re-armed the debounce; clear it
+        // so the drain timer below is the only pending firing (a leaked handle
+        // would fire a spurious extra cycle).
+        if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
         idleTimerRef.current = setTimeout(() => {
           void startCycle();
         }, 0);
-      } else {
-        // Nothing queued behind this cycle: every known edit has been pushed
-        // (or is on the retry path, which keeps failureCount > 0).
+      } else if (!idleTimerRef.current && !maxWaitTimerRef.current) {
+        // Nothing queued AND no debounce armed: every known edit has been
+        // pushed (or is on the retry path, which keeps failureCount > 0). An
+        // armed timer means an edit landed DURING this cycle — it hasn't been
+        // sent, so pending must survive until its own cycle settles.
         setPending(false);
       }
     });
@@ -261,6 +267,9 @@ export function useDraftSync({
   useEffect(() => {
     if (!enabled || !draft || !idsRef.current) {
       firstArmRef.current = true;
+      // Disabled / session ended: no cycle will run to clear pending, so
+      // reset it here rather than leaving the lifecycle stuck on "editing".
+      setPending(false);
       return;
     }
     if (firstArmRef.current) firstArmRef.current = false;

--- a/frontend/src/pages/stacks/hooks/use-draft-sync.ts
+++ b/frontend/src/pages/stacks/hooks/use-draft-sync.ts
@@ -41,11 +41,21 @@ export interface UseDraftSyncArgs {
   onStackRefreshed: (stack: Stack) => void;
   /** Called when a sync op throws, before the mirror heals. */
   onSyncError?: (info: SyncErrorInfo) => void;
+  /** When provided, replaces the hook's own getStackById for post-save and
+   *  error-heal refetches. The provider owns applying the result to UI state
+   *  (ticket-guarded), so onStackRefreshed is NOT called on those paths — the
+   *  hook still heals its mirror from the returned stack. */
+  refetchStack?: () => Promise<Stack>;
 }
 
 export interface UseDraftSync {
   status: SyncStatus;
   failureCount: number;
+  /** True from the moment a draft change arms the debounce until the settling
+   *  cycle finishes with nothing queued. Distinguishes "an edit exists that the
+   *  server hasn't seen yet" from the status flags, which read settled during
+   *  the pre-PUT debounce window. */
+  pending: boolean;
   flush: () => Promise<boolean>;
   /** External writers (revert) hand the fresh stack here so the mirror stays truthful. */
   notifyExternalUpdate: (stack: Stack) => void;
@@ -92,9 +102,11 @@ export function useDraftSync({
   ids,
   onStackRefreshed,
   onSyncError,
+  refetchStack,
 }: UseDraftSyncArgs): UseDraftSync {
   const [status, setStatus] = useState<SyncStatus>(SYNC_STATUS.idle);
   const [failureCount, setFailureCount] = useState(0);
+  const [pending, setPending] = useState(false);
 
   const sessionRef = useRef(session);
   sessionRef.current = session;
@@ -104,6 +116,8 @@ export function useDraftSync({
   onRefreshedRef.current = onStackRefreshed;
   const onSyncErrorRef = useRef(onSyncError);
   onSyncErrorRef.current = onSyncError;
+  const refetchStackRef = useRef(refetchStack);
+  refetchStackRef.current = refetchStack;
 
   const mirrorRef = useRef<ServerStackState | null>(null);
   const runningRef = useRef<Promise<boolean> | null>(null);
@@ -170,9 +184,12 @@ export function useDraftSync({
           await executeOp(op, currentIds);
         }
         opsSucceeded = true;
-        const fresh = await getStackById(currentIds.orgId, currentIds.projectName, currentIds.stackId);
+        const fetchFresh = refetchStackRef.current;
+        const fresh = fetchFresh
+          ? await fetchFresh()
+          : await getStackById(currentIds.orgId, currentIds.projectName, currentIds.stackId);
         mirrorRef.current = serverStateFromStack(fresh);
-        onRefreshedRef.current(fresh);
+        if (!fetchFresh) onRefreshedRef.current(fresh);
         // Deliberately NOT rebasing the session here: the diff baseline stays
         // pinned to the deployed release so autosaved edits remain visibly
         // dirty/revertable. Only deploy or discard moves the baseline.
@@ -195,9 +212,12 @@ export function useDraftSync({
         });
         // Heal the mirror from server truth; the draft stays authoritative locally.
         try {
-          const fresh = await getStackById(currentIds.orgId, currentIds.projectName, currentIds.stackId);
+          const fetchFresh = refetchStackRef.current;
+          const fresh = fetchFresh
+            ? await fetchFresh()
+            : await getStackById(currentIds.orgId, currentIds.projectName, currentIds.stackId);
           mirrorRef.current = serverStateFromStack(fresh);
-          onRefreshedRef.current(fresh);
+          if (!fetchFresh) onRefreshedRef.current(fresh);
         } catch {
           /* keep the stale mirror; the next attempt refetches again */
         }
@@ -221,6 +241,10 @@ export function useDraftSync({
         idleTimerRef.current = setTimeout(() => {
           void startCycle();
         }, 0);
+      } else {
+        // Nothing queued behind this cycle: every known edit has been pushed
+        // (or is on the retry path, which keeps failureCount > 0).
+        setPending(false);
       }
     });
     runningRef.current = run;
@@ -230,8 +254,17 @@ export function useDraftSync({
   // Debounce: every draft change (while active+enabled) restarts the idle
   // window; a max-wait timer guarantees persistence under continuous typing.
   const draft = session.isActive ? session.draft : null;
+  // The debounce effect also fires once when a session starts (initial draft
+  // identity, no edit yet) — that arm schedules a no-op cycle and must not
+  // read as "pending edits". Only arms after the first one mark pending.
+  const firstArmRef = useRef(true);
   useEffect(() => {
-    if (!enabled || !draft || !idsRef.current) return;
+    if (!enabled || !draft || !idsRef.current) {
+      firstArmRef.current = true;
+      return;
+    }
+    if (firstArmRef.current) firstArmRef.current = false;
+    else setPending(true);
     if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
     idleTimerRef.current = setTimeout(() => {
       clearDebounceTimers();
@@ -289,7 +322,7 @@ export function useDraftSync({
   );
 
   return useMemo(
-    () => ({ status, failureCount, flush, notifyExternalUpdate }),
-    [status, failureCount, flush, notifyExternalUpdate],
+    () => ({ status, failureCount, pending, flush, notifyExternalUpdate }),
+    [status, failureCount, pending, flush, notifyExternalUpdate],
   );
 }

--- a/frontend/src/pages/stacks/hooks/use-stack-revert.ts
+++ b/frontend/src/pages/stacks/hooks/use-stack-revert.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import type { Stack } from "@/api/stacks";
-import { getStackById, applyStack } from "@/api/stacks";
+import { applyStack } from "@/api/stacks";
 import { deleteVolume } from "@/api/volumes";
 import type { StackReleaseSnapshot } from "@/api/releases";
 import { snapshotToUpdateRequest, volumesToDelete } from "@/pages/stacks/lib/draft-sync/snapshot-to-update";
@@ -10,6 +10,10 @@ export interface UseStackRevertArgs {
   ids: { orgId: string; projectName: string; stackId: string } | null;
   stack: Stack | undefined;
   liveSnapshot: StackReleaseSnapshot | undefined;
+  /** Page-provided, ticket-gated stack refetch (applies the payload to page
+   *  state itself and returns the newest applied stack) — keeps this hook's
+   *  refetch inside the page's response-ordering domain. */
+  fetchStack: () => Promise<Stack>;
   /** session.discard — the page's session auto-start effect re-seeds from the refreshed stack. */
   onReverted: (fresh: Stack) => void;
   /** Called with the backend reason when the revert throws. */
@@ -17,7 +21,7 @@ export interface UseStackRevertArgs {
 }
 
 /** Restore the authored stack to the last deployed snapshot. */
-export function useStackRevert({ ids, stack, liveSnapshot, onReverted, onError }: UseStackRevertArgs) {
+export function useStackRevert({ ids, stack, liveSnapshot, fetchStack, onReverted, onError }: UseStackRevertArgs) {
   const [reverting, setReverting] = useState(false);
 
   const revert = useCallback(async (): Promise<boolean> => {
@@ -31,7 +35,7 @@ export function useStackRevert({ ids, stack, liveSnapshot, onReverted, onError }
       for (const v of volumesToDelete(stack, liveSnapshot)) {
         await deleteVolume(ids.orgId, ids.projectName, v.id);
       }
-      const fresh = await getStackById(ids.orgId, ids.projectName, ids.stackId);
+      const fresh = await fetchStack();
       onReverted(fresh);
       return true;
     } catch (err) {
@@ -40,7 +44,7 @@ export function useStackRevert({ ids, stack, liveSnapshot, onReverted, onError }
     } finally {
       setReverting(false);
     }
-  }, [ids, stack, liveSnapshot, onReverted, onError]);
+  }, [ids, stack, liveSnapshot, fetchStack, onReverted, onError]);
 
   return { reverting, revert };
 }

--- a/frontend/src/pages/stacks/hooks/use-volume-delete.ts
+++ b/frontend/src/pages/stacks/hooks/use-volume-delete.ts
@@ -91,7 +91,6 @@ export function useVolumeDelete({
 
         await deleteVolume(ids.orgId, ids.projectName, id);
 
-        // fetchStack applies the payload to page state itself (ticket-gated).
         const fresh2 = await fetchStack();
         draftSync.notifyExternalUpdate(fresh2);
         toast({ title: "Volume deleted", description: `"${name}" and its data were deleted.`, variant: "success" });

--- a/frontend/src/pages/stacks/hooks/use-volume-delete.ts
+++ b/frontend/src/pages/stacks/hooks/use-volume-delete.ts
@@ -1,7 +1,6 @@
 import { useCallback, useState } from "react";
 import axios from "axios";
 import type { Stack, Volume } from "@/api/stacks";
-import { getStackById } from "@/api/stacks";
 import { deleteVolume } from "@/api/volumes";
 
 export type VolumeDeleteToast = (t: { title: string; description?: string; variant?: "destructive" | "success" }) => void;
@@ -9,8 +8,10 @@ export type VolumeDeleteToast = (t: { title: string; description?: string; varia
 export interface UseVolumeDeleteArgs {
   ids: { orgId: string; projectName: string; stackId: string } | null;
   draftSync: { flush(): Promise<boolean>; notifyExternalUpdate(stack: Stack): void };
-  /** Same setter revert's onReverted uses — keeps the page's stack state truthful. */
-  onServerRefresh: (fresh: Stack) => void;
+  /** Page-provided, ticket-gated stack refetch — applies the payload to page
+   *  state itself and returns the newest applied stack, so this hook's own
+   *  GETs can't clobber fresher state with a late response. */
+  fetchStack: () => Promise<Stack>;
   /** Failure path: re-add the volume to the session draft (it reappears floating). */
   onRestoreVolume: (fresh: Volume) => void;
   toast: VolumeDeleteToast;
@@ -30,7 +31,7 @@ export interface UseVolumeDelete {
 export function useVolumeDelete({
   ids,
   draftSync,
-  onServerRefresh,
+  fetchStack,
   onRestoreVolume,
   toast,
 }: UseVolumeDeleteArgs): UseVolumeDelete {
@@ -43,7 +44,7 @@ export function useVolumeDelete({
     async (name: string): Promise<void> => {
       if (!ids) return;
       try {
-        const fresh = await getStackById(ids.orgId, ids.projectName, ids.stackId);
+        const fresh = await fetchStack();
         draftSync.notifyExternalUpdate(fresh);
         const vol = (fresh.spec?.volumes ?? []).find((v) => v.name === name);
         if (vol) onRestoreVolume(vol as Volume);
@@ -55,7 +56,7 @@ export function useVolumeDelete({
         });
       }
     },
-    [ids, draftSync, onRestoreVolume, toast],
+    [ids, fetchStack, draftSync, onRestoreVolume, toast],
   );
 
   const runDelete = useCallback(
@@ -79,7 +80,7 @@ export function useVolumeDelete({
           return false;
         }
 
-        const fresh = await getStackById(ids.orgId, ids.projectName, ids.stackId);
+        const fresh = await fetchStack();
         const id = fresh.spec?.volumes?.find((v) => v.name === name)?.id;
         if (id == null) {
           // Never persisted server-side (or already gone) — the local delete is
@@ -90,9 +91,9 @@ export function useVolumeDelete({
 
         await deleteVolume(ids.orgId, ids.projectName, id);
 
-        const fresh2 = await getStackById(ids.orgId, ids.projectName, ids.stackId);
+        // fetchStack applies the payload to page state itself (ticket-gated).
+        const fresh2 = await fetchStack();
         draftSync.notifyExternalUpdate(fresh2);
-        onServerRefresh(fresh2);
         toast({ title: "Volume deleted", description: `"${name}" and its data were deleted.`, variant: "success" });
         return true;
       } catch (err) {
@@ -116,7 +117,7 @@ export function useVolumeDelete({
         setDeleting(false);
       }
     },
-    [ids, draftSync, onServerRefresh, refetchAndRestore, toast],
+    [ids, fetchStack, draftSync, refetchAndRestore, toast],
   );
 
   return { deleting, deleteVolume: runDelete };

--- a/frontend/src/pages/stacks/lib/canvas/stack-fetch-gate.ts
+++ b/frontend/src/pages/stacks/lib/canvas/stack-fetch-gate.ts
@@ -1,0 +1,29 @@
+/**
+ * Monotonic guard for concurrent stack refetches. Multiple writers (autosave
+ * refetch, release-transition refetch, revert, volume delete) GET the stack
+ * concurrently; without ordering, a GET issued before an edit landed can
+ * resolve last and clobber fresher state. Callers take a ticket via begin()
+ * BEFORE issuing the request and apply the response only if shouldApply(ticket)
+ * — which admits each ticket at most once and refuses any ticket older than
+ * the newest applied.
+ */
+export interface StackFetchGate {
+  begin(): number;
+  shouldApply(ticket: number): boolean;
+}
+
+export function createStackFetchGate(): StackFetchGate {
+  let next = 0;
+  let lastApplied = 0;
+  return {
+    begin() {
+      next += 1;
+      return next;
+    },
+    shouldApply(ticket: number) {
+      if (ticket <= lastApplied) return false;
+      lastApplied = ticket;
+      return true;
+    },
+  };
+}

--- a/frontend/src/pages/stacks/lib/draft-sync/draft-snapshot.ts
+++ b/frontend/src/pages/stacks/lib/draft-sync/draft-snapshot.ts
@@ -1,0 +1,19 @@
+import type { StackReleaseSnapshot } from "@/api/releases";
+import type { EditSessionDraft } from "@/pages/stacks/hooks/use-stack-edit-session";
+import { buildDesiredState } from "./desired-state";
+
+/**
+ * Adapt the live edit-session draft into release-snapshot shape so the staged
+ * diff can compare it against a release baseline WITHOUT waiting for the
+ * autosave round-trip. Reuses the exact desired-state derivation autosave
+ * persists, so what the diff shows is what a save will produce (invalid/held
+ * resources excluded on both paths).
+ */
+export function draftToSnapshot(draft: EditSessionDraft): StackReleaseSnapshot {
+  const desired = buildDesiredState(draft);
+  return {
+    resources: [...desired.resources.values()] as StackReleaseSnapshot["resources"],
+    volumes: [...desired.volumes.values()] as StackReleaseSnapshot["volumes"],
+    connections: [...desired.connections.values()],
+  };
+}

--- a/frontend/src/pages/stacks/lib/draft-sync/tests/draft-snapshot.test.ts
+++ b/frontend/src/pages/stacks/lib/draft-sync/tests/draft-snapshot.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { draftToSnapshot } from "../draft-snapshot";
+import type { EditSessionDraft } from "@/pages/stacks/hooks/use-stack-edit-session";
+
+const validResource = {
+  name: "web",
+  sourceType: "image" as const,
+  source: { image: { ref: "nginx:1" } },
+  execution_config: {
+    command: ["sh", "-c", "echo hi"],
+    environment_variables: [
+      { from: "stack" as const, name: "MODE", value: "prod" },
+      { from: "secret" as const, name: "TOKEN", secretId: "s-1", secretKey: "token" },
+    ],
+  },
+};
+
+describe("draftToSnapshot", () => {
+  it("emits server-shaped resources, volumes, and connections as arrays", () => {
+    const vol = { name: "web-data", sourceType: "None" as const, spec: { size: "1Gi", access_mode: "ReadWriteOnce" }, labels: [] };
+    const snap = draftToSnapshot({ resources: [validResource], volumes: [vol] } as unknown as EditSessionDraft);
+    expect(snap.resources.map((r) => r.name)).toEqual(["web"]);
+    expect(snap.resources[0].execution_config?.command).toEqual(["sh", "-c", "echo hi"]);
+    // secret row rides as a connection, not an env var
+    expect(snap.resources[0].execution_config?.environment_variables).toEqual([
+      { name: "MODE", value: "prod" },
+    ]);
+    expect(snap.connections).toHaveLength(1);
+    expect(snap.volumes.map((v) => v.name)).toEqual(["web-data"]);
+  });
+
+  it("omits invalid (held) resources — matching what autosave would persist", () => {
+    const broken = { name: "api", sourceType: "image" as const, source: { image: { ref: "" } } };
+    const snap = draftToSnapshot({ resources: [validResource, broken], volumes: [] } as unknown as EditSessionDraft);
+    expect(snap.resources.map((r) => r.name)).toEqual(["web"]);
+  });
+
+  it("returns empty collections for an empty draft", () => {
+    const snap = draftToSnapshot({ resources: [], volumes: [] } as unknown as EditSessionDraft);
+    expect(snap).toEqual({ resources: [], volumes: [], connections: [] });
+  });
+});

--- a/frontend/src/pages/stacks/lib/tests/stack-fetch-gate.test.ts
+++ b/frontend/src/pages/stacks/lib/tests/stack-fetch-gate.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { createStackFetchGate } from "../canvas/stack-fetch-gate";
+
+describe("createStackFetchGate", () => {
+  it("applies responses arriving in order", () => {
+    const gate = createStackFetchGate();
+    const a = gate.begin();
+    const b = gate.begin();
+    expect(gate.shouldApply(a)).toBe(true);
+    expect(gate.shouldApply(b)).toBe(true);
+  });
+
+  it("drops a stale response that resolves after a newer one", () => {
+    const gate = createStackFetchGate();
+    const older = gate.begin();
+    const newer = gate.begin();
+    expect(gate.shouldApply(newer)).toBe(true);
+    expect(gate.shouldApply(older)).toBe(false);
+  });
+
+  it("never applies the same ticket twice", () => {
+    const gate = createStackFetchGate();
+    const t = gate.begin();
+    expect(gate.shouldApply(t)).toBe(true);
+    expect(gate.shouldApply(t)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 📝 What this does
Edits in the canvas editor sometimes didn't show up in the deploy pill, the "Undeployed changes" modal, or the Deployments DRAFT row until a full page refresh. Root causes: those surfaces were derived from the server round-trip instead of the local draft (1–5s lag by design), the pre-PUT debounce window read as "settled", and concurrent stack refetches had no ordering — a stale response could permanently overwrite a fresher one.

## 🏗️ Architecture
### Flows
```mermaid
sequenceDiagram
    participant U as User edit
    participant D as session.draft
    participant L as lifecycle.stagedDiff
    participant A as autosave
    participant S as server
    U->>D: keystroke
    D->>L: draftToSnapshot (instant)
    Note over L: pill / modal / DRAFT row update immediately
    D->>A: debounce 1.2–5s
    A->>S: PUT ops
    A->>S: GET stack (ticket N)
    S-->>A: response
    A->>L: apply only if N > last applied
    Note over A: stale responses dropped by the ticket gate
```

## 🔀 Changes
- Added a monotonic ticket gate that every stack refetch writer (autosave, release-transition, revert, volume delete) routes through, so an out-of-order response can no longer clobber fresher state
- Staged diff now computes from the live edit draft via a new `draftToSnapshot` adapter (reusing the autosave desired-state derivation), so the pill, changes modal, and DRAFT timeline row update on keystroke
- Autosave exposes a `pending` flag covering the pre-PUT debounce window; the lifecycle's "editing" detection uses it, so the DRAFT row no longer vanishes and the pill no longer under-counts right after an edit
- Autosave's post-save refetch is injectable and routed through the same ticket gate as every other refetch

## 🧪 How to test
- [ ] Edit a field in a resource drawer, immediately open "Details" on the deploy pill — the edit is listed before autosave lands (verify by throttling the network)
- [ ] Edit a field and switch to the Deployments tab within a second — the DRAFT row shows the change with an "Unsaved" badge
- [ ] Let autosave settle — surfaces keep the same content (no flicker to stale)
- [ ] Deploy, then edit immediately after the release converges — the edit stays visible without refreshing (the old race window)