### PR TITLE
CI: Continuous deploy to box on merge to main (dispatch-only)

### DIFF
--- a/.github/workflows/deploy-main.yaml
+++ b/.github/workflows/deploy-main.yaml
@@ -1,0 +1,190 @@
+name: Deploy main to box
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Existing tag to deploy, e.g. main-abc1234 (rollback). Empty = build from this ref."
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_REPO: ${{ vars.IMAGE_REPO || 'quay.io/stackdome/stackdome' }}
+
+jobs:
+  gate:
+    name: unit tests & lint
+    if: ${{ inputs.image_tag == '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Configure private module access
+        run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Download dependencies
+        run: go mod download
+        env:
+          GOPRIVATE: github.com/ashishmax31/*,stackdome.io/*,github.com/Stackdome/*
+
+      - name: Install Mage
+        run: go install github.com/magefile/mage@latest
+
+      - name: Unit tests
+        run: mage test:unit
+        env:
+          GOPRIVATE: github.com/ashishmax31/*,stackdome.io/*,github.com/Stackdome/*
+
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: frontend/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Frontend install
+        run: pnpm install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Frontend lint
+        run: pnpm lint
+        working-directory: frontend
+
+      - name: Frontend test
+        run: pnpm test:run
+        working-directory: frontend
+
+  build:
+    name: build & push amd64 image
+    if: ${{ inputs.image_tag == '' }}
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Configure private module access
+        run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Download dependencies
+        run: go mod download
+        env:
+          GOPRIVATE: github.com/ashishmax31/*,stackdome.io/*,github.com/Stackdome/*
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: frontend/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Compute image reference
+        id: meta
+        run: |
+          SHA7="${GITHUB_SHA::7}"
+          echo "sha7=$SHA7" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE_REPO}:main-${SHA7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build frontend
+        run: make frontend
+
+      - name: Build binary
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/linux_amd64/stackdome-server cmd/main.go
+        env:
+          GOPRIVATE: github.com/ashishmax31/*,stackdome.io/*,github.com/Stackdome/*
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to Quay.io
+        run: echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u "${{ secrets.QUAY_USER }}" --password-stdin
+
+      - name: Build and push
+        run: |
+          docker buildx build --platform linux/amd64 \
+            -t "${{ steps.meta.outputs.image }}" \
+            -t "${IMAGE_REPO}:main" \
+            --push .
+
+      - name: Verify pushed image
+        run: docker buildx imagetools inspect "${{ steps.meta.outputs.image }}"
+
+  deploy:
+    name: patch box & wait for convergence
+    needs: build
+    if: ${{ !cancelled() && (inputs.image_tag != '' || needs.build.result == 'success') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write kubeconfig
+        run: |
+          umask 077
+          mkdir -p "$RUNNER_TEMP/kube"
+          echo "$BOX_KUBE_CA" | base64 -d > "$RUNNER_TEMP/kube/ca.crt"
+          kubectl config set-cluster box \
+            --server="$BOX_KUBE_SERVER" \
+            --certificate-authority="$RUNNER_TEMP/kube/ca.crt" \
+            --embed-certs=true
+          kubectl config set-credentials ci-deployer --token="$BOX_KUBE_TOKEN"
+          kubectl config set-context box --cluster=box --user=ci-deployer --namespace=stackdome-control-plane
+          kubectl config use-context box
+        env:
+          KUBECONFIG: ${{ runner.temp }}/kube/config
+          BOX_KUBE_SERVER: ${{ secrets.BOX_KUBE_SERVER }}
+          BOX_KUBE_CA: ${{ secrets.BOX_KUBE_CA }}
+          BOX_KUBE_TOKEN: ${{ secrets.BOX_KUBE_TOKEN }}
+
+      - name: Patch StackResource image
+        id: patch
+        run: |
+          if [ -n "${INPUT_TAG:-}" ]; then
+            IMAGE="${IMAGE_REPO}:${INPUT_TAG}"
+          else
+            IMAGE="$BUILT_IMAGE"
+          fi
+          echo "deploying $IMAGE"
+          GEN=$(kubectl patch stackresource api-server -n stackdome-control-plane --type=merge \
+            -p "{\"spec\":{\"imageSpec\":{\"image\":\"$IMAGE\"}}}" \
+            -o jsonpath='{.metadata.generation}')
+          echo "generation=$GEN" >> "$GITHUB_OUTPUT"
+          echo "patched to generation $GEN"
+        env:
+          KUBECONFIG: ${{ runner.temp }}/kube/config
+          BUILT_IMAGE: ${{ needs.build.outputs.image }}
+          INPUT_TAG: ${{ inputs.image_tag }}
+          IMAGE_REPO: ${{ vars.IMAGE_REPO || 'quay.io/stackdome/stackdome' }}
+
+      - name: Wait for convergence
+        run: hack/wait-for-stackresource.sh api-server stackdome-control-plane "$GEN" 600
+        env:
+          KUBECONFIG: ${{ runner.temp }}/kube/config
+          GEN: ${{ steps.patch.outputs.generation }}

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.23.1
 	sigs.k8s.io/kind v0.29.0
 	sigs.k8s.io/yaml v1.6.0
-	stackdome.io/cluster-agent v0.6.5-alpha
+	stackdome.io/cluster-agent v0.6.7-alpha
 )
 
 require (
@@ -207,4 +207,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
 
-replace stackdome.io/cluster-agent => github.com/Stackdome/cluster-agent v0.6.5-alpha
+replace stackdome.io/cluster-agent => github.com/Stackdome/cluster-agent v0.6.7-alpha

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Stackdome/cluster-agent v0.6.5-alpha h1:OhRU7bwmtP6t7pP0apAMv+4ukKQNxyAlfjy66UWrOqs=
-github.com/Stackdome/cluster-agent v0.6.5-alpha/go.mod h1:1o76givNdNw9Tgj29ZbuPqNvNKbY2HqFkVF6yLxyq9M=
+github.com/Stackdome/cluster-agent v0.6.7-alpha h1:/E3ittFQGnqDElLQnQrTlBdkxuvj1ivGjcTB2DQxD34=
+github.com/Stackdome/cluster-agent v0.6.7-alpha/go.mod h1:1o76givNdNw9Tgj29ZbuPqNvNKbY2HqFkVF6yLxyq9M=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/hack/ci-deployer-rbac.yaml
+++ b/hack/ci-deployer-rbac.yaml
@@ -1,0 +1,47 @@
+# Least-privilege identity used by .github/workflows/deploy-main.yaml to roll a new
+# api-server image onto the box. Apply on the box:
+#   kubectl apply -f hack/ci-deployer-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ci-deployer
+  namespace: stackdome-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ci-deployer
+  namespace: stackdome-control-plane
+rules:
+  - apiGroups: ["core.stackdome.io"]
+    resources: ["stackresources"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ci-deployer
+  namespace: stackdome-control-plane
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ci-deployer
+subjects:
+  - kind: ServiceAccount
+    name: ci-deployer
+    namespace: stackdome-control-plane
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ci-deployer-token
+  namespace: stackdome-control-plane
+  annotations:
+    kubernetes.io/service-account.name: ci-deployer
+type: kubernetes.io/service-account-token

--- a/hack/wait-for-stackresource.sh
+++ b/hack/wait-for-stackresource.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Wait until the cluster agent has reconciled a StackResource at or past a given
+# generation and reports Converged=True.
+#
+# Why not `kubectl wait --for=condition=Converged=True`: that ignores
+# observedGeneration and matches the condition left over from the previous spec,
+# returning success before the agent has looked at the new image at all.
+#
+# Convergence is read from the Converged condition's OWN observedGeneration,
+# which is the same test the agent itself applies (isResourceConverged:
+# cond.Status == True && cond.ObservedGeneration == resource.Generation). Both
+# halves come out of one API read, so there is no window where a stale True
+# pairs with a fresh generation.
+set -uo pipefail
+
+NAME=${1:?usage: wait-for-stackresource.sh <name> <namespace> <min-generation> [timeout-seconds]}
+NAMESPACE=${2:?namespace required}
+MIN_GEN=${3:?min-generation required}
+TIMEOUT=${4:-600}
+INTERVAL=5
+
+case $MIN_GEN in
+  '' | *[!0-9]*) echo "error: min-generation must be a non-negative integer, got: '$MIN_GEN'" >&2; exit 1 ;;
+esac
+case $TIMEOUT in
+  '' | *[!0-9]*) echo "error: timeout-seconds must be a non-negative integer, got: '$TIMEOUT'" >&2; exit 1 ;;
+esac
+
+kget() { kubectl get stackresource "$NAME" -n "$NAMESPACE" "$@" 2>/dev/null; }
+
+# Reads one condition's status and its own observedGeneration in a single API
+# call, as "<status>|<generation>". A condition that does not exist yields an
+# empty string rather than a shifted field, so parsing stays safe.
+cond_pair() {
+  kget -o jsonpath="{range .status.conditions[?(@.type==\"$1\")]}{.status}|{.observedGeneration}{end}"
+}
+
+dump() {
+  echo "--- conditions ---"
+  kget -o jsonpath='{range .status.conditions[*]}{.type}={.status} gen={.observedGeneration} reason={.reason} message={.message}{"\n"}{end}'
+  echo "--- lastFailureDetail ---"
+  kget -o jsonpath='{range .status.lastFailureDetail[*]}{.containerName}: {.lastTerminationReason} exit={.lastTerminationExitCode} restarts={.restartCount} message={.lastTerminationMessage}{"\n"}{end}'
+  echo "--- pods ---"
+  kubectl get pods -n "$NAMESPACE" -l "resource=$NAME" -o wide
+  echo "--- logs (current) ---"
+  kubectl logs -n "$NAMESPACE" -l "resource=$NAME" --all-containers --tail=100
+  echo "--- logs (previous) ---"
+  kubectl logs -n "$NAMESPACE" -l "resource=$NAME" --all-containers --previous --tail=100
+}
+
+# Preflight: stderr is deliberately NOT suppressed here. Without it a wrong
+# name, wrong namespace, rotated token, unreachable API server or missing CRD
+# looks identical to "not reconciled yet" and burns the whole timeout in silence.
+if ! kubectl get stackresource "$NAME" -n "$NAMESPACE" -o name; then
+  echo "preflight failed: cannot read stackresource $NAME in namespace $NAMESPACE" >&2
+  exit 1
+fi
+
+deadline=$(( $(date +%s) + TIMEOUT ))
+
+while :; do
+  snapshot=$(kget -o jsonpath='{.status.observedGeneration}|{.status.phase}')
+  observed=${snapshot%%|*}
+  phase=${snapshot##*|}
+  observed=${observed:-0}
+  phase=${phase:-Unknown}
+
+  conv=$(cond_pair Converged)
+  conv_status=${conv%%|*}
+  conv_gen=${conv##*|}
+  conv_status=${conv_status:-Unknown}
+  conv_gen=${conv_gen:-0}
+
+  stalled=$(cond_pair Stalled)
+  stalled_status=${stalled%%|*}
+  stalled_gen=${stalled##*|}
+  stalled_status=${stalled_status:-Unknown}
+  stalled_gen=${stalled_gen:-0}
+
+  if [ "$conv_gen" -ge "$MIN_GEN" ] && [ "$conv_status" = "True" ]; then
+    echo "converged: Converged=True at observedGeneration=$conv_gen (>= $MIN_GEN) phase=$phase"
+    exit 0
+  fi
+
+  # Only trust failure signals once the agent has stamped them with our
+  # generation, otherwise a stale failure from the previous spec aborts a
+  # healthy deploy. Stalled=True is the agent's terminal-failure marker and,
+  # unlike phase, carries its own generation. Degraded/Pending are NOT failures
+  # -- Degraded is the normal mid-rollout state.
+  if [ "$stalled_gen" -ge "$MIN_GEN" ] && [ "$stalled_status" = "True" ]; then
+    echo "FAILED: Stalled=True at observedGeneration=$stalled_gen (>= $MIN_GEN) phase=$phase"
+    dump
+    exit 1
+  fi
+
+  if [ "$observed" -ge "$MIN_GEN" ] && [ "$phase" = "Failed" ]; then
+    echo "FAILED at observedGeneration=$observed phase=$phase"
+    dump
+    exit 1
+  fi
+
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "TIMEOUT after ${TIMEOUT}s: Converged=$conv_status@gen$conv_gen (want True@gen>=$MIN_GEN) observedGeneration=$observed phase=$phase"
+    dump
+    exit 1
+  fi
+
+  echo "waiting: Converged=$conv_status@gen$conv_gen/$MIN_GEN observedGeneration=$observed phase=$phase stalled=$stalled_status@gen$stalled_gen"
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## 📝 What this does
Adds a new GitHub Actions workflow that builds an image and rolls it onto the production k3s box's `api-server` StackResource. It's dispatch-only for now — the `push: branches: [main]` trigger lands in a follow-up PR once this has been verified with a real dispatch against the box.

## 📎 References
- **Spec**: [docs/superpowers/specs/2026-07-30-cd-to-box-design.md](docs/superpowers/specs/2026-07-30-cd-to-box-design.md)
- **Plan**: [docs/superpowers/plans/2026-07-30-cd-to-box.md](docs/superpowers/plans/2026-07-30-cd-to-box.md)

## 🏗️ Architecture
### Flow
```mermaid
sequenceDiagram
    participant GHA as deploy-main.yaml
    participant Quay as quay.io
    participant Box as api-server StackResource (box)
    GHA->>GHA: gate — unit tests + lint
    GHA->>Quay: build & push main-<sha7> + main (amd64 only)
    GHA->>Box: kubectl patch imageSpec.image
    GHA->>Box: poll Converged condition's own observedGeneration
    Box-->>GHA: converged / failed / timeout (with diagnostic dump)
```
Rollback reuses the same `deploy` job: a `workflow_dispatch` input `image_tag` skips `gate`/`build` and patches an existing tag directly.

## 🔀 Changes
- Added `.github/workflows/deploy-main.yaml`: `gate` (unit tests + lint) → `build` (amd64-only image, tags `main-<sha7>` + `main`, never `latest`) → `deploy` (patch the box's StackResource, wait for convergence)
- Added `hack/wait-for-stackresource.sh`, a generation-aware convergence wait — keys off the `Converged` condition's own `observedGeneration` rather than `kubectl wait`, which would falsely pass on the previous image's leftover `Converged=True`
- Added `workflow_dispatch` `image_tag` input for rollback; `deploy` keys its condition on `inputs.image_tag != ''` rather than `build.result`, since a skipped `build` is ambiguous between "rollback" and "cascaded from a gate failure"
- Tracked the previously-untracked `hack/ci-deployer-rbac.yaml` — the least-privilege ServiceAccount/Role already applied on the box for this CI identity
- Bumped `stackdome.io/cluster-agent` to `v0.6.7-alpha` to match the agent version actually running on the box

## 🧪 How to test
- [ ] Merge, then dispatch the workflow manually and confirm the box lands on the new `main-<sha7>` tag with the wait reporting `converged`
- [ ] Dispatch with a deliberately bad `image_tag` and confirm it fails loudly (`ImagePullBackOff` in the diagnostic dump) rather than hanging silently, and that the previous pod keeps serving
- [ ] Dispatch a rollback to a known-good tag and confirm it converges