### PR TITLE
Feature: Connection details on the Postgres add-on page

### DIFF
--- a/frontend/src/api/addons.ts
+++ b/frontend/src/api/addons.ts
@@ -6,6 +6,8 @@ export type PostgresAddonList = components["schemas"]["PostgresAddonList"];
 export type PostgresAddonSpec = components["schemas"]["PostgresAddonSpec"];
 export type PostgresAddonStatus = components["schemas"]["PostgresAddonStatus"];
 export type PostgresAddonState = NonNullable<PostgresAddonStatus["state"]>;
+export type PostgresConnectionInfo = components["schemas"]["PostgresConnectionInfo"];
+export type PostgresCredentials = components["schemas"]["PostgresCredentials"];
 
 export type PostgresAddonCreateInput = Pick<PostgresAddon, "name" | "spec"> &
   Partial<Pick<PostgresAddon, "labels" | "annotations" | "cluster_id">>;
@@ -43,4 +45,20 @@ export async function updatePostgresAddon(
 
 export async function deletePostgresAddon(orgId: string, projectName: string, id: string): Promise<void> {
   await api.delete(`/organizations/${orgId}/projects/${projectName}/addons/postgres/${id}`);
+}
+
+// Credentials are minted on demand from the cluster secret — never persisted by the hub,
+// so every reveal is a fresh read.
+export async function getPostgresCredentials(
+  orgId: string,
+  projectName: string,
+  id: string,
+  database: string,
+  superuser: boolean,
+): Promise<PostgresCredentials> {
+  const res = await api.get(
+    `/organizations/${orgId}/projects/${projectName}/addons/postgres/${id}/credentials/${encodeURIComponent(database)}`,
+    { params: { superuser } },
+  );
+  return res.data as PostgresCredentials;
 }

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,13 @@
+export async function copyText(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  // Clipboard API unavailable (insecure context): textarea fallback.
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  document.body.appendChild(ta);
+  ta.select();
+  document.execCommand("copy");
+  ta.remove();
+}

--- a/frontend/src/pages/addons/components/postgres-connection-panel.tsx
+++ b/frontend/src/pages/addons/components/postgres-connection-panel.tsx
@@ -321,8 +321,7 @@ export function PostgresConnectionPanel({
       />
 
       <p className="max-w-2xl text-[12px] text-muted-foreground">
-        Reachable from stacks running on this cluster. The database is not exposed to the
-        internet — connect from a stack, or port-forward for a local session.
+        Reachable from your stacks. The database is not exposed to the internet.
       </p>
 
       <div className="flex flex-col gap-3 border-t border-border pt-5">

--- a/frontend/src/pages/addons/components/postgres-connection-panel.tsx
+++ b/frontend/src/pages/addons/components/postgres-connection-panel.tsx
@@ -1,0 +1,409 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { Check, Copy, Download, Eye, EyeOff, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Panel, EmptyState, StatusPill } from "@/components/branded";
+import { getErrorMessage } from "@/api/client";
+import {
+  getPostgresCredentials,
+  type PostgresAddon,
+  type PostgresCredentials,
+} from "@/api/addons";
+import { getCurrentOrganizationId } from "@/helpers/common";
+import { ADDON_OUTPUT_FIELDS } from "@/pages/stacks/lib/addon-presets";
+import { copyText } from "@/lib/clipboard";
+import { cn } from "@/lib/utils";
+
+const COPY_FLASH_MS = 1400;
+const MASK = "••••••••••••";
+
+interface CredentialState {
+  loading: boolean;
+  error: string | null;
+  credentials: PostgresCredentials | null;
+  superuser: boolean;
+  revealed: boolean;
+}
+
+const INITIAL: CredentialState = {
+  loading: true,
+  error: null,
+  credentials: null,
+  superuser: false,
+  revealed: false,
+};
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout>>(null);
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      aria-label={label}
+      className="size-7 text-muted-foreground hover:text-foreground"
+      onClick={() => {
+        void copyText(value).then(() => {
+          setCopied(true);
+          if (timer.current) clearTimeout(timer.current);
+          timer.current = setTimeout(() => setCopied(false), COPY_FLASH_MS);
+        });
+      }}
+    >
+      {copied ? <Check className="size-3.5 text-success" /> : <Copy className="size-3.5" />}
+    </Button>
+  );
+}
+
+function ValueRow({
+  label,
+  display,
+  copyValue,
+  copyLabel,
+  action,
+  className,
+}: {
+  label: ReactNode;
+  display: ReactNode;
+  copyValue?: string;
+  copyLabel?: string;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex min-w-0 flex-col gap-1", className)}>
+      <span className="text-[12px] text-muted-foreground">{label}</span>
+      <div className="flex min-w-0 items-start gap-1">
+        <span className="min-w-0 flex-1 break-all pt-1 font-mono text-[13px] leading-5 text-foreground">
+          {display}
+        </span>
+        {action}
+        {copyValue !== undefined && <CopyButton value={copyValue} label={copyLabel ?? "Copy"} />}
+      </div>
+    </div>
+  );
+}
+
+function maskPassword(url: string, password: string): string {
+  if (!password) return url;
+  return url.split(password).join(MASK).split(encodeURIComponent(password)).join(MASK);
+}
+
+function downloadCertificate(database: string, certificate: string) {
+  const url = URL.createObjectURL(new Blob([certificate], { type: "application/x-pem-file" }));
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `${database}-ca.crt`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function CredentialsBlock({
+  database,
+  state,
+  superuserAllowed,
+  onScopeChange,
+  onReveal,
+  onRetry,
+}: {
+  database: string;
+  state: CredentialState;
+  superuserAllowed: boolean;
+  onScopeChange: (superuser: boolean) => void;
+  onReveal: () => void;
+  onRetry: () => void;
+}) {
+  if (state.loading) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-border bg-muted/25 px-4 py-3 text-[13px] text-muted-foreground">
+        <Loader2 className="size-3.5 animate-spin" />
+        Reading credentials…
+      </div>
+    );
+  }
+
+  if (state.error) {
+    return (
+      <div className="flex items-center justify-between gap-4 rounded-md border border-danger-border bg-danger-bg px-4 py-3">
+        <span className="text-[13px] text-danger">{state.error}</span>
+        <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  const credentials = state.credentials;
+  if (!credentials) return null;
+
+  const password = credentials.password ?? "";
+  const url = credentials.connectionString ?? "";
+  const certificate = credentials.caCertificate ?? "";
+
+  return (
+    <div className="flex flex-col gap-4 rounded-md border border-border bg-muted/25 px-4 py-3.5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <span className="text-[12.5px] text-muted-foreground">
+          Credentials for <span className="font-mono text-foreground">{database}</span>
+        </span>
+        {superuserAllowed && (
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant={state.superuser ? "outline" : "secondary"}
+              size="sm"
+              onClick={() => onScopeChange(false)}
+            >
+              Owner
+            </Button>
+            <Button
+              type="button"
+              variant={state.superuser ? "secondary" : "outline"}
+              size="sm"
+              onClick={() => onScopeChange(true)}
+            >
+              Superuser
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <ValueRow
+          label="Username"
+          display={credentials.username ?? "—"}
+          copyValue={credentials.username ?? ""}
+          copyLabel="Copy username"
+        />
+        <ValueRow
+          label="Password"
+          display={state.revealed ? password : MASK}
+          copyValue={password}
+          copyLabel="Copy password"
+          action={
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={state.revealed ? "Hide password" : "Reveal password"}
+              className="size-7 text-muted-foreground hover:text-foreground"
+              onClick={onReveal}
+            >
+              {state.revealed ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+            </Button>
+          }
+        />
+      </div>
+
+      <ValueRow
+        label="Connection URL"
+        display={state.revealed ? url : maskPassword(url, password)}
+        copyValue={url}
+        copyLabel="Copy connection URL"
+      />
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <ValueRow label="SSL mode" display={credentials.sslMode ?? "—"} />
+        {certificate && (
+          <ValueRow
+            label="CA certificate"
+            display={<span className="text-muted-foreground">PEM certificate</span>}
+            copyValue={certificate}
+            copyLabel="Copy CA certificate"
+            action={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Download CA certificate"
+                className="size-7 text-muted-foreground hover:text-foreground"
+                onClick={() => downloadCertificate(database, certificate)}
+              >
+                <Download className="size-3.5" />
+              </Button>
+            }
+          />
+        )}
+      </div>
+
+      <p className="text-[12px] text-muted-foreground">
+        Copy always copies the real value — only the text on screen is masked.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Connection details for a Postgres add-on: the in-cluster endpoint from the
+ * add-on status, plus per-database credentials read on demand.
+ */
+export function PostgresConnectionPanel({
+  addon,
+  projectName,
+}: {
+  addon: PostgresAddon;
+  projectName: string;
+}) {
+  const [states, setStates] = useState<Record<string, CredentialState>>({});
+  const info = addon.status?.connection_info;
+  const databases = info?.databases ?? [];
+  const appUserSecrets = info?.credentials?.app_user_secrets ?? {};
+  const superuserAllowed = !!addon.spec.configuration?.enable_superuser_access;
+
+  const load = useCallback(
+    async (database: string, superuser: boolean) => {
+      const orgId = getCurrentOrganizationId();
+      if (!orgId || !addon.id) return;
+      setStates((prev) => ({ ...prev, [database]: { ...INITIAL, superuser } }));
+      try {
+        const credentials = await getPostgresCredentials(
+          orgId,
+          projectName,
+          addon.id,
+          database,
+          superuser,
+        );
+        setStates((prev) => ({
+          ...prev,
+          [database]: { loading: false, error: null, credentials, superuser, revealed: false },
+        }));
+      } catch (e) {
+        setStates((prev) => ({
+          ...prev,
+          [database]: {
+            loading: false,
+            error: getErrorMessage(e),
+            credentials: null,
+            superuser,
+            revealed: false,
+          },
+        }));
+      }
+    },
+    [addon.id, projectName],
+  );
+
+  const hide = useCallback((database: string) => {
+    setStates((prev) => {
+      const next = { ...prev };
+      delete next[database];
+      return next;
+    });
+  }, []);
+
+  const toggleReveal = useCallback((database: string) => {
+    setStates((prev) => {
+      const current = prev[database];
+      if (!current) return prev;
+      return { ...prev, [database]: { ...current, revealed: !current.revealed } };
+    });
+  }, []);
+
+  const body = !info || databases.length === 0 ? (
+    <EmptyState
+      title="No connection details yet"
+      description="Connection details appear once the database is ready."
+    />
+  ) : (
+    <div className="flex flex-col gap-6">
+      <div className="grid max-w-3xl grid-cols-1 gap-5 sm:grid-cols-2">
+        <ValueRow
+          label="Host"
+          display={info.host ?? "—"}
+          copyValue={info.host ?? ""}
+          copyLabel="Copy host"
+        />
+        <ValueRow label="Port" display={info.port ?? 5432} />
+      </div>
+
+      <p className="max-w-2xl text-[12px] text-muted-foreground">
+        Reachable from stacks running on this cluster. The database is not exposed to the
+        internet — connect from a stack, or port-forward for a local session.
+      </p>
+
+      <div className="flex flex-col gap-3 border-t border-border pt-5">
+        <h3 className="text-sm font-semibold text-foreground">Databases</h3>
+        {databases.map((db) => {
+          const name = db.name ?? "";
+          const state = states[name];
+          return (
+            <div key={name} className="flex flex-col gap-3 border-b border-border pb-3 last:border-b-0 last:pb-0">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-col gap-0.5">
+                  <span className="font-mono text-[13px] text-foreground">{name}</span>
+                  <span className="text-[12px] text-muted-foreground">
+                    Owner <span className="font-mono">{db.owner ?? "—"}</span>
+                    {appUserSecrets[name] && (
+                      <>
+                        {" · secret "}
+                        <span className="font-mono">{appUserSecrets[name]}</span>
+                      </>
+                    )}
+                  </span>
+                </div>
+                {state ? (
+                  <Button type="button" variant="outline" size="sm" onClick={() => hide(name)}>
+                    <EyeOff className="size-3.5" />
+                    Hide
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void load(name, false)}
+                  >
+                    <Eye className="size-3.5" />
+                    Show credentials
+                  </Button>
+                )}
+              </div>
+              {state && (
+                <CredentialsBlock
+                  database={name}
+                  state={state}
+                  superuserAllowed={superuserAllowed}
+                  onScopeChange={(superuser) => void load(name, superuser)}
+                  onReveal={() => toggleReveal(name)}
+                  onRetry={() => void load(name, state.superuser)}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-col gap-3 border-t border-border pt-5">
+        <h3 className="text-sm font-semibold text-foreground">Use from a stack</h3>
+        <p className="max-w-2xl text-[12px] leading-relaxed text-muted-foreground">
+          On a stack resource, add an env connection from this add-on, pick the database and
+          credential scope, then map any of these outputs to environment variable names. The
+          values are injected as secret references when the stack is released — nothing is
+          baked into the image, and rotating the add-on password reaches the app on its next
+          release.
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {ADDON_OUTPUT_FIELDS.map((field) => (
+            <span
+              key={field}
+              className="rounded-sm border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-[11.5px] text-muted-foreground"
+            >
+              {field}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <Panel
+      title="Connection"
+      action={<StatusPill variant="neutral" withDot={false}>In-cluster only</StatusPill>}
+    >
+      {body}
+    </Panel>
+  );
+}

--- a/frontend/src/pages/addons/components/postgres-connection-panel.tsx
+++ b/frontend/src/pages/addons/components/postgres-connection-panel.tsx
@@ -9,12 +9,12 @@ import {
   type PostgresCredentials,
 } from "@/api/addons";
 import { getCurrentOrganizationId } from "@/helpers/common";
-import { ADDON_OUTPUT_FIELDS } from "@/pages/stacks/lib/addon-presets";
 import { copyText } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 
 const COPY_FLASH_MS = 1400;
 const MASK = "••••••••••••";
+const DEFAULT_PORT = 5432;
 
 interface CredentialState {
   loading: boolean;
@@ -76,7 +76,7 @@ function ValueRow({
     <div className={cn("flex min-w-0 flex-col gap-1", className)}>
       <span className="text-[12px] text-muted-foreground">{label}</span>
       <div className="flex min-w-0 items-start gap-1">
-        <span className="min-w-0 flex-1 break-all pt-1 font-mono text-[13px] leading-5 text-foreground">
+        <span className="min-w-0 break-all pt-1 font-mono text-[13px] leading-5 text-foreground">
           {display}
         </span>
         {action}
@@ -308,15 +308,17 @@ export function PostgresConnectionPanel({
     />
   ) : (
     <div className="flex flex-col gap-6">
-      <div className="grid max-w-3xl grid-cols-1 gap-5 sm:grid-cols-2">
-        <ValueRow
-          label="Host"
-          display={info.host ?? "—"}
-          copyValue={info.host ?? ""}
-          copyLabel="Copy host"
-        />
-        <ValueRow label="Port" display={info.port ?? 5432} />
-      </div>
+      <ValueRow
+        label="Endpoint"
+        display={
+          <>
+            {info.host ?? "—"}
+            <span className="text-muted-foreground">:{info.port ?? DEFAULT_PORT}</span>
+          </>
+        }
+        copyValue={`${info.host ?? ""}:${info.port ?? DEFAULT_PORT}`}
+        copyLabel="Copy endpoint"
+      />
 
       <p className="max-w-2xl text-[12px] text-muted-foreground">
         Reachable from stacks running on this cluster. The database is not exposed to the
@@ -373,27 +375,6 @@ export function PostgresConnectionPanel({
             </div>
           );
         })}
-      </div>
-
-      <div className="flex flex-col gap-3 border-t border-border pt-5">
-        <h3 className="text-sm font-semibold text-foreground">Use from a stack</h3>
-        <p className="max-w-2xl text-[12px] leading-relaxed text-muted-foreground">
-          On a stack resource, add an env connection from this add-on, pick the database and
-          credential scope, then map any of these outputs to environment variable names. The
-          values are injected as secret references when the stack is released — nothing is
-          baked into the image, and rotating the add-on password reaches the app on its next
-          release.
-        </p>
-        <div className="flex flex-wrap gap-1.5">
-          {ADDON_OUTPUT_FIELDS.map((field) => (
-            <span
-              key={field}
-              className="rounded-sm border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-[11.5px] text-muted-foreground"
-            >
-              {field}
-            </span>
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/addons/components/tests/postgres-connection-panel.test.tsx
+++ b/frontend/src/pages/addons/components/tests/postgres-connection-panel.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PostgresAddon, PostgresCredentials } from "@/api/addons";
+
+vi.mock("@/api/addons", async () => {
+  const actual = await vi.importActual<typeof import("@/api/addons")>("@/api/addons");
+  return { ...actual, getPostgresCredentials: vi.fn() };
+});
+
+vi.mock("@/helpers/common", () => ({
+  getCurrentOrganizationId: vi.fn(() => "org-1"),
+}));
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    getErrorMessage: vi.fn((e: unknown) => (e as { message?: string })?.message ?? "error"),
+  };
+});
+
+import { getPostgresCredentials } from "@/api/addons";
+import { ADDON_OUTPUT_FIELDS } from "@/pages/stacks/lib/addon-presets";
+import { PostgresConnectionPanel } from "../postgres-connection-panel";
+
+const mockedCredentials = vi.mocked(getPostgresCredentials);
+
+const CREDENTIALS: PostgresCredentials = {
+  database: "app",
+  host: "pg-rw.addons.svc.cluster.local",
+  port: 5432,
+  username: "app",
+  password: "s3cr3t-pw",
+  sslMode: "require",
+  connectionString: "postgresql://app:s3cr3t-pw@pg-rw.addons.svc.cluster.local:5432/app?sslmode=require",
+  caCertificate: "-----BEGIN CERTIFICATE-----",
+};
+
+function mkAddon(overrides: Partial<PostgresAddon> = {}): PostgresAddon {
+  return {
+    id: "addon-1",
+    name: "asdasdff12",
+    spec: {
+      version: { major: 17 },
+      instances: { count: 1 },
+      storage: { size: "10Gi" },
+      configuration: { enable_superuser_access: false },
+    },
+    status: {
+      state: "Ready",
+      connection_info: {
+        host: "pg-rw.addons.svc.cluster.local",
+        port: 5432,
+        databases: [{ name: "app", owner: "app" }],
+        credentials: { app_user_secrets: { app: "addon-1-app" } },
+      },
+    },
+    ...overrides,
+  } as PostgresAddon;
+}
+
+beforeEach(() => {
+  mockedCredentials.mockReset();
+  Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+});
+afterEach(cleanup);
+
+describe("PostgresConnectionPanel", () => {
+  it("shows the in-cluster endpoint and databases from the addon status", () => {
+    render(<PostgresConnectionPanel addon={mkAddon()} projectName="default" />);
+
+    expect(screen.getByText("pg-rw.addons.svc.cluster.local")).toBeInTheDocument();
+    expect(screen.getByText("5432")).toBeInTheDocument();
+    expect(screen.getAllByText("app").length).toBeGreaterThan(0);
+    expect(screen.getByText("addon-1-app")).toBeInTheDocument();
+  });
+
+  it("lists every addon output that a stack env connection can map", () => {
+    render(<PostgresConnectionPanel addon={mkAddon()} projectName="default" />);
+
+    for (const field of ADDON_OUTPUT_FIELDS) {
+      expect(screen.getAllByText(field).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("renders an empty state when the addon has no connection info", () => {
+    const addon = mkAddon({ status: { state: "Creating" } });
+    render(<PostgresConnectionPanel addon={addon} projectName="default" />);
+
+    expect(screen.getByText("No connection details yet")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /show credentials/i })).not.toBeInTheDocument();
+  });
+
+  it("fetches credentials on demand and masks the password until revealed", async () => {
+    mockedCredentials.mockResolvedValue(CREDENTIALS);
+    render(<PostgresConnectionPanel addon={mkAddon()} projectName="default" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /show credentials/i }));
+
+    await waitFor(() =>
+      expect(mockedCredentials).toHaveBeenCalledWith("org-1", "default", "addon-1", "app", false),
+    );
+    expect(await screen.findByText("require")).toBeInTheDocument();
+    expect(screen.queryByText(CREDENTIALS.password!)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /reveal password/i }));
+    expect(screen.getByText(CREDENTIALS.password!)).toBeInTheDocument();
+  });
+
+  it("copies the real password even while it is masked", async () => {
+    mockedCredentials.mockResolvedValue(CREDENTIALS);
+    render(<PostgresConnectionPanel addon={mkAddon()} projectName="default" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /show credentials/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /copy password/i }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(CREDENTIALS.password);
+  });
+
+  it("re-reads credentials with the superuser scope when superuser access is on", async () => {
+    mockedCredentials.mockResolvedValue(CREDENTIALS);
+    const addon = mkAddon();
+    addon.spec.configuration = { enable_superuser_access: true };
+    render(<PostgresConnectionPanel addon={addon} projectName="default" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /show credentials/i }));
+    await userEvent.click(await screen.findByRole("button", { name: "Superuser" }));
+
+    await waitFor(() =>
+      expect(mockedCredentials).toHaveBeenLastCalledWith("org-1", "default", "addon-1", "app", true),
+    );
+  });
+
+  it("surfaces a fetch failure inline with a retry", async () => {
+    mockedCredentials.mockRejectedValueOnce(new Error("cluster unreachable"));
+    render(<PostgresConnectionPanel addon={mkAddon()} projectName="default" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /show credentials/i }));
+    expect(await screen.findByText("cluster unreachable")).toBeInTheDocument();
+
+    mockedCredentials.mockResolvedValue(CREDENTIALS);
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(await screen.findByText("require")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/addons/components/tests/postgres-connection-panel.test.tsx
+++ b/frontend/src/pages/addons/components/tests/postgres-connection-panel.test.tsx
@@ -23,7 +23,6 @@ vi.mock("@/api/client", async () => {
 });
 
 import { getPostgresCredentials } from "@/api/addons";
-import { ADDON_OUTPUT_FIELDS } from "@/pages/stacks/lib/addon-presets";
 import { PostgresConnectionPanel } from "../postgres-connection-panel";
 
 const mockedCredentials = vi.mocked(getPostgresCredentials);
@@ -73,17 +72,19 @@ describe("PostgresConnectionPanel", () => {
     render(<PostgresConnectionPanel addon={mkAddon()} projectName="default" />);
 
     expect(screen.getByText("pg-rw.addons.svc.cluster.local")).toBeInTheDocument();
-    expect(screen.getByText("5432")).toBeInTheDocument();
+    expect(screen.getByText(":5432")).toBeInTheDocument();
     expect(screen.getAllByText("app").length).toBeGreaterThan(0);
     expect(screen.getByText("addon-1-app")).toBeInTheDocument();
   });
 
-  it("lists every addon output that a stack env connection can map", () => {
+  it("copies the endpoint as host:port", async () => {
     render(<PostgresConnectionPanel addon={mkAddon()} projectName="default" />);
 
-    for (const field of ADDON_OUTPUT_FIELDS) {
-      expect(screen.getAllByText(field).length).toBeGreaterThan(0);
-    }
+    await userEvent.click(screen.getByRole("button", { name: /copy endpoint/i }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "pg-rw.addons.svc.cluster.local:5432",
+    );
   });
 
   it("renders an empty state when the addon has no connection info", () => {

--- a/frontend/src/pages/addons/postgres-detail-page.tsx
+++ b/frontend/src/pages/addons/postgres-detail-page.tsx
@@ -22,6 +22,7 @@ import { useObjectStores } from "@/pages/object-stores/hooks/use-object-stores";
 import { detectPlan } from "./lib/payload";
 import { PLAN_PRESETS } from "./lib/plan-presets";
 import { PostgresDetailHeader } from "./components/postgres-detail-header";
+import { PostgresConnectionPanel } from "./components/postgres-connection-panel";
 import { BackupsList } from "./components/backups-list";
 import { usePostgresBackups } from "./hooks/use-postgres-backups";
 
@@ -216,6 +217,8 @@ export default function PostgresDetailPage() {
           canWrite={canWrite(addon.project_id ?? "")}
           onDelete={() => void handleDelete()}
         />
+
+        <PostgresConnectionPanel addon={addon} projectName={defaultProjectName ?? ""} />
 
         <Panel title="Configuration">
           <div className="flex flex-col gap-6">

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/environment-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/drawer-tabs/environment-tab.tsx
@@ -537,7 +537,7 @@ function StackResourceEnvironmentTabImpl({
                         <SelectContent>
                           {addons.length === 0 ? (
                             <div className="px-3 py-2 text-xs text-muted-foreground">
-                          No addons linked. Add one from the bottom panel.
+                              No add-ons on this stack. Add one from the canvas with Add resource.
                             </div>
                           ) : (
                             addons.map((a) => (

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/resource-drawer.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/resource-drawer.tsx
@@ -73,9 +73,12 @@ export function ResourceDrawer({
 
   const secrets = useSecrets();
   const { addons: allAddons } = usePostgresAddons();
+  // An addon linked during this session is only in the session's set until the
+  // stack is saved — the canvas reads the same way, so the picker matches it.
+  const linkedAddonIds = session.isActive ? session.linkedAddonIds : connectionAddonIds;
   const addons = useMemo(
-    () => allAddons.filter((a: PostgresAddon) => a.id && connectionAddonIds.has(a.id)),
-    [allAddons, connectionAddonIds],
+    () => allAddons.filter((a: PostgresAddon) => a.id && linkedAddonIds.has(a.id)),
+    [allAddons, linkedAddonIds],
   );
   const addonNameById = useMemo(
     () =>


### PR DESCRIPTION
## 📝 What this does
Creating a Postgres add-on gave you no way to see where the database lives or how to reach it — the detail page listed configuration only. This adds a Connection panel that shows the in-cluster endpoint and fetches per-database credentials on demand.

## 🔀 Changes
- Added a Connection panel above Configuration: in-cluster host and port, one row per database with owner and app-user secret.
- Revealing a database calls the just-in-time credentials endpoint; password and the password segment of the connection URL stay masked on screen while copy copies the real value.
- Gated the Owner/Superuser scope toggle on the add-on's superuser-access setting.
- Listed the outputs a stack env connection can map, sourced from the same constant the connection mapper uses so the list cannot drift.
- Fixed the stack editor's add-on picker, which ignored add-ons linked during the current session — a just-linked add-on showed on the canvas but was unpickable, and the picker was the only way to save a connection to it.

## 🧪 How to test
- [ ] Open a ready Postgres add-on and confirm host, port and databases appear.
- [ ] Reveal credentials for a database; check the password is masked and the copy button yields the real value.
- [ ] Turn on superuser access, reload, and switch the scope toggle to Superuser.
- [ ] Open an add-on with no connection details yet and confirm the empty state.
- [ ] On a stack, link an add-on from the canvas, then pick it in an env variable's add-on source without saving first.