### PR TITLE
Fix: canvas node jumps while renaming a resource

### DIFF
--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
@@ -19,7 +19,8 @@ import { useStackTopology } from "@/pages/stacks/hooks/use-stack-topology";
 import type { ReleaseLiveStatus } from "@/api/releases";
 import { deriveGraph } from "@/pages/stacks/lib/canvas/graph-from-connections";
 import { mergeTopology } from "@/pages/stacks/lib/canvas/merge-topology";
-import { layoutGraph, NEW_NODE_GAP_X, NEW_NODE_OFFSET_Y } from "@/pages/stacks/lib/canvas/layout-graph";
+import { layoutGraph, NODE_SEP } from "@/pages/stacks/lib/canvas/layout-graph";
+import { resolveCollisions } from "@/pages/stacks/lib/canvas/resolve-collisions";
 import { addBlockToStack } from "@/pages/stacks/lib/block-to-form";
 import { blockCatalog, getBlockById } from "@/pages/stacks/data/blocks/registry";
 import { CanvasEditor } from "./canvas-editor";
@@ -229,23 +230,34 @@ function StackCanvasFlow({
 
   const onNodeDragStop = useCallback<OnNodeDrag<CanvasFlowNode>>(
     (_event, node) => {
-      if (!isFloatingVolume(node)) return;
-      const target = dropTargetFor(node);
-      // Clear all rings.
-      setNodes((prev) =>
-        prev.map((n) =>
-          (n.data as ResourceNodeData).dropTarget
-            ? ({ ...n, data: { ...n.data, dropTarget: false } } as CanvasFlowNode)
-            : n,
-        ),
-      );
-      if (!target) {
-        dragStartPos.current = null;
-        return; // plain reposition
+      if (isFloatingVolume(node)) {
+        const target = dropTargetFor(node);
+        // Clear all rings.
+        setNodes((prev) =>
+          prev.map((n) =>
+            (n.data as ResourceNodeData).dropTarget
+              ? ({ ...n, data: { ...n.data, dropTarget: false } } as CanvasFlowNode)
+              : n,
+          ),
+        );
+        if (target) {
+          const volumeName = node.id.slice(NODE_ID_PREFIX.volume.length);
+          const resourceIdx = (target.data as ResourceNodeData).resourceIdx!;
+          setAttachRequest({ volumeName, resourceIdx });
+          return;
+        }
       }
-      const volumeName = node.id.slice(NODE_ID_PREFIX.volume.length);
-      const resourceIdx = (target.data as ResourceNodeData).resourceIdx!;
-      setAttachRequest({ volumeName, resourceIdx });
+      // Plain reposition (any node type): nudge apart any overlap the drag
+      // created. Everything except the dropped node stays pinned so the
+      // user's arrangement doesn't reshuffle — the dropped node yields.
+      dragStartPos.current = null;
+      setNodes(
+        (prev) =>
+          resolveCollisions(prev, {
+            margin: NODE_SEP / 2,
+            isLocked: (n) => n.id !== node.id,
+          }) as CanvasFlowNode[],
+      );
     },
     [dropTargetFor, setNodes],
   );
@@ -279,32 +291,32 @@ function StackCanvasFlow({
       const posById = new Map(prev.map((n) => [n.id, n.position]));
       // Empty canvas (no preserved nodes): use the fresh dagre layout as-is.
       if (posById.size === 0) return laid.nodes as CanvasFlowNode[];
-      // Bounding box of the PRESERVED nodes — new nodes land above-left of it so
-      // they never overlap the frozen layout (their fresh dagre coords belong to a
-      // different frame and would collide). Above = consumer side under BT ranks.
-      const preserved = [...posById.values()];
-      const minX = Math.min(...preserved.map((p) => p.x));
-      const minY = Math.min(...preserved.map((p) => p.y));
-      let newCount = 0;
+      // Node ids embed the resource NAME, so renaming mints a new id every
+      // keystroke. The session index is the stable identity — a laid node whose
+      // id is unknown but whose resourceIdx matches a previous node is a rename,
+      // not an addition, and inherits that node's position.
+      const posByResourceIdx = new Map<number, { x: number; y: number }>();
+      for (const n of prev) {
+        const idx = (n.data as ResourceNodeData).resourceIdx;
+        if (idx != null) posByResourceIdx.set(idx, n.position);
+      }
+      const keptIds = new Set<string>();
       const next = laid.nodes.map((n) => {
-        const kept = posById.get(n.id);
-        if (kept) return { ...n, position: kept } as CanvasFlowNode;
-        // Stagger multiple new nodes in one pass so they don't stack on each other.
-        const position = {
-          x: minX + newCount * NEW_NODE_GAP_X,
-          y: minY - NEW_NODE_OFFSET_Y,
-        };
-        newCount += 1;
-        return { ...n, position } as CanvasFlowNode;
+        const idx = (n.data as ResourceNodeData).resourceIdx;
+        const kept = posById.get(n.id) ?? (idx != null ? posByResourceIdx.get(idx) : undefined);
+        if (kept) {
+          keptIds.add(n.id);
+          return { ...n, position: kept } as CanvasFlowNode;
+        }
+        // Genuinely-new node: keep its fresh dagre coords (near its topological
+        // neighbours) — the collision pass below shoves it clear of the frozen
+        // layout instead of teleporting it to a corner.
+        return n as CanvasFlowNode;
       });
-      // TODO: a genuinely-new node parks above-left of the frozen layout and can
-      // land outside the current viewport (the user never sees it appear). A blind
-      // fitView here would work but is unsafe: this effect also re-runs on server
-      // topology refreshes (autosave), so it would reset the user's pan/zoom
-      // mid-edit and could jump the board during a drag. A clean "ensure-visible"
-      // (pan only when the new node is off-screen, no zoom reset) needs viewport
-      // math that risks disrupting drag UX, so it's deferred over forcing a fit.
-      return next;
+      return resolveCollisions(next, {
+        margin: NODE_SEP / 2,
+        isLocked: (n) => keptIds.has(n.id),
+      }) as CanvasFlowNode[];
     });
     setEdges(mergedGraph.edges as Edge[]);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally keyed on topology only

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
@@ -263,9 +263,8 @@ function StackCanvasFlow({
           return;
         }
       }
-      // Plain reposition (any node type): nudge apart any overlap the drag
-      // created. Everything except the dropped node stays pinned so the
-      // user's arrangement doesn't reshuffle — the dropped node yields.
+      // Plain reposition: only the dropped node yields to any overlap it
+      // created — the rest of the user's arrangement stays pinned.
       dragStartPos.current = null;
       setNodes(
         (prev) =>
@@ -307,11 +306,9 @@ function StackCanvasFlow({
     setNodes((prev) => {
       // Empty canvas (no preserved nodes): use the fresh dagre layout as-is.
       if (prev.length === 0) return laid.nodes as CanvasFlowNode[];
-      // Renames mint new ids (ids embed the name); carryPositions matches by
-      // stable session identity so a rename keeps its spot. Genuinely-new
-      // nodes keep their fresh dagre coords (near their topological
-      // neighbours) — the collision pass shoves them clear of the frozen
-      // layout instead of teleporting them to a corner.
+      // carryPositions keeps renamed nodes in place (ids embed the name);
+      // new nodes keep their dagre coords near their topological neighbours
+      // and the locked collision pass shoves them clear of the frozen layout.
       const { nodes: next, keptIds } = carryPositions(prev, laid.nodes as CanvasFlowNode[]);
       return resolveCollisions(next, {
         margin: NODE_SEP / 2,

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
@@ -19,8 +19,24 @@ import { useStackTopology } from "@/pages/stacks/hooks/use-stack-topology";
 import type { ReleaseLiveStatus } from "@/api/releases";
 import { deriveGraph } from "@/pages/stacks/lib/canvas/graph-from-connections";
 import { mergeTopology } from "@/pages/stacks/lib/canvas/merge-topology";
-import { layoutGraph, NODE_SEP } from "@/pages/stacks/lib/canvas/layout-graph";
-import { resolveCollisions } from "@/pages/stacks/lib/canvas/resolve-collisions";
+import {
+  layoutGraph,
+  ATTACHMENT_NODE_HEIGHT,
+  ATTACHMENT_NODE_WIDTH,
+  NODE_HEIGHT,
+  NODE_SEP,
+  NODE_WIDTH,
+} from "@/pages/stacks/lib/canvas/layout-graph";
+import { resolveCollisions, type CollidableNode } from "@/pages/stacks/lib/canvas/resolve-collisions";
+import { carryPositions } from "@/pages/stacks/lib/canvas/carry-positions";
+
+/** Collision-box dims for nodes React Flow hasn't measured yet (fresh layout
+ *  output) — attachment cards are markedly smaller than resource cards. */
+function attachmentAwareFallbackSize(node: CollidableNode): { width: number; height: number } {
+  return (node as { type?: string }).type === "attachment"
+    ? { width: ATTACHMENT_NODE_WIDTH, height: ATTACHMENT_NODE_HEIGHT }
+    : { width: NODE_WIDTH, height: NODE_HEIGHT };
+}
 import { addBlockToStack } from "@/pages/stacks/lib/block-to-form";
 import { blockCatalog, getBlockById } from "@/pages/stacks/data/blocks/registry";
 import { CanvasEditor } from "./canvas-editor";
@@ -256,6 +272,7 @@ function StackCanvasFlow({
           resolveCollisions(prev, {
             margin: NODE_SEP / 2,
             isLocked: (n) => n.id !== node.id,
+            fallbackSize: attachmentAwareFallbackSize,
           }) as CanvasFlowNode[],
       );
     },
@@ -288,34 +305,18 @@ function StackCanvasFlow({
   useEffect(() => {
     const laid = layoutGraph(mergedGraph);
     setNodes((prev) => {
-      const posById = new Map(prev.map((n) => [n.id, n.position]));
       // Empty canvas (no preserved nodes): use the fresh dagre layout as-is.
-      if (posById.size === 0) return laid.nodes as CanvasFlowNode[];
-      // Node ids embed the resource NAME, so renaming mints a new id every
-      // keystroke. The session index is the stable identity — a laid node whose
-      // id is unknown but whose resourceIdx matches a previous node is a rename,
-      // not an addition, and inherits that node's position.
-      const posByResourceIdx = new Map<number, { x: number; y: number }>();
-      for (const n of prev) {
-        const idx = (n.data as ResourceNodeData).resourceIdx;
-        if (idx != null) posByResourceIdx.set(idx, n.position);
-      }
-      const keptIds = new Set<string>();
-      const next = laid.nodes.map((n) => {
-        const idx = (n.data as ResourceNodeData).resourceIdx;
-        const kept = posById.get(n.id) ?? (idx != null ? posByResourceIdx.get(idx) : undefined);
-        if (kept) {
-          keptIds.add(n.id);
-          return { ...n, position: kept } as CanvasFlowNode;
-        }
-        // Genuinely-new node: keep its fresh dagre coords (near its topological
-        // neighbours) — the collision pass below shoves it clear of the frozen
-        // layout instead of teleporting it to a corner.
-        return n as CanvasFlowNode;
-      });
+      if (prev.length === 0) return laid.nodes as CanvasFlowNode[];
+      // Renames mint new ids (ids embed the name); carryPositions matches by
+      // stable session identity so a rename keeps its spot. Genuinely-new
+      // nodes keep their fresh dagre coords (near their topological
+      // neighbours) — the collision pass shoves them clear of the frozen
+      // layout instead of teleporting them to a corner.
+      const { nodes: next, keptIds } = carryPositions(prev, laid.nodes as CanvasFlowNode[]);
       return resolveCollisions(next, {
         margin: NODE_SEP / 2,
         isLocked: (n) => keptIds.has(n.id),
+        fallbackSize: attachmentAwareFallbackSize,
       }) as CanvasFlowNode[];
     });
     setEdges(mergedGraph.edges as Edge[]);

--- a/frontend/src/pages/stacks/lib/canvas/carry-positions.ts
+++ b/frontend/src/pages/stacks/lib/canvas/carry-positions.ts
@@ -1,0 +1,73 @@
+import { NODE_KIND } from "./graph-from-connections";
+
+/**
+ * Structural subset of a React Flow node this helper needs — pure and
+ * unit-testable without React Flow imports.
+ */
+export interface CarryableNode {
+  id: string;
+  type?: string;
+  position: { x: number; y: number };
+  measured?: { width?: number; height?: number };
+  data: { kind?: unknown; resourceIdx?: number; volumeIdx?: number; [key: string]: unknown };
+  [key: string]: unknown;
+}
+
+export interface CarryResult<T> {
+  nodes: T[];
+  /** Ids (from `laid`) whose position came from `prev` — i.e. everything that
+   *  is NOT genuinely new. Callers lock these during collision resolution. */
+  keptIds: Set<string>;
+}
+
+const isResource = (n: CarryableNode) => n.type === "resource" && n.data.resourceIdx != null;
+const isVolume = (n: CarryableNode) => n.type === "attachment" && n.data.kind === NODE_KIND.volume;
+
+/**
+ * Carry user-arranged positions from the previous node set onto a freshly
+ * laid-out one. Match by id first; a miss falls back to the node's stable
+ * session identity (resourceIdx for resources, volumeIdx for floating
+ * volumes) — node ids embed the NAME, so renaming mints a new id per
+ * keystroke and id-matching alone would treat the rename as an add.
+ *
+ * The identity fallback is parity-gated per kind: indexes are raw array
+ * positions, so a topology change that deletes AND renames in one pass
+ * shifts them — node B (idx 1) renamed after deleting A (idx 0) would
+ * inherit deleted A's position. When the kind's node count changed, the
+ * fallback is disabled and an unmatched node keeps its fresh layout coords.
+ *
+ * Kept nodes also inherit `measured` (React Flow only measures rendered
+ * nodes; fresh layout output carries none, and collision resolution needs
+ * real boxes).
+ */
+export function carryPositions<T extends CarryableNode>(prev: T[], laid: T[]): CarryResult<T> {
+  const prevById = new Map(prev.map((n) => [n.id, n]));
+
+  const resourceParity = prev.filter(isResource).length === laid.filter(isResource).length;
+  const volumeParity = prev.filter(isVolume).length === laid.filter(isVolume).length;
+
+  const prevByResourceIdx = new Map<number, T>();
+  const prevByVolumeIdx = new Map<number, T>();
+  for (const n of prev) {
+    if (isResource(n)) prevByResourceIdx.set(n.data.resourceIdx!, n);
+    else if (isVolume(n) && n.data.volumeIdx != null) prevByVolumeIdx.set(n.data.volumeIdx, n);
+  }
+
+  const keptIds = new Set<string>();
+  const nodes = laid.map((n) => {
+    let source = prevById.get(n.id);
+    if (!source) {
+      if (isResource(n) && resourceParity) source = prevByResourceIdx.get(n.data.resourceIdx!);
+      else if (isVolume(n) && volumeParity && n.data.volumeIdx != null) source = prevByVolumeIdx.get(n.data.volumeIdx);
+    }
+    if (!source) return n;
+    keptIds.add(n.id);
+    return {
+      ...n,
+      position: source.position,
+      ...(source.measured ? { measured: source.measured } : {}),
+    };
+  });
+
+  return { nodes, keptIds };
+}

--- a/frontend/src/pages/stacks/lib/canvas/graph-from-connections.ts
+++ b/frontend/src/pages/stacks/lib/canvas/graph-from-connections.ts
@@ -84,6 +84,9 @@ export interface AttachmentNodeData {
   kind: AttachmentKind;
   name: string;
   kindLabel: string; // "SECRET" | "VOLUME" | "OBJECT STORE"
+  /** Index into the draft's volumeNames array — the stable identity a volume
+   *  keeps while being renamed (its node id embeds the name). Volume kind only. */
+  volumeIdx?: number;
   [key: string]: unknown;
 }
 
@@ -282,13 +285,13 @@ export function deriveGraph(input: DeriveGraphInput): CanvasGraph {
   const edges: CanvasEdge[] = [];
   const seen = new Set<string>();
 
-  const ensureAttachment = (id: string, kind: AttachmentKind, name: string) => {
+  const ensureAttachment = (id: string, kind: AttachmentKind, name: string, volumeIdx?: number) => {
     if (nodeById.has(id)) return;
     const node: CanvasNode = {
       id,
       type: "attachment",
       position: { x: 0, y: 0 },
-      data: { kind, name, kindLabel: ATTACHMENT_LABEL[kind] },
+      data: { kind, name, kindLabel: ATTACHMENT_LABEL[kind], volumeIdx },
     };
     nodeById.set(id, node);
     nodes.push(node);
@@ -327,10 +330,10 @@ export function deriveGraph(input: DeriveGraphInput): CanvasGraph {
       if (m.source_volume_name) mountedVolumes.add(m.source_volume_name as string);
     }
   }
-  for (const volumeName of input.volumeNames ?? []) {
-    if (!volumeName || mountedVolumes.has(volumeName)) continue;
-    ensureAttachment(NODE_ID_PREFIX.volume + volumeName, NODE_KIND.volume, volumeName);
-  }
+  (input.volumeNames ?? []).forEach((volumeName, volumeIdx) => {
+    if (!volumeName || mountedVolumes.has(volumeName)) return;
+    ensureAttachment(NODE_ID_PREFIX.volume + volumeName, NODE_KIND.volume, volumeName, volumeIdx);
+  });
 
   for (const resource of input.resources) {
     for (const dep of resource.depends_on ?? []) {

--- a/frontend/src/pages/stacks/lib/canvas/layout-graph.ts
+++ b/frontend/src/pages/stacks/lib/canvas/layout-graph.ts
@@ -6,11 +6,6 @@ import type { CanvasGraph } from "./graph-from-connections";
 export const NODE_WIDTH = 216;
 export const NODE_HEIGHT = 104;
 
-/** Horizontal pitch between consecutive freshly-added nodes so they don't stack. */
-export const NEW_NODE_GAP_X = NODE_WIDTH + NODE_HEIGHT;
-/** Vertical drop below the preserved layout where new nodes are parked. */
-export const NEW_NODE_OFFSET_Y = NODE_HEIGHT * 2;
-
 export interface LayoutOptions {
   direction?: "LR" | "TB" | "BT";
 }

--- a/frontend/src/pages/stacks/lib/canvas/layout-graph.ts
+++ b/frontend/src/pages/stacks/lib/canvas/layout-graph.ts
@@ -6,6 +6,11 @@ import type { CanvasGraph } from "./graph-from-connections";
 export const NODE_WIDTH = 216;
 export const NODE_HEIGHT = 104;
 
+/** Attachment (volume/secret/object-store) card box — w-[180px], two compact
+ *  rows. Used as the collision-box fallback for unmeasured attachment nodes. */
+export const ATTACHMENT_NODE_WIDTH = 180;
+export const ATTACHMENT_NODE_HEIGHT = 56;
+
 export interface LayoutOptions {
   direction?: "LR" | "TB" | "BT";
 }

--- a/frontend/src/pages/stacks/lib/canvas/resolve-collisions.ts
+++ b/frontend/src/pages/stacks/lib/canvas/resolve-collisions.ts
@@ -1,0 +1,90 @@
+import { NODE_WIDTH, NODE_HEIGHT } from "./layout-graph";
+
+/**
+ * Structural subset of a React Flow node this util needs — keeps it pure and
+ * unit-testable without React Flow imports (mirrors layout-graph's approach).
+ */
+export interface CollidableNode {
+  id: string;
+  position: { x: number; y: number };
+  measured?: { width?: number; height?: number };
+  [key: string]: unknown;
+}
+
+export interface ResolveCollisionsOptions {
+  /** Minimum clear space to leave between node boxes after separation. */
+  margin: number;
+  /** Hard stop for the relaxation loop (a pile of N nodes needs ~N passes). */
+  maxIterations?: number;
+  /** Locked nodes are never moved; an overlap between two locked nodes is left
+   *  alone. Use to pin the user's arranged layout while placing new nodes. */
+  isLocked?: (node: CollidableNode) => boolean;
+}
+
+const DEFAULT_MAX_ITERATIONS = 50;
+
+/**
+ * Iteratively push overlapping node boxes apart along the axis of least
+ * penetration until no pair overlaps (or maxIterations). Pattern from React
+ * Flow's node-collisions example, adapted with lockable nodes so collision
+ * resolution can place NEW nodes without disturbing the frozen layout.
+ * Copy-on-write: returns the input array untouched when nothing overlaps.
+ */
+export function resolveCollisions<T extends CollidableNode>(
+  nodes: T[],
+  { margin, maxIterations = DEFAULT_MAX_ITERATIONS, isLocked }: ResolveCollisionsOptions,
+): T[] {
+  const boxes = nodes.map((n) => ({
+    node: n,
+    x: n.position.x,
+    y: n.position.y,
+    w: n.measured?.width ?? NODE_WIDTH,
+    h: n.measured?.height ?? NODE_HEIGHT,
+    locked: isLocked?.(n) ?? false,
+    moved: false,
+  }));
+
+  let anyMoved = false;
+  for (let iter = 0; iter < maxIterations; iter++) {
+    let movedThisPass = false;
+    for (let i = 0; i < boxes.length; i++) {
+      for (let j = i + 1; j < boxes.length; j++) {
+        const a = boxes[i];
+        const b = boxes[j];
+        if (a.locked && b.locked) continue;
+
+        const overlapX = Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x) + margin;
+        const overlapY = Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y) + margin;
+        if (overlapX <= 0 || overlapY <= 0) continue;
+
+        // Separate along the axis needing the smaller shove. Direction pushes
+        // the boxes' centres apart; ties push b down-right (deterministic).
+        const axis: "x" | "y" = overlapX <= overlapY ? "x" : "y";
+        const amount = axis === "x" ? overlapX : overlapY;
+        const aCentre = axis === "x" ? a.x + a.w / 2 : a.y + a.h / 2;
+        const bCentre = axis === "x" ? b.x + b.w / 2 : b.y + b.h / 2;
+        const dir = bCentre >= aCentre ? 1 : -1;
+
+        const push = (box: typeof a, delta: number) => {
+          if (axis === "x") box.x += delta;
+          else box.y += delta;
+          box.moved = true;
+        };
+        if (a.locked) push(b, dir * amount);
+        else if (b.locked) push(a, -dir * amount);
+        else {
+          push(a, -dir * (amount / 2));
+          push(b, dir * (amount / 2));
+        }
+        movedThisPass = true;
+        anyMoved = true;
+      }
+    }
+    if (!movedThisPass) break;
+  }
+
+  if (!anyMoved) return nodes;
+  return boxes.map(({ node, x, y, moved }) =>
+    moved ? { ...node, position: { x, y } } : node,
+  );
+}

--- a/frontend/src/pages/stacks/lib/canvas/resolve-collisions.ts
+++ b/frontend/src/pages/stacks/lib/canvas/resolve-collisions.ts
@@ -19,6 +19,10 @@ export interface ResolveCollisionsOptions {
   /** Locked nodes are never moved; an overlap between two locked nodes is left
    *  alone. Use to pin the user's arranged layout while placing new nodes. */
   isLocked?: (node: CollidableNode) => boolean;
+  /** Box dimensions for nodes without `measured` (fresh layout output is never
+   *  measured — React Flow only measures rendered nodes). Defaults to the
+   *  resource-card dims, which oversizes attachment nodes. */
+  fallbackSize?: (node: CollidableNode) => { width: number; height: number };
 }
 
 const DEFAULT_MAX_ITERATIONS = 50;
@@ -32,17 +36,20 @@ const DEFAULT_MAX_ITERATIONS = 50;
  */
 export function resolveCollisions<T extends CollidableNode>(
   nodes: T[],
-  { margin, maxIterations = DEFAULT_MAX_ITERATIONS, isLocked }: ResolveCollisionsOptions,
+  { margin, maxIterations = DEFAULT_MAX_ITERATIONS, isLocked, fallbackSize }: ResolveCollisionsOptions,
 ): T[] {
-  const boxes = nodes.map((n) => ({
-    node: n,
-    x: n.position.x,
-    y: n.position.y,
-    w: n.measured?.width ?? NODE_WIDTH,
-    h: n.measured?.height ?? NODE_HEIGHT,
-    locked: isLocked?.(n) ?? false,
-    moved: false,
-  }));
+  const boxes = nodes.map((n) => {
+    const fallback = fallbackSize?.(n) ?? { width: NODE_WIDTH, height: NODE_HEIGHT };
+    return {
+      node: n,
+      x: n.position.x,
+      y: n.position.y,
+      w: n.measured?.width ?? fallback.width,
+      h: n.measured?.height ?? fallback.height,
+      locked: isLocked?.(n) ?? false,
+      moved: false,
+    };
+  });
 
   let anyMoved = false;
   for (let iter = 0; iter < maxIterations; iter++) {
@@ -81,6 +88,36 @@ export function resolveCollisions<T extends CollidableNode>(
       }
     }
     if (!movedThisPass) break;
+  }
+
+  // Escape hatch: a movable node wedged in a corridor narrower than its box
+  // (between locked nodes) ping-pongs until maxIterations and would return
+  // still-overlapping. Park any such node above the bounding box of everything
+  // else, staggered — deterministic and always resolvable.
+  const stillOverlapping = (i: number) =>
+    boxes.some((other, j) => {
+      if (i === j) return false;
+      const a = boxes[i];
+      return (
+        Math.min(a.x + a.w, other.x + other.w) - Math.max(a.x, other.x) + margin > 0 &&
+        Math.min(a.y + a.h, other.y + other.h) - Math.max(a.y, other.y) + margin > 0
+      );
+    });
+  const wedged = boxes.map((_, i) => i).filter((i) => !boxes[i].locked && stillOverlapping(i));
+  // rest empty = an all-movable pile under a tiny maxIterations budget, not a
+  // locked corridor — there's no frozen layout to park against, so leave it.
+  if (wedged.length > 0 && wedged.length < boxes.length) {
+    const wedgedSet = new Set(wedged);
+    const rest = boxes.filter((_, i) => !wedgedSet.has(i));
+    const minX = Math.min(...rest.map((b) => b.x));
+    const minY = Math.min(...rest.map((b) => b.y));
+    wedged.forEach((i, k) => {
+      const b = boxes[i];
+      b.x = minX + k * (b.w + margin);
+      b.y = minY - b.h - margin;
+      b.moved = true;
+      anyMoved = true;
+    });
   }
 
   if (!anyMoved) return nodes;

--- a/frontend/src/pages/stacks/lib/canvas/tests/carry-positions.test.ts
+++ b/frontend/src/pages/stacks/lib/canvas/tests/carry-positions.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { carryPositions, type CarryableNode } from "../carry-positions";
+
+const res = (id: string, idx: number, x = 0, y = 0): CarryableNode => ({
+  id: `resource:${id}`,
+  type: "resource",
+  position: { x, y },
+  data: { kind: "service", name: id, resourceIdx: idx },
+});
+
+const vol = (name: string, idx: number, x = 0, y = 0): CarryableNode => ({
+  id: `volume:${name}`,
+  type: "attachment",
+  position: { x, y },
+  data: { kind: "volume", name, volumeIdx: idx },
+});
+
+describe("carryPositions", () => {
+  it("carries positions by id for unchanged nodes", () => {
+    const prev = [res("web", 0, 100, 200)];
+    const laid = [res("web", 0)];
+    const { nodes, keptIds } = carryPositions(prev, laid);
+    expect(nodes[0].position).toEqual({ x: 100, y: 200 });
+    expect(keptIds.has("resource:web")).toBe(true);
+  });
+
+  it("a renamed resource inherits its old position via resourceIdx", () => {
+    const prev = [res("web", 0, 100, 200), res("api", 1, 400, 200)];
+    const laid = [res("websda", 0), res("api", 1)];
+    const { nodes, keptIds } = carryPositions(prev, laid);
+    expect(nodes[0].position).toEqual({ x: 100, y: 200 });
+    expect(keptIds.has("resource:websda")).toBe(true);
+  });
+
+  it("does NOT inherit across a simultaneous delete + rename (index shift)", () => {
+    // [A(0), B(1)] -> delete A, rename B→B2: B2 now has idx 0. Inheriting A's
+    // position would teleport B2 onto the deleted node's spot.
+    const prev = [res("a", 0, 100, 200), res("b", 1, 400, 200)];
+    const laid = [res("b2", 0)];
+    const { nodes, keptIds } = carryPositions(prev, laid);
+    expect(keptIds.has("resource:b2")).toBe(false);
+    expect(nodes[0].position).toEqual({ x: 0, y: 0 }); // fresh layout coords kept
+  });
+
+  it("a renamed volume inherits its old position via volumeIdx", () => {
+    const prev = [res("web", 0, 100, 200), vol("data", 0, 700, 100)];
+    const laid = [res("web", 0), vol("dat", 0)];
+    const { nodes, keptIds } = carryPositions(prev, laid);
+    expect(nodes[1].position).toEqual({ x: 700, y: 100 });
+    expect(keptIds.has("volume:dat")).toBe(true);
+  });
+
+  it("volume parity gate: delete+rename of volumes falls back to fresh coords", () => {
+    const prev = [vol("a", 0, 100, 100), vol("b", 1, 400, 100)];
+    const laid = [vol("b2", 0)];
+    const { keptIds } = carryPositions(prev, laid);
+    expect(keptIds.has("volume:b2")).toBe(false);
+  });
+
+  it("carries measured dimensions forward for kept nodes", () => {
+    const prev = [{ ...res("web", 0, 100, 200), measured: { width: 216, height: 104 } }];
+    const laid = [res("web", 0)];
+    const { nodes } = carryPositions(prev, laid);
+    expect(nodes[0].measured).toEqual({ width: 216, height: 104 });
+  });
+
+  it("genuinely-new nodes are not in keptIds and keep their layout coords", () => {
+    const prev = [res("web", 0, 100, 200)];
+    const laid = [res("web", 0), res("api", 1, 33, 44)];
+    const { nodes, keptIds } = carryPositions(prev, laid);
+    expect(keptIds.has("resource:api")).toBe(false);
+    expect(nodes[1].position).toEqual({ x: 33, y: 44 });
+  });
+});

--- a/frontend/src/pages/stacks/lib/canvas/tests/resolve-collisions.test.ts
+++ b/frontend/src/pages/stacks/lib/canvas/tests/resolve-collisions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveCollisions, type CollidableNode } from "../canvas/resolve-collisions";
+import { resolveCollisions, type CollidableNode } from "../resolve-collisions";
 
 const node = (id: string, x: number, y: number, w = 216, h = 104): CollidableNode => ({
   id,
@@ -59,6 +59,39 @@ describe("resolveCollisions", () => {
     // One iteration may not fully resolve a pile; the call must still return.
     const out = resolveCollisions(nodes, { margin: 15, maxIterations: 1 });
     expect(out).toHaveLength(3);
+  });
+
+  it("parks a node wedged in a too-narrow locked corridor above the layout instead of returning overlap", () => {
+    // Two TALL locked walls 100px apart; a 216-wide movable node between them
+    // can never fit horizontally and the walls are too tall to slide past —
+    // it must escape above the layout, not stay overlapping.
+    const walls = [node("left", 0, 0, 216, 2000), node("right", 316, 0, 216, 2000)];
+    const trapped = node("t", 100, 900);
+    const out = resolveCollisions([...walls, trapped], {
+      margin: 15,
+      isLocked: (n) => n.id !== "t",
+    });
+    const t = out.find((n) => n.id === "t")!;
+    for (const w of out.filter((n) => n.id !== "t")) {
+      expect(rectsOverlap(t, w)).toBe(false);
+    }
+    expect(t.position.y).toBeLessThan(0); // parked above the frozen layout
+  });
+
+  it("uses fallbackSize for unmeasured nodes", () => {
+    // Unmeasured node sitting 60px above a locked box: with the 56px-tall
+    // attachment fallback its bottom edge (-4) clears the box; the default
+    // 104px fallback would read as overlapping and shove it.
+    const small = { id: "s", position: { x: 0, y: -60 } }; // no measured
+    const big = node("b", 0, 0);
+    const opts = { margin: 0, isLocked: (n: { id: string }) => n.id === "b" };
+    const withFallback = resolveCollisions([big, small], {
+      ...opts,
+      fallbackSize: () => ({ width: 180, height: 56 }),
+    });
+    expect(withFallback.find((n) => n.id === "s")!.position).toEqual({ x: 0, y: -60 });
+    const withoutFallback = resolveCollisions([big, small], opts);
+    expect(withoutFallback.find((n) => n.id === "s")!.position).not.toEqual({ x: 0, y: -60 });
   });
 
   it("does not mutate the input nodes", () => {

--- a/frontend/src/pages/stacks/lib/tests/resolve-collisions.test.ts
+++ b/frontend/src/pages/stacks/lib/tests/resolve-collisions.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { resolveCollisions, type CollidableNode } from "../canvas/resolve-collisions";
+
+const node = (id: string, x: number, y: number, w = 216, h = 104): CollidableNode => ({
+  id,
+  position: { x, y },
+  measured: { width: w, height: h },
+});
+
+const rectsOverlap = (a: CollidableNode, b: CollidableNode, margin = 0) => {
+  const aw = a.measured!.width!, ah = a.measured!.height!;
+  const bw = b.measured!.width!, bh = b.measured!.height!;
+  return (
+    a.position.x < b.position.x + bw + margin &&
+    b.position.x < a.position.x + aw + margin &&
+    a.position.y < b.position.y + bh + margin &&
+    b.position.y < a.position.y + ah + margin
+  );
+};
+
+describe("resolveCollisions", () => {
+  it("returns the same array when nothing overlaps", () => {
+    const nodes = [node("a", 0, 0), node("b", 500, 0)];
+    expect(resolveCollisions(nodes, { margin: 15 })).toBe(nodes);
+  });
+
+  it("separates two overlapping nodes to at least the margin", () => {
+    const nodes = [node("a", 0, 0), node("b", 40, 10)];
+    const out = resolveCollisions(nodes, { margin: 15 });
+    expect(rectsOverlap(out[0], out[1])).toBe(false);
+  });
+
+  it("never moves locked nodes — the movable one is pushed instead", () => {
+    const nodes = [node("a", 0, 0), node("b", 40, 10)];
+    const out = resolveCollisions(nodes, { margin: 15, isLocked: (n) => n.id === "a" });
+    expect(out[0].position).toEqual({ x: 0, y: 0 });
+    expect(rectsOverlap(out[0], out[1])).toBe(false);
+  });
+
+  it("leaves a locked-locked overlap alone and terminates", () => {
+    const nodes = [node("a", 0, 0), node("b", 10, 10)];
+    const out = resolveCollisions(nodes, { margin: 15, isLocked: () => true });
+    expect(out[0].position).toEqual({ x: 0, y: 0 });
+    expect(out[1].position).toEqual({ x: 10, y: 10 });
+  });
+
+  it("resolves a pile of stacked nodes into a fully non-overlapping set", () => {
+    const nodes = [node("a", 0, 0), node("b", 5, 5), node("c", 10, 10), node("d", 15, 15)];
+    const out = resolveCollisions(nodes, { margin: 15 });
+    for (let i = 0; i < out.length; i++) {
+      for (let j = i + 1; j < out.length; j++) {
+        expect(rectsOverlap(out[i], out[j])).toBe(false);
+      }
+    }
+  });
+
+  it("respects maxIterations as a hard stop", () => {
+    const nodes = [node("a", 0, 0), node("b", 1, 1), node("c", 2, 2)];
+    // One iteration may not fully resolve a pile; the call must still return.
+    const out = resolveCollisions(nodes, { margin: 15, maxIterations: 1 });
+    expect(out).toHaveLength(3);
+  });
+
+  it("does not mutate the input nodes", () => {
+    const nodes = [node("a", 0, 0), node("b", 40, 10)];
+    resolveCollisions(nodes, { margin: 15 });
+    expect(nodes[1].position).toEqual({ x: 40, y: 10 });
+  });
+});


### PR DESCRIPTION
## 📝 What this does
Typing in a resource's Name field made its canvas node teleport to the top-left of the layout on the first keystroke. Canvas node ids embed the resource name, so every keystroke minted a new node id; the position-preserving re-layout classified it as a freshly-added node and applied the anti-collision parking spot. Renames now keep their position, and new-node placement moves to React Flow's collision-resolution pattern.

## 🔀 Changes
- Renamed resources inherit their previous canvas position via the stable session index instead of being treated as new nodes
- Added a lockable AABB collision resolver (adapted from React Flow's node-collisions example) that pushes overlapping nodes apart along the axis of least penetration
- New nodes now keep their natural dagre coordinates near their topological neighbours and get nudged clear of the frozen layout, replacing the park-above-left heuristic that could land them off-screen
- Dropping a dragged node runs the same collision pass, so manual repositioning can't leave two cards overlapped

## 🧪 How to test
- [ ] Open a stack, click a resource node, type in the Name field — the node must not move
- [ ] Add a new resource from the canvas — it appears near its connected nodes without overlapping anything
- [ ] Drag a node onto another and release — the dropped node nudges apart instead of stacking
- [ ] Drag a volume onto a resource — the attach flow still triggers (collision pass must not interfere)