### PR TITLE
CI: Deploy to box automatically on every push to main

### DIFF
--- a/.github/workflows/deploy-main.yaml
+++ b/.github/workflows/deploy-main.yaml
@@ -1,6 +1,8 @@
 name: Deploy main to box
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       image_tag:


### PR DESCRIPTION
## 📝 What this does
Turns on the automatic side of #191: every push to `main` now triggers `deploy-main.yaml` directly, instead of requiring a manual dispatch. The workflow itself was already verified live against the box in #191 (gate → build → deploy all green, box confirmed on the new image, `/health` 200).

## 🔀 Changes
- Added `push: branches: [main]` alongside the existing `workflow_dispatch` trigger
- No other change — `gate`/`build`'s `inputs.image_tag == ''` and `deploy`'s rollback condition are unaffected, since `inputs.image_tag` reads as empty on a push event

## 🧪 How to test
- [ ] Merging this PR is itself the first automatic deploy — confirm the triggered run is `event: push` and lands green
- [ ] Confirm the box's `api-server` StackResource image matches this merge commit's `main-<sha7>` and phase is `Ready`