### PR TITLE
Fix: stop branch-tracking resources reading as modified after deploy

### DIFF
--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/derive.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/derive.ts
@@ -4,7 +4,7 @@ import { ReleaseEventType, type ReleaseEvent, type StackRelease, type ReleaseLiv
 import type { Stages } from "@/components/branded";
 import { statusVariant, type StatusVariant } from "@/components/branded/status-variant";
 import { ReleaseState, isTerminal } from "./release-states";
-import { gitUnpinned } from "./release-snapshot-diff";
+import { unpinnedRevisionKeys } from "./release-snapshot-diff";
 
 export type Stack = components["schemas"]["Stack"];
 export type ReleaseHealth = components["schemas"]["ReleaseHealth"];
@@ -29,9 +29,9 @@ export function deriveHeaderHealth(stack: Stack): ReleaseHealth | undefined {
 
 /**
  * The deployed snapshot stores the RESOLVED git revision (branch/commit written by
- * the pin resolver at deploy time). When the saved spec doesn't pin one, those are
- * deploy-time facts, not config drift — strip them so the diff baseline compares
- * intent with intent instead of reading every unpinned git resource as dirty.
+ * the pin resolver at deploy time). Each revision key the saved spec doesn't pin is
+ * a deploy-time fact, not config drift — strip it so the diff baseline compares
+ * intent with intent instead of reading every branch-tracking resource as dirty.
  */
 export function stripUnpinnedGitRevisions(
   snapshotResources: StackResource[],
@@ -40,9 +40,12 @@ export function stripUnpinnedGitRevisions(
   const savedByName = new Map(savedResources.map((r) => [r.name, r]));
   return snapshotResources.map((r) => {
     const git = r.source?.git;
-    if (!git || !gitUnpinned(savedByName.get(r.name))) return r;
-    const { branch: _b, commit: _c, tag: _t, ...unpinned } = git;
-    return { ...r, source: { ...r.source, git: unpinned } };
+    if (!git) return r;
+    const drop = unpinnedRevisionKeys(savedByName.get(r.name)).filter((k) => git[k]);
+    if (!drop.length) return r;
+    const stripped = { ...git };
+    for (const k of drop) delete stripped[k];
+    return { ...r, source: { ...r.source, git: stripped } };
   });
 }
 

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/release-snapshot-diff.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/release-snapshot-diff.ts
@@ -34,12 +34,16 @@ function configScalars(r: SnapResource): Record<string, string | undefined> {
 
 /** Revision keys the deploy-time pin resolver writes into snapshots. */
 const REVISION_KEYS = ["branch", "tag", "commit"] as const;
+type RevisionKey = (typeof REVISION_KEYS)[number];
 
-/** True when the resource's git source pins no revision — the resolver picks
- *  one at deploy time and records it in the snapshot. */
-export function gitUnpinned(r: SnapResource | undefined): boolean {
+/** Revision keys the resource's git source leaves unpinned. The resolver fills
+ *  each unpinned key into the snapshot at deploy time, so a value present only
+ *  on the baseline for such a key is a resolver fact, not drift — a spec
+ *  tracking a branch must not read as dirty from the resolved commit. */
+export function unpinnedRevisionKeys(r: SnapResource | undefined): RevisionKey[] {
   const git = r?.source?.git;
-  return !!git && !git.branch && !git.tag && !git.commit;
+  if (!git) return [];
+  return REVISION_KEYS.filter((k) => !git[k]);
 }
 
 /** Server-written fields — never user intent, excluded from the catch-all. */
@@ -48,12 +52,12 @@ const VOLUME_SERVER_FIELDS = ["id", "project_id", "status"] as const;
 
 const GENERIC_ROW: DiffRow = { key: "other configuration", kind: "changed" };
 
-function canonicalResource(r: SnapResource, dropRevisions: boolean): unknown {
+function canonicalResource(r: SnapResource, dropRevisions: RevisionKey[]): unknown {
   const out = { ...r } as Record<string, unknown>;
   for (const k of RESOURCE_SERVER_FIELDS) delete out[k];
-  if (dropRevisions && r.source?.git) {
+  if (dropRevisions.length && r.source?.git) {
     const git = { ...r.source.git } as Record<string, unknown>;
-    for (const k of REVISION_KEYS) delete git[k];
+    for (const k of dropRevisions) delete git[k];
     out.source = { ...r.source, git };
   }
   const env = r.execution_config?.environment_variables;
@@ -68,9 +72,9 @@ function canonicalResource(r: SnapResource, dropRevisions: boolean): unknown {
 
 /** Real config drift outside the projected scalar set. Both sides are
  *  canonicalized the same way, so resolver-written revisions on the baseline
- *  of an unpinned spec never count. */
+ *  of keys the spec leaves unpinned never count. */
 function resourceResidual(prev: SnapResource, cur: SnapResource): boolean {
-  const drop = gitUnpinned(cur);
+  const drop = unpinnedRevisionKeys(cur);
   return !deepEqual(canonicalResource(prev, drop), canonicalResource(cur, drop));
 }
 
@@ -94,11 +98,9 @@ function envMap(r: SnapResource): Record<string, string> {
 function configRows(prev: SnapResource | undefined, cur: SnapResource | undefined): DiffRow[] {
   const p = prev ? configScalars(prev) : {};
   const c = cur ? configScalars(cur) : {};
-  // `cur` is the user's spec side. When it pins no revision, the baseline's
-  // branch/commit are deploy-time resolver facts, not drift — drop them.
-  if (gitUnpinned(cur)) {
-    for (const k of REVISION_KEYS) delete p[k];
-  }
+  // `cur` is the user's spec side. Each revision key it leaves unpinned is a
+  // deploy-time resolver fact on the baseline, not drift — drop it.
+  for (const k of unpinnedRevisionKeys(cur)) delete p[k];
   const rows: DiffRow[] = [];
   for (const key of new Set([...Object.keys(p), ...Object.keys(c)])) {
     const from = p[key];

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/derive.test.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/derive.test.ts
@@ -368,9 +368,16 @@ describe("stripUnpinnedGitRevisions", () => {
     expect(out.source?.git).toEqual({ repo_url: "https://x/y", dockerfile_path: "Dockerfile" });
   });
 
-  it("passes a snapshot resource through unchanged (same object reference) when the saved spec pins a branch", () => {
-    const pinned = gitResource("api", { repo_url: "https://x/y", branch: "main", commit: "abc123" });
+  it("strips only the resolver-written commit when the saved spec pins a branch, keeping the branch", () => {
+    const snapshot = [gitResource("api", { repo_url: "https://x/y", branch: "main", commit: "abc123" })];
     const saved = [gitResource("api", { repo_url: "https://x/y", branch: "main" })];
+    const [out] = stripUnpinnedGitRevisions(snapshot, saved);
+    expect(out.source?.git).toEqual({ repo_url: "https://x/y", branch: "main" });
+  });
+
+  it("passes a snapshot resource through unchanged (same object reference) when the saved spec pins every revision key present", () => {
+    const pinned = gitResource("api", { repo_url: "https://x/y", branch: "main", commit: "abc123" });
+    const saved = [gitResource("api", { repo_url: "https://x/y", branch: "main", commit: "abc123" })];
     const [out] = stripUnpinnedGitRevisions([pinned], saved);
     expect(out).toBe(pinned);
   });

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/release-snapshot-diff.test.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/release-snapshot-diff.test.ts
@@ -265,6 +265,24 @@ describe("diffSnapshots git sources", () => {
     expect(diffSnapshots(snap([deployed]), snap([unpinnedSpec])).resources).toEqual([]);
   });
 
+  it("ignores the resolver-written commit when the spec tracks a branch", () => {
+    // Branch-tracking spec: branch set, no commit. Deploy resolves the branch
+    // and writes the commit into the snapshot — comparing that against the
+    // spec's empty commit read as MODIFIED forever after every deploy.
+    const deployed = gitWeb({ branch: "main", commit: "0f5c32589c37115508af0f48fe6d566925493700" });
+    const branchTrackingSpec = gitWeb({ branch: "main" });
+    expect(diffSnapshots(snap([deployed]), snap([branchTrackingSpec])).resources).toEqual([]);
+  });
+
+  it("flags only the branch change on a branch-tracking spec, without a phantom commit row", () => {
+    const deployed = gitWeb({ branch: "master", commit: "abc123" });
+    const branchTrackingSpec = gitWeb({ branch: "dev" });
+    const out = diffSnapshots(snap([deployed]), snap([branchTrackingSpec])).resources;
+    expect(out).toHaveLength(1);
+    const cfg = out[0].sections.find((s) => s.kind === "configuration")!;
+    expect(cfg.rows).toEqual([{ key: "branch", from: "master", to: "dev", kind: "changed" }]);
+  });
+
   it("flags a commit pin change beside an unchanged branch as a single commit row", () => {
     const out = diffSnapshots(
       snap([gitWeb({ branch: "main", commit: "aaa111" })]),


### PR DESCRIPTION
## 📝 What this does
A resource that tracks a git branch (branch set, no commit pin) showed up in "Undeployed changes" as MODIFIED forever — deploying never cleared it, and "Discard all" silently converted the resource into a commit-pinned one. The diff now ignores deploy-time resolved revisions per key, so branch-tracking stacks read clean after a deploy while real revision edits still surface.

## 📎 References
- **Bug report**: [Jam recording](https://jam.dev/c/287919ed-6aa9-4e5e-8582-683e4cbb07e8)

## 🔀 Changes
- Replaced the all-or-nothing unpinned-git guard with a per-key one: a baseline revision value (branch/tag/commit) is ignored exactly when the spec leaves that key empty, since the deploy-time resolver wrote it into the snapshot
- Applied the same per-key rule to the catch-all residual diff and the drift heuristic's snapshot strip, so no path re-reports the phantom change
- Rewrote the test that encoded the old behaviour (resolved commit surviving the strip when a branch is pinned) and added coverage for the branch-tracking cases

## 🧪 How to test
Acceptance criteria (all four verified against a live release via unit tests and in the running app):
- [x] Branch-tracking spec vs snapshot with resolved commit → no undeployed changes after deploy
- [x] Branch edited on a branch-tracking spec → exactly one branch row, no phantom commit row
- [x] Commit pin changed on a commit-pinned spec → single commit row (strict compare kept)
- [x] Fully unpinned spec vs resolved snapshot → no diff (existing behaviour preserved)

Manual re-check:
- [x] Deploy a stack whose git resource tracks a branch, wait for "Release is live", reopen the stack — no "Apply changes" pill
- [x] Edit the branch and confirm the changes modal lists only the branch change