### PR TITLE
Fix: exempt SSE streaming routes from the 180s request timeout

### DIFF
--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -11,6 +11,23 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// Route names for the streaming (SSE) endpoints. These are exempted from the
+// request timeout middleware so long-running follow streams are not cut off.
+const (
+	routeNameStreamStackLogs     = "stream-stack-logs"
+	routeNameStreamResourceLogs  = "stream-resource-logs"
+	routeNameStreamReleaseEvents = "stream-release-events"
+)
+
+// streamingRouteNames is the set of route names exempt from the request timeout.
+func streamingRouteNames() map[string]struct{} {
+	return map[string]struct{}{
+		routeNameStreamStackLogs:     {},
+		routeNameStreamResourceLogs:  {},
+		routeNameStreamReleaseEvents: {},
+	}
+}
+
 func (s apiServer) routes() *mux.Router {
 	mainRouter := mux.NewRouter()
 
@@ -266,14 +283,14 @@ func (s apiServer) routes() *mux.Router {
 	projectResourceRouter.HandleFunc("/stacks/{id}", stackHandler.Update).Methods(http.MethodPut)
 	projectResourceRouter.HandleFunc("/stacks/{id}/apply", stackHandler.Apply).Methods(http.MethodPut)
 	projectResourceRouter.HandleFunc("/stacks/{id}", stackHandler.Delete).Methods(http.MethodDelete)
-	projectResourceRouter.HandleFunc("/stacks/{id}/logs", stackHandler.StreamLogs).Methods(http.MethodGet)
+	projectResourceRouter.HandleFunc("/stacks/{id}/logs", stackHandler.StreamLogs).Methods(http.MethodGet).Name(routeNameStreamStackLogs)
 	projectResourceRouter.HandleFunc("/stacks/{id}/metrics", stackHandler.GetMetrics).Methods(http.MethodGet)
 	projectResourceRouter.HandleFunc("/stacks/{id}/resources", stackResourceHandler.Create).Methods(http.MethodPost)
 	projectResourceRouter.HandleFunc("/stacks/{id}/resources", stackResourceHandler.List).Methods(http.MethodGet)
 	projectResourceRouter.HandleFunc("/stacks/{id}/resources/{resource_name}", stackResourceHandler.GetByResourceName).Methods(http.MethodGet)
 	projectResourceRouter.HandleFunc("/stacks/{id}/resources/{resource_name}", stackResourceHandler.Update).Methods(http.MethodPut)
 	projectResourceRouter.HandleFunc("/stacks/{id}/resources/{resource_name}", stackResourceHandler.Delete).Methods(http.MethodDelete)
-	projectResourceRouter.HandleFunc("/stacks/{id}/resources/{resource_name}/logs", stackResourceHandler.StreamLogs).Methods(http.MethodGet)
+	projectResourceRouter.HandleFunc("/stacks/{id}/resources/{resource_name}/logs", stackResourceHandler.StreamLogs).Methods(http.MethodGet).Name(routeNameStreamResourceLogs)
 	projectResourceRouter.HandleFunc("/stacks/{id}/resources/{resource_name}/metrics", stackResourceHandler.GetMetrics).Methods(http.MethodGet)
 	projectResourceRouter.HandleFunc("/stacks/{id}/resources/{resource_name}/builds", imageBuildHandler.ListByResourceName).Methods(http.MethodGet)
 	projectResourceRouter.HandleFunc("/stacks/{id}/resources/{resource_name}/actions/restart", stackResourceHandler.Restart).Methods(http.MethodPost)
@@ -289,7 +306,7 @@ func (s apiServer) routes() *mux.Router {
 	projectResourceRouter.HandleFunc("/stacks/{id}/releases/{release_id}", stackReleaseHandler.GetByID).Methods(http.MethodGet)
 	projectResourceRouter.HandleFunc("/stacks/{id}/releases/{release_id}/cancel", stackReleaseHandler.Cancel).Methods(http.MethodPost)
 	projectResourceRouter.HandleFunc("/stacks/{id}/releases/{release_id}/events", stackReleaseHandler.ListEvents).Methods(http.MethodGet)
-	projectResourceRouter.HandleFunc("/stacks/{id}/releases/{release_id}/events/stream", stackReleaseHandler.StreamEvents).Methods(http.MethodGet)
+	projectResourceRouter.HandleFunc("/stacks/{id}/releases/{release_id}/events/stream", stackReleaseHandler.StreamEvents).Methods(http.MethodGet).Name(routeNameStreamReleaseEvents)
 
 	// Secrets (project-scoped)
 	projectResourceRouter.HandleFunc("/secrets", secretHandler.Create).Methods(http.MethodPost)

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -17,7 +17,13 @@ import (
 	applogger "github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/google/uuid"
 	gorillahandlers "github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
 )
+
+// requestTimeoutDuration bounds how long a normal request may run before its
+// context is cancelled. Streaming (SSE) routes are exempt via
+// newRequestTimeoutMiddleware so long-running follow streams are not cut off.
+const requestTimeoutDuration = 180 * time.Second
 
 type Server interface {
 	Start()
@@ -49,6 +55,11 @@ func NewAPIServer(env environment.EnvImpl) Server {
 	openapi, err := NewOpenAPIMiddleWare(openapi.OpenAPISpec)
 	check(err, "Unable to create openapi spec middleware")
 	mainRouter.Use(openapi.Middleware)
+
+	// Apply the request timeout as router middleware so it can be exempted
+	// per-route. Streaming (SSE) routes carry a name in streamingRouteNames and
+	// are skipped, letting follow=true streams outlive the timeout.
+	mainRouter.Use(newRequestTimeoutMiddleware(requestTimeoutDuration, streamingRouteNames()))
 
 	// referring to the router as type http.Handler allows us to add middleware via more handlers
 	var mainHandler http.Handler = mainRouter
@@ -83,7 +94,7 @@ func NewAPIServer(env environment.EnvImpl) Server {
 
 	s.httpServer = &http.Server{
 		Addr:        env.Environment().Config.Server.BindAddress,
-		Handler:     WithRequestTimeoutMiddleware(mainHandler, 180*time.Second),
+		Handler:     mainHandler,
 		ReadTimeout: 120 * time.Second,
 	}
 
@@ -239,13 +250,23 @@ func removeTrailingSlash(next http.Handler) http.Handler {
 	})
 }
 
-func WithRequestTimeoutMiddleware(next http.Handler, timeoutDuration time.Duration) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancelFn := context.WithTimeout(r.Context(), timeoutDuration)
-		defer cancelFn()
-		r = r.WithContext(ctx)
-		next.ServeHTTP(w, r)
-	})
+// newRequestTimeoutMiddleware returns gorilla/mux middleware that applies a
+// context timeout to every matched route except those whose route name is in
+// exemptRouteNames (the streaming SSE routes). mux applies parent-router
+// middleware to the matched leaf route, so mux.CurrentRoute reflects the
+// specific route being served.
+func newRequestTimeoutMiddleware(timeoutDuration time.Duration, exemptRouteNames map[string]struct{}) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, exempt := exemptRouteNames[mux.CurrentRoute(r).GetName()]; exempt {
+				next.ServeHTTP(w, r)
+				return
+			}
+			ctx, cancelFn := context.WithTimeout(r.Context(), timeoutDuration)
+			defer cancelFn()
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }
 
 func check(err error, msg string) {

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Server Suite")
+}
+
+var _ = Describe("newRequestTimeoutMiddleware", func() {
+	const testTimeout = 50 * time.Millisecond
+
+	var (
+		router            *mux.Router
+		normalDeadlineSet bool
+		streamDeadlineSet bool
+	)
+
+	captureDeadline := func(target *bool) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			_, ok := r.Context().Deadline()
+			*target = ok
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+
+	BeforeEach(func() {
+		normalDeadlineSet = false
+		streamDeadlineSet = false
+
+		// Mirror production wiring: streaming routes live on a nested subrouter
+		// and carry a name; the timeout middleware is applied to the parent.
+		router = mux.NewRouter()
+		sub := router.PathPrefix("/api/v1").Subrouter()
+		sub.HandleFunc("/stacks/{id}/logs", captureDeadline(&streamDeadlineSet)).
+			Methods(http.MethodGet).Name(routeNameStreamStackLogs)
+		sub.HandleFunc("/stacks/{id}", captureDeadline(&normalDeadlineSet)).
+			Methods(http.MethodGet)
+
+		router.Use(newRequestTimeoutMiddleware(testTimeout, streamingRouteNames()))
+	})
+
+	It("applies a request timeout to a normal route", func() {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/stacks/abc", nil)
+		router.ServeHTTP(httptest.NewRecorder(), req)
+		Expect(normalDeadlineSet).To(BeTrue())
+	})
+
+	It("does not apply a request timeout to a streaming (SSE) route", func() {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/stacks/abc/logs", nil)
+		router.ServeHTTP(httptest.NewRecorder(), req)
+		Expect(streamDeadlineSet).To(BeFalse())
+	})
+})


### PR DESCRIPTION
## 📝 What this does
Live log and event streams (`follow=true`) were being cut off at 180 seconds by the global request-timeout middleware — even while the pod or Kaniko build was still producing output. Long image builds that run past three minutes were the most visible casualty: the client saw the stream end mid-build. Streaming routes are now exempt from the deadline.

## 🔀 Changes
- Moved the request timeout from an outer wrap on the HTTP server handler to gorilla/mux router middleware that inspects the matched route.
- Named the SSE routes (stack logs, resource logs, release-event stream) and exempted them from the timeout.
- Every non-streaming route still gets the 180s budget; auth, CORS, logging, and openapi middleware are unchanged.

## 🧪 How to test
- [ ] Stream a resource's logs with `follow=true` and confirm the stream stays open past 3 minutes.
- [ ] Hit a normal endpoint and confirm it still times out at 180s.