### PR TITLE
Fix: block creating a stack with an existing name

### DIFF
--- a/frontend/src/pages/stacks/components/editor/index.tsx
+++ b/frontend/src/pages/stacks/components/editor/index.tsx
@@ -27,7 +27,8 @@ import type { FormStackResourceData, FormVolumeExtendedData as VolumeFormData, F
 import type { StackResource, Volume, Stack } from "@/pages/stacks/types";
 import type { StackConnection } from "@/api/connections";
 import { alignBaselineToDraft, renameFingerprint } from "@/pages/stacks/lib/stack-diff";
-import { applyStackByName, getStackById, deleteStack } from "@/api/stacks";
+import { applyStackByName, getStackById, deleteStack, getStacksByOrg } from "@/api/stacks";
+import { stackNameConflictError } from "@/pages/stacks/lib/stack-name-conflict";
 import { createStackFetchGate } from "@/pages/stacks/lib/canvas/stack-fetch-gate";
 import { draftToSnapshot } from "@/pages/stacks/lib/draft-sync/draft-snapshot";
 import { emptyDraftSeed, buildDraftFormData, type DraftSeed } from "@/pages/stacks/lib/canvas/draft-seed";
@@ -85,7 +86,7 @@ export default function CanvasEditorPage() {
 
   const { setCustomLabel, setPathLoading } = useBreadcrumb();
   const { toast } = useToast();
-  const { projectNameById, defaultProjectName } = useResourceProjects();
+  const { projects, projectNameById, defaultProjectName } = useResourceProjects();
   const { canWrite } = useCurrentUser();
 
   const currentStack = stacks.find((stack) => stack.id === id);
@@ -735,6 +736,26 @@ export default function CanvasEditorPage() {
           description: "Could not resolve a project to save into.",
           variant: "destructive",
         });
+        setDraftDeploying(false);
+        return;
+      }
+
+      const projectId = projects.find((p) => p.default_project)?.id ?? "";
+      let existingStacks: Stack[] = [];
+      try {
+        existingStacks = (await getStacksByOrg(orgId)).items ?? [];
+      } catch {
+        existingStacks = [];
+      }
+      const conflict = stackNameConflictError({
+        isCreate: isNewStack,
+        name: formStackData.name,
+        projectId,
+        existingStacks,
+      });
+      if (conflict) {
+        setNameError(conflict);
+        toast({ title: "Name already taken", description: conflict, variant: "destructive" });
         setDraftDeploying(false);
         return;
       }

--- a/frontend/src/pages/stacks/lib/stack-name-conflict.test.ts
+++ b/frontend/src/pages/stacks/lib/stack-name-conflict.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { stackNameConflictError, stackNameTakenMessage } from "./stack-name-conflict";
+import type { Stack } from "@/pages/stacks/types";
+
+const stack = (name: string, project_id: string): Pick<Stack, "name" | "project_id"> => ({
+  name,
+  project_id,
+});
+
+const projectId = "project-1";
+const existingStacks = [stack("api", projectId), stack("web", "project-2")];
+
+describe("stackNameConflictError", () => {
+  it("blocks create when the name is already taken in the target project", () => {
+    const err = stackNameConflictError({
+      isCreate: true,
+      name: "api",
+      projectId,
+      existingStacks,
+    });
+    expect(err).toBe(stackNameTakenMessage("api"));
+  });
+
+  it("allows create when the name is free in the target project", () => {
+    const err = stackNameConflictError({
+      isCreate: true,
+      name: "worker",
+      projectId,
+      existingStacks,
+    });
+    expect(err).toBeUndefined();
+  });
+
+  it("does not treat a name taken only in another project as a conflict", () => {
+    const err = stackNameConflictError({
+      isCreate: true,
+      name: "web",
+      projectId,
+      existingStacks,
+    });
+    expect(err).toBeUndefined();
+  });
+
+  it("trims the candidate name before comparing", () => {
+    const err = stackNameConflictError({
+      isCreate: true,
+      name: "  api  ",
+      projectId,
+      existingStacks,
+    });
+    expect(err).toBe(stackNameTakenMessage("api"));
+  });
+
+  it("matches case-sensitively", () => {
+    const err = stackNameConflictError({
+      isCreate: true,
+      name: "API",
+      projectId,
+      existingStacks,
+    });
+    expect(err).toBeUndefined();
+  });
+
+  it("never blocks the update path even on a name collision", () => {
+    const err = stackNameConflictError({
+      isCreate: false,
+      name: "api",
+      projectId,
+      existingStacks,
+    });
+    expect(err).toBeUndefined();
+  });
+});

--- a/frontend/src/pages/stacks/lib/stack-name-conflict.ts
+++ b/frontend/src/pages/stacks/lib/stack-name-conflict.ts
@@ -1,0 +1,18 @@
+import type { Stack } from "@/pages/stacks/types";
+
+export const stackNameTakenMessage = (name: string): string =>
+  `A stack named "${name}" already exists`;
+
+export function stackNameConflictError(params: {
+  isCreate: boolean;
+  name: string;
+  projectId: string;
+  existingStacks: Pick<Stack, "name" | "project_id">[];
+}): string | undefined {
+  if (!params.isCreate) return undefined;
+  const trimmed = params.name.trim();
+  const taken = params.existingStacks.some(
+    (s) => s.project_id === params.projectId && s.name === trimmed,
+  );
+  return taken ? stackNameTakenMessage(trimmed) : undefined;
+}


### PR DESCRIPTION
## 📝 What this does
Creating a stack and editing one both go through the same upsert-by-name apply endpoint, so a user who intended to create a *new* stack but picked a name already in use silently overwrote the existing stack with no warning. The create flow now catches the collision up front.

## 🔀 Changes
- On the create path only, the editor checks the org's stacks for a name collision in the target project before applying, matching the backend's case-sensitive, per-project uniqueness.
- On collision, a "name already taken" error is shown on the name field and the create is blocked instead of clobbering the existing stack.
- Editing an existing stack is unaffected. The check is best-effort — the server-side upsert stays the final authority.

## 🧪 How to test
- [ ] Create a stack, then start a new stack with the same name; confirm it's blocked with a name error.
- [ ] Create a stack with a fresh name; confirm it proceeds.
- [ ] Open an existing stack and redeploy; confirm editing is not blocked.