### PR TITLE
Fix: least-privilege RBAC for the hub service account

### DIFF
--- a/install/manifests/rbac.yaml
+++ b/install/manifests/rbac.yaml
@@ -17,9 +17,63 @@ metadata:
     app.kubernetes.io/managed-by: stackdome-installer
     stackdome.io/bootstrap: "true"
 rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]
+  # Stackdome CRs: hub writes desired state, watches status (informers need list+watch).
+  - apiGroups: ["core.stackdome.io"]
+    resources: ["stacks", "stackresources"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["storage.stackdome.io"]
+    resources: ["volumes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["users.stackdome.io"]
+    resources: ["users"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["registry.stackdome.io"]
+    resources: ["clusterregistries"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["addons.stackdome.io"]
+    resources: ["postgresclusters"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  # Agent-created build CRs: hub only observes.
+  - apiGroups: ["builds.stackdome.io"]
+    resources: ["imagebuilds"]
+    verbs: ["get", "list", "watch"]
+  # TLS issuer provisioned once per cluster at registration.
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "create"]
+  # Postgres addon dependencies.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["imagecatalogs"]
+    verbs: ["get", "create"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["backups"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["barmancloud.cnpg.io"]
+    resources: ["objectstores"]
+    verbs: ["get", "create", "update", "delete"]
+  # Workload namespaces and app/registry/backup secrets.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "delete"]
+  # Log streaming and metrics.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/magefile.go
+++ b/magefile.go
@@ -1251,57 +1251,14 @@ metadata:
 		return fmt.Errorf("failed to ensure namespace: %w", err)
 	}
 
-	// Create ServiceAccount
-	if err := runKubectlApply(ctx, kubeconfig, fmt.Sprintf(`
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: %s
-  namespace: %s`, DevSAName, DevSANamespace)); err != nil {
-		return fmt.Errorf("failed to create service account: %w", err)
-	}
-
-	// Create ClusterRole with full permissions for API server
-	if err := runKubectlApply(ctx, kubeconfig, fmt.Sprintf(`
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: %s
-rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]`, DevRoleName)); err != nil {
-		return fmt.Errorf("failed to create cluster role: %w", err)
-	}
-
-	// Create ClusterRoleBinding
-	if err := runKubectlApply(ctx, kubeconfig, fmt.Sprintf(`
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: %s-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: %s
-subjects:
-  - kind: ServiceAccount
-    name: %s
-    namespace: %s`, DevRoleName, DevRoleName, DevSAName, DevSANamespace)); err != nil {
-		return fmt.Errorf("failed to create cluster role binding: %w", err)
-	}
-
-	// Create Secret for ServiceAccount token
-	if err := runKubectlApply(ctx, kubeconfig, fmt.Sprintf(`
-apiVersion: v1
-kind: Secret
-metadata:
-  name: %s
-  namespace: %s
-  annotations:
-    kubernetes.io/service-account.name: %s
-type: kubernetes.io/service-account-token`, DevSecretName, DevSANamespace, DevSAName)); err != nil {
-		return fmt.Errorf("failed to create secret: %w", err)
+	// SA, ClusterRole, binding and token secret come from the install manifest
+	// (single source of truth for the hub's least-privilege rules).
+	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig,
+		"apply", "-f", "install/manifests/rbac.yaml")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to apply install/manifests/rbac.yaml: %w", err)
 	}
 
 	// Wait for token to be populated

--- a/test/int/bootstrap/client.go
+++ b/test/int/bootstrap/client.go
@@ -162,22 +162,107 @@ func deployAPIServerServiceAccount(ctx context.Context, cluster *testutil.TestCl
 		return fmt.Errorf("failed to create service account: %w", err)
 	}
 
-	// Create cluster role
+	// Create cluster role — rules mirror install/manifests/rbac.yaml (keep in sync)
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "stackdome-api-server-role",
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups: []string{"*"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
+				APIGroups: []string{"core.stackdome.io"},
+				Resources: []string{"stacks", "stackresources"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{"storage.stackdome.io"},
+				Resources: []string{"volumes"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{"users.stackdome.io"},
+				Resources: []string{"users"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{"registry.stackdome.io"},
+				Resources: []string{"clusterregistries"},
+				Verbs:     []string{"get", "list", "watch", "create", "delete"},
+			},
+			{
+				APIGroups: []string{"addons.stackdome.io"},
+				Resources: []string{"postgresclusters"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{"builds.stackdome.io"},
+				Resources: []string{"imagebuilds"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"cert-manager.io"},
+				Resources: []string{"clusterissuers"},
+				Verbs:     []string{"get", "create"},
+			},
+			{
+				APIGroups: []string{"postgresql.cnpg.io"},
+				Resources: []string{"imagecatalogs"},
+				Verbs:     []string{"get", "create"},
+			},
+			{
+				APIGroups: []string{"postgresql.cnpg.io"},
+				Resources: []string{"backups"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"barmancloud.cnpg.io"},
+				Resources: []string{"objectstores"},
+				Verbs:     []string{"get", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs:     []string{"get", "create", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods/log"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes"},
+				Verbs:     []string{"list"},
+			},
+			{
+				APIGroups: []string{"metrics.k8s.io"},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list"},
 			},
 		},
 	}
 	_, err = kubeClient.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
-	if err != nil && !strings.Contains(err.Error(), "already exists") {
-		return fmt.Errorf("failed to create cluster role: %w", err)
+	if err != nil {
+		if !strings.Contains(err.Error(), "already exists") {
+			return fmt.Errorf("failed to create cluster role: %w", err)
+		}
+		if _, err := kubeClient.RbacV1().ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update cluster role: %w", err)
+		}
 	}
 
 	// Create cluster role binding

--- a/test/int/bootstrap/client.go
+++ b/test/int/bootstrap/client.go
@@ -19,6 +19,19 @@ import (
 const (
 	controlPlaneNamespace   = "stackdome-control-plane"
 	apiServerServiceAccount = "stackdome-api-server-account"
+
+	verbGet    = "get"
+	verbList   = "list"
+	verbWatch  = "watch"
+	verbCreate = "create"
+	verbUpdate = "update"
+	verbDelete = "delete"
+)
+
+var (
+	verbsFull      = []string{verbGet, verbList, verbWatch, verbCreate, verbUpdate, verbDelete}
+	verbsReadOnly  = []string{verbGet, verbList, verbWatch}
+	verbsGetCreate = []string{verbGet, verbCreate}
 )
 
 type ClientManager struct {
@@ -171,87 +184,87 @@ func deployAPIServerServiceAccount(ctx context.Context, cluster *testutil.TestCl
 			{
 				APIGroups: []string{"core.stackdome.io"},
 				Resources: []string{"stacks", "stackresources"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+				Verbs:     verbsFull,
 			},
 			{
 				APIGroups: []string{"storage.stackdome.io"},
 				Resources: []string{"volumes"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+				Verbs:     verbsFull,
 			},
 			{
 				APIGroups: []string{"users.stackdome.io"},
 				Resources: []string{"users"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+				Verbs:     verbsFull,
 			},
 			{
 				APIGroups: []string{"registry.stackdome.io"},
 				Resources: []string{"clusterregistries"},
-				Verbs:     []string{"get", "list", "watch", "create", "delete"},
+				Verbs:     []string{verbGet, verbList, verbWatch, verbCreate, verbDelete},
 			},
 			{
 				APIGroups: []string{"addons.stackdome.io"},
 				Resources: []string{"postgresclusters"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+				Verbs:     verbsFull,
 			},
 			{
 				APIGroups: []string{"builds.stackdome.io"},
 				Resources: []string{"imagebuilds"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     verbsReadOnly,
 			},
 			{
 				APIGroups: []string{"cert-manager.io"},
 				Resources: []string{"clusterissuers"},
-				Verbs:     []string{"get", "create"},
+				Verbs:     verbsGetCreate,
 			},
 			{
 				APIGroups: []string{"postgresql.cnpg.io"},
 				Resources: []string{"imagecatalogs"},
-				Verbs:     []string{"get", "create"},
+				Verbs:     verbsGetCreate,
 			},
 			{
 				APIGroups: []string{"postgresql.cnpg.io"},
 				Resources: []string{"backups"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     verbsReadOnly,
 			},
 			{
 				APIGroups: []string{"barmancloud.cnpg.io"},
 				Resources: []string{"objectstores"},
-				Verbs:     []string{"get", "create", "update", "delete"},
+				Verbs:     []string{verbGet, verbCreate, verbUpdate, verbDelete},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"namespaces"},
-				Verbs:     []string{"get", "create", "delete"},
+				Verbs:     []string{verbGet, verbCreate, verbDelete},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"secrets"},
-				Verbs:     []string{"get", "create", "update", "delete"},
+				Verbs:     []string{verbGet, verbCreate, verbUpdate, verbDelete},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
+				Verbs:     []string{verbGet, verbList},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods/log"},
-				Verbs:     []string{"get"},
+				Verbs:     []string{verbGet},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"services"},
-				Verbs:     []string{"get"},
+				Verbs:     []string{verbGet},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"nodes"},
-				Verbs:     []string{"list"},
+				Verbs:     []string{verbList},
 			},
 			{
 				APIGroups: []string{"metrics.k8s.io"},
 				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
+				Verbs:     []string{verbGet, verbList},
 			},
 		},
 	}


### PR DESCRIPTION
## 📝 What this does
Replaces the hub service account's `*:*` ClusterRole with an audited least-privilege rule set, and makes every environment consume the same manifest. The hub registers the control-plane cluster as a managed cluster using this SA's token, so this role is the exact permission boundary the API server operates under.

Stacked on #179 (uses its integration-bootstrap changes) — retarget to `main` once that merges.

## 🔀 Changes
- Replaced the wildcard ClusterRole in the install manifest with 17 scoped rules covering exactly what the hub does: Stackdome CRs, cert-manager issuer setup, CNPG/barman backup dependencies, and core namespaces, secrets, pod logs, and metrics.
- Left out everything the audit proved the hub never does: `pods/exec` and `portforward` (agent-provisioned user grants), events, leases (leadership is DB-based), workload kinds (the agent's job), and `patch`.
- Unified all environments on the manifest: `mage dev:setup` (and therefore `hack/run_local.sh`) now applies `install/manifests/rbac.yaml` instead of its own inline wildcard role.
- Mirrored the rules in the integration-test bootstrap and made it update the role in place so rule changes apply to reused clusters.

## 🧪 How to test
- [ ] Run the integration suite — it provisions the SA with these rules; the full run passes with zero Forbidden errors
- [ ] Run `mage dev:setup` and confirm the dev cluster's role matches the manifest (`kubectl get clusterrole stackdome-api-server-role -o yaml`)
- [ ] Deploy a stack with a postgres addon and delete the addon — CR deletion was the one verb the initial audit missed, caught by e2e
- [ ] Check API-server logs for `is forbidden` after exercising builds, logs, metrics, and volume flows