### PR TITLE
Fix: eslint indentation error in header-collapse.ts

### DIFF
--- a/frontend/src/pages/stacks/lib/canvas/header-collapse.ts
+++ b/frontend/src/pages/stacks/lib/canvas/header-collapse.ts
@@ -6,4 +6,4 @@ import { createContext } from "react";
 export const HeaderCollapseContext = createContext<{
   collapsed: boolean;
   setCollapsed: (collapsed: boolean) => void;
-}>({ collapsed: false, setCollapsed: () => {} });
+    }>({ collapsed: false, setCollapsed: () => {} });


### PR DESCRIPTION
## 📝 What this does
The `lint & test` CI job is failing on `main` on a single eslint indentation error in `header-collapse.ts` (introduced in #181). Because the lint step runs across the whole repo and hard-fails on any error, every branch cut from `main` inherits a red check. This applies the eslint autofix so CI goes green again.

## 🔀 Changes
- Fixed the continuation-line indentation flagged by the `indent` rule (autofix).

## 🧪 How to test
- [ ] Run `pnpm --prefix frontend lint`; confirm 0 errors.

> Merge this first — PRs #182–#185 are blocked by the same failing lint job and will pass on re-run once this lands on `main`.