### PR TITLE
Fix: don't re-emit a superseded release's failure on the next release

### DIFF
--- a/pkg/controllers/stackresource/stack_resource_controller.go
+++ b/pkg/controllers/stackresource/stack_resource_controller.go
@@ -149,7 +149,7 @@ func (w *stackResourceReconciler) recordResourceEvent(ctx context.Context, stack
 	if resource.Status == nil {
 		return
 	}
-	eventType, reason, message, emit := resourceEvent(resource.Status.Conditions, resource.Status.LastFailure, convergedForGeneration(cr))
+	eventType, reason, message, emit := resourceEvent(resource.Status.Conditions, resource.Status.LastFailure, convergedForGeneration(cr), stalledForGeneration(cr), observedForGeneration(cr))
 	if !emit {
 		return
 	}
@@ -191,6 +191,26 @@ func convergedForGeneration(cr *corev1alpha1.StackResource) bool {
 	return cond != nil && cond.Status == metav1.ConditionTrue && cond.ObservedGeneration == cr.Generation
 }
 
+// stalledForGeneration reports whether the Stalled condition was written for the
+// CR's current generation. Like convergedForGeneration it reads the raw CR
+// because the server-side condition model drops ObservedGeneration. The agent
+// does not rewrite Stalled on a NotReady report, so a stale Stalled=True can
+// outlive its generation even after the top-level Status.ObservedGeneration
+// advances — the condition's own ObservedGeneration is the authoritative signal.
+func stalledForGeneration(cr *corev1alpha1.StackResource) bool {
+	cond := meta.FindStatusCondition(cr.Status.Conditions, string(corev1alpha1.StackResourceStalled))
+	return cond != nil && cond.ObservedGeneration == cr.Generation
+}
+
+// observedForGeneration reports whether the CR's status was written for its
+// current generation. The cluster agent stamps Status.ObservedGeneration on
+// every terminal report, so a status still carrying a prior generation's value
+// is a leftover from a superseded rollout. Used to gate the runtime-failure
+// path, whose LastFailureDetails carry no generation of their own.
+func observedForGeneration(cr *corev1alpha1.StackResource) bool {
+	return cr.Status.ObservedGeneration == cr.Generation
+}
+
 // resourceEvent maps the cluster-agent's status conditions (and any captured
 // runtime crash detail) to a release timeline event. Conditions are the
 // authoritative signal — Phase is a coarse rollup the agent writes alongside
@@ -203,12 +223,22 @@ func convergedForGeneration(cr *corev1alpha1.StackResource) bool {
 // therefore additionally requires converged, and the not-converged path keeps
 // the Converged condition's detail so a stuck rollout is diagnosable from the
 // timeline.
-func resourceEvent(conditions []models.Condition, failure *models.StackResourceFailure, converged bool) (eventType models.ReleaseEventType, reason, message string, emit bool) {
+//
+// A failure carried over from a prior generation must not be attributed to the
+// new release, so both failure paths are gated the same way the Ready path is
+// gated on convergedForGeneration: the Stalled condition only counts for its own
+// current generation (stalledCurrentGeneration), and the runtime crash detail
+// only counts when the status as a whole is for the current generation
+// (runtimeCurrentGeneration). A terminal build failure is suppressed regardless
+// of generation because those events are always the imagebuild controller's.
+func resourceEvent(conditions []models.Condition, failure *models.StackResourceFailure, converged, stalledCurrentGeneration, runtimeCurrentGeneration bool) (eventType models.ReleaseEventType, reason, message string, emit bool) {
 	if cond := models.FindCondition(conditions, string(corev1alpha1.StackResourceStalled)); cond != nil && cond.Status == string(models.ConditionTrue) {
 		if cond.Reason == stalledReasonBuildFailed {
 			return "", "", "", false
 		}
-		return models.ReleaseEventTypeResourceFailed, cond.Reason, cond.Message, true
+		if stalledCurrentGeneration {
+			return models.ReleaseEventTypeResourceFailed, cond.Reason, cond.Message, true
+		}
 	}
 	if cond := models.FindCondition(conditions, string(corev1alpha1.StackResourceDependenciesReady)); cond != nil && cond.Status == string(models.ConditionFalse) {
 		return models.ReleaseEventTypeResourceWaiting, cond.Reason, cond.Message, true
@@ -216,7 +246,7 @@ func resourceEvent(conditions []models.Condition, failure *models.StackResourceF
 	if cond := models.FindCondition(conditions, string(corev1alpha1.StackResourceBuildReady)); cond != nil && cond.Status == string(models.ConditionFalse) {
 		return "", "", "", false
 	}
-	if r, m := runtimeFailureDetail(failure); r != "" || m != "" {
+	if r, m := runtimeFailureDetail(failure); (r != "" || m != "") && runtimeCurrentGeneration {
 		return models.ReleaseEventTypeResourceFailed, r, m, true
 	}
 	available := models.FindCondition(conditions, string(corev1alpha1.StackResourceStatusAvailable))

--- a/pkg/controllers/stackresource/stack_resource_controller_test.go
+++ b/pkg/controllers/stackresource/stack_resource_controller_test.go
@@ -191,13 +191,15 @@ func cond(condType string, status string, reason, message string) models.Conditi
 }
 
 type resourceEventCase struct {
-	conditions  []models.Condition
-	failure     *models.StackResourceFailure
-	converged   bool
-	wantType    models.ReleaseEventType
-	wantReason  string
-	wantMessage string
-	wantEmit    bool
+	conditions               []models.Condition
+	failure                  *models.StackResourceFailure
+	converged                bool
+	stalledCurrentGeneration bool
+	runtimeCurrentGeneration bool
+	wantType                 models.ReleaseEventType
+	wantReason               string
+	wantMessage              string
+	wantEmit                 bool
 }
 
 var _ = Describe("resourceEvent", func() {
@@ -211,7 +213,7 @@ var _ = Describe("resourceEvent", func() {
 
 	DescribeTable("mapping conditions and failures to release events",
 		func(tc resourceEventCase) {
-			gotType, gotReason, gotMessage, gotEmit := resourceEvent(tc.conditions, tc.failure, tc.converged)
+			gotType, gotReason, gotMessage, gotEmit := resourceEvent(tc.conditions, tc.failure, tc.converged, tc.stalledCurrentGeneration, tc.runtimeCurrentGeneration)
 			Expect(gotEmit).To(Equal(tc.wantEmit))
 			if !tc.wantEmit {
 				return
@@ -245,30 +247,45 @@ var _ = Describe("resourceEvent", func() {
 			wantMessage: "waiting for redis",
 			wantEmit:    true,
 		}),
-		Entry("stalled records failed with the condition reason and message", resourceEventCase{
+		Entry("stalled for the current generation records failed with the condition reason and message", resourceEventCase{
 			conditions: []models.Condition{
 				cond(string(corev1alpha1.StackResourceStalled), string(models.ConditionTrue), "JobFailed", "job has reached the specified backoff limit"),
 			},
-			wantType:    models.ReleaseEventTypeResourceFailed,
-			wantReason:  "JobFailed",
-			wantMessage: "job has reached the specified backoff limit",
-			wantEmit:    true,
+			stalledCurrentGeneration: true,
+			wantType:                 models.ReleaseEventTypeResourceFailed,
+			wantReason:               "JobFailed",
+			wantMessage:              "job has reached the specified backoff limit",
+			wantEmit:                 true,
+		}),
+		Entry("stalled carried over from a previous generation does not record failed", resourceEventCase{
+			conditions: []models.Condition{
+				cond(string(corev1alpha1.StackResourceStalled), string(models.ConditionTrue), "JobFailed", "job has reached the specified backoff limit"),
+			},
+			stalledCurrentGeneration: false,
+			wantEmit:                 false,
 		}),
 		Entry("stalled by a terminal build failure is the imagebuild controller's event", resourceEventCase{
 			conditions: []models.Condition{
 				cond(string(corev1alpha1.StackResourceStalled), string(models.ConditionTrue), stalledReasonBuildFailed, "application build failed terminally"),
 			},
-			wantEmit: false,
+			stalledCurrentGeneration: true,
+			wantEmit:                 false,
 		}),
-		Entry("runtime crash records failed with both reason and message", resourceEventCase{
+		Entry("runtime crash for the current generation records failed with both reason and message", resourceEventCase{
 			conditions: []models.Condition{
 				cond(string(corev1alpha1.StackResourceConverged), string(models.ConditionFalse), "NotConverged", "rollout not converged"),
 			},
-			failure:     runtimeCrash,
-			wantType:    models.ReleaseEventTypeResourceFailed,
-			wantReason:  "CrashLoopBackOff",
-			wantMessage: "back-off restarting failed container",
-			wantEmit:    true,
+			failure:                  runtimeCrash,
+			runtimeCurrentGeneration: true,
+			wantType:                 models.ReleaseEventTypeResourceFailed,
+			wantReason:               "CrashLoopBackOff",
+			wantMessage:              "back-off restarting failed container",
+			wantEmit:                 true,
+		}),
+		Entry("runtime crash carried over from a previous generation does not record failed", resourceEventCase{
+			failure:                  runtimeCrash,
+			runtimeCurrentGeneration: false,
+			wantEmit:                 false,
 		}),
 		Entry("carried-over build failure does not masquerade as a runtime failure", resourceEventCase{
 			conditions: []models.Condition{
@@ -413,6 +430,49 @@ func failedStackResourceCR(hash string, conditions []metav1.Condition) *corev1al
 	}
 }
 
+// generationCR builds a CR pinned to an explicit generation and observed
+// generation, optionally carrying a runtime-crash LastFailure, so a superseded
+// rollout's failure (observedGeneration < generation, or a Stalled condition
+// whose ObservedGeneration lags) can be reproduced.
+func generationCR(generation, observedGeneration int64, conditions []metav1.Condition, withRuntimeFailure bool) *corev1alpha1.StackResource {
+	cr := &corev1alpha1.StackResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "web",
+			Namespace:  "ns-1",
+			Generation: generation,
+			Labels:     map[string]string{corev1alpha1.LabelStackID: "stack-1"},
+		},
+		Status: corev1alpha1.StackResourceStatus{
+			Phase:              corev1alpha1.StackResourcePhaseFailed,
+			StatusHash:         "gen-hash",
+			ObservedGeneration: observedGeneration,
+			Conditions:         conditions,
+		},
+	}
+	if withRuntimeFailure {
+		cr.Status.LastFailureDetails = []corev1alpha1.LastFailureDetail{
+			{
+				ContainerName:           "web",
+				RestartCount:            3,
+				LastTerminationReason:   "CrashLoopBackOff",
+				LastTerminationMessage:  "back-off restarting failed container",
+				LastTerminationExitCode: ptr.To(int32(1)),
+			},
+		}
+	}
+	return cr
+}
+
+func stalledCondition(observedGeneration int64) metav1.Condition {
+	return metav1.Condition{
+		Type:               string(corev1alpha1.StackResourceStalled),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: observedGeneration,
+		Reason:             "InvalidSpec",
+		Message:            "invalid workload spec",
+	}
+}
+
 func newReconcilerForTest(cr *corev1alpha1.StackResource) (
 	*stackResourceReconciler,
 	*mocks.MockStackResourceService,
@@ -525,6 +585,75 @@ var _ = Describe("Reconcile", func() {
 		checker.EXPECT().InternalGetActiveByStackID(gomock.Any(), "stack-1").Return(release, nil)
 		recorder.EXPECT().
 			RecordResourceEvent(gomock.Any(), release, "web", models.ReleaseEventTypeResourceFailed, "InvalidSpec", "invalid workload spec").
+			Return(nil)
+
+		_, err := r.Reconcile(context.Background(), reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// Bug: a Stalled failure left over from a superseded release (its condition
+	// ObservedGeneration lags the CR generation) must NOT be re-emitted as
+	// resource_failed against the newly active release. The status update still
+	// persists, but no active-release lookup or event record happens.
+	It("does not record a stalled failure carried over from a previous generation", func() {
+		cr := generationCR(2, 2, []metav1.Condition{stalledCondition(1)}, false)
+		r, svc, _, _ := newReconcilerForTest(cr)
+
+		db := &models.StackResource{ID: "sr-1", Name: "web", Status: &models.StackResourceStatus{LastObservedStatusHash: "old"}}
+		svc.EXPECT().InternalGetByStackIDAndResourceName(gomock.Any(), "stack-1", "web").Return(db, nil)
+		svc.EXPECT().UpdateStatus(gomock.Any(), "sr-1", gomock.Any()).Return(nil)
+		// checker + recorder must not be called.
+
+		_, err := r.Reconcile(context.Background(), reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// Bug: a runtime crash captured under a superseded release (top-level
+	// ObservedGeneration lags the CR generation) must NOT be re-emitted as
+	// resource_failed against the newly active release.
+	It("does not record a runtime failure carried over from a previous generation", func() {
+		cr := generationCR(2, 1, nil, true)
+		r, svc, _, _ := newReconcilerForTest(cr)
+
+		db := &models.StackResource{ID: "sr-1", Name: "web", Status: &models.StackResourceStatus{LastObservedStatusHash: "old"}}
+		svc.EXPECT().InternalGetByStackIDAndResourceName(gomock.Any(), "stack-1", "web").Return(db, nil)
+		svc.EXPECT().UpdateStatus(gomock.Any(), "sr-1", gomock.Any()).Return(nil)
+		// checker + recorder must not be called.
+
+		_, err := r.Reconcile(context.Background(), reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// A stalled failure for the current generation still records resource_failed.
+	It("records a stalled failure for the current generation", func() {
+		cr := generationCR(2, 2, []metav1.Condition{stalledCondition(2)}, false)
+		r, svc, checker, recorder := newReconcilerForTest(cr)
+
+		release := &models.StackRelease{ID: "rel-2"}
+		db := &models.StackResource{ID: "sr-1", Name: "web", Status: &models.StackResourceStatus{LastObservedStatusHash: "old"}}
+		svc.EXPECT().InternalGetByStackIDAndResourceName(gomock.Any(), "stack-1", "web").Return(db, nil)
+		svc.EXPECT().UpdateStatus(gomock.Any(), "sr-1", gomock.Any()).Return(nil)
+		checker.EXPECT().InternalGetActiveByStackID(gomock.Any(), "stack-1").Return(release, nil)
+		recorder.EXPECT().
+			RecordResourceEvent(gomock.Any(), release, "web", models.ReleaseEventTypeResourceFailed, "InvalidSpec", "invalid workload spec").
+			Return(nil)
+
+		_, err := r.Reconcile(context.Background(), reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// A runtime crash for the current generation still records resource_failed.
+	It("records a runtime failure for the current generation", func() {
+		cr := generationCR(2, 2, nil, true)
+		r, svc, checker, recorder := newReconcilerForTest(cr)
+
+		release := &models.StackRelease{ID: "rel-2"}
+		db := &models.StackResource{ID: "sr-1", Name: "web", Status: &models.StackResourceStatus{LastObservedStatusHash: "old"}}
+		svc.EXPECT().InternalGetByStackIDAndResourceName(gomock.Any(), "stack-1", "web").Return(db, nil)
+		svc.EXPECT().UpdateStatus(gomock.Any(), "sr-1", gomock.Any()).Return(nil)
+		checker.EXPECT().InternalGetActiveByStackID(gomock.Any(), "stack-1").Return(release, nil)
+		recorder.EXPECT().
+			RecordResourceEvent(gomock.Any(), release, "web", models.ReleaseEventTypeResourceFailed, "CrashLoopBackOff", "back-off restarting failed container").
 			Return(nil)
 
 		_, err := r.Reconcile(context.Background(), reconcileRequest())


### PR DESCRIPTION
## 📝 What this does
When a release failed and a new one was created, the new release's activity feed showed the *old* release's `RESOURCE_FAILED` event — timestamped a moment before the new release even started building, then persisted for good even as that release went on to deploy successfully. The failure paths, unlike the Ready path, weren't checking whether the observed status actually belonged to the current rollout.

## 🔀 Changes
- Gated both resource-failure paths on the current CR generation, mirroring how the Ready path already trusts the converged condition's generation.
- Runtime failures gate on the CR's top-level `ObservedGeneration`; the Stalled path gates on the Stalled condition's own `ObservedGeneration`, because the top-level field advances to the new generation while a prior generation's Stalled condition can still linger.
- Ready-path behavior and the per-release event dedupe are unchanged.

## 🧪 How to test
- [ ] Fail a release, then trigger a new release for the same stack; confirm the new release's feed shows no carried-over `resource_failed` before its build starts.
- [ ] Cause a genuine current-generation failure and confirm `resource_failed` is still emitted.