### PR TITLE
Feature: Draft/Live canvas views with persistent drawers

### DIFF
--- a/frontend/src/pages/stacks/components/editor/index.tsx
+++ b/frontend/src/pages/stacks/components/editor/index.tsx
@@ -37,6 +37,7 @@ import { deriveHeaderHealth, latestDeployFailed, stackSummariesStale, stripUnpin
 import { useDeployLifecycle } from "@/pages/stacks/components/editor/tabs/deployments/use-deploy-lifecycle";
 import { useReleaseAnchors } from "@/pages/stacks/components/editor/hooks/use-release-anchors";
 import { mapVolumeToFormData, formResourcesFromSpec } from "@/pages/stacks/lib/spec-to-form";
+import { addonIdsFromConnections } from "@/pages/stacks/lib/connection-mapping";
 import { useBreadcrumb } from "@/hooks/use-breadcrumb";
 import { getCurrentOrganizationId } from "@/helpers/common";
 import { useResourceProjects } from "@/hooks/use-resource-projects";
@@ -301,12 +302,7 @@ export default function CanvasEditorPage() {
   );
 
   const connectionAddonIds = useMemo<Set<string>>(
-    () =>
-      new Set(
-        (savedStack?.spec?.connections ?? [])
-          .filter((c) => c.from?.type === "addon/postgres" && c.from?.id)
-          .map((c) => c.from!.id as string),
-      ),
+    () => addonIdsFromConnections(savedStack?.spec?.connections),
     [savedStack],
   );
 
@@ -546,6 +542,19 @@ export default function CanvasEditorPage() {
   // Live snapshot: already lazily fetched above (convergedReleaseId ensure); peek
   // here to gate canDiscardDraft and pass to the revert hook.
   const liveSnapshot = convergedReleaseDetail?.snapshot;
+
+  // The converged release as form data — feeds the canvas's read-only Live
+  // view. Undefined until a converged release exists and its detail has
+  // loaded; the Draft/Live toggle simply doesn't render before then.
+  const liveView = useMemo(() => {
+    if (!liveSnapshot) return undefined;
+    const connections = liveSnapshot.connections as StackConnection[] | undefined;
+    return {
+      resources: formResourcesFromSpec((liveSnapshot.resources ?? []) as StackResource[], connections),
+      volumes: ((liveSnapshot.volumes ?? []) as Volume[]).map(mapVolumeToFormData),
+      linkedAddonIds: addonIdsFromConnections(connections),
+    };
+  }, [liveSnapshot]);
 
   const [viewChangesOpen, setViewChangesOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -1011,6 +1020,7 @@ export default function CanvasEditorPage() {
               releaseInFlight={deployBusy || lifecycle.phase === "deploying"}
               liveStatusResources={statusLiveStatus?.resources}
               publicEndpoints={publicEndpoints}
+              liveView={liveView}
             />
           </>
         }

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
@@ -385,11 +385,12 @@ function StackCanvasFlow({
 
   const toggleConnections = useCallback(() => setShowConnections((v) => !v), []);
 
-  // Re-run auto-layout: reset every node to its fresh dagre position and re-fit.
+  // Re-run auto-layout: reset every node to its fresh dagre position and
+  // glide the viewport onto the result — an instant re-fit reads as a flicker.
   const autoLayout = useCallback(() => {
     const laid = layoutGraph(mergedGraph);
     setNodes(laid.nodes as CanvasFlowNode[]);
-    requestAnimationFrame(() => fitView(FIT_OPTIONS));
+    requestAnimationFrame(() => fitView({ ...FIT_OPTIONS, duration: 300 }));
   }, [mergedGraph, setNodes, fitView]);
 
   // Switching views keeps drawers open on the same-named resource/volume in

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
@@ -419,7 +419,6 @@ function StackCanvasFlow({
           {
             linkedAddonIds: new Set(connectionAddonIds),
             openResourceIdx: front?.index,
-            openTab: "configuration",
             draft: { resources: draftResources, volumes: draftVolumes },
           },
         );
@@ -773,7 +772,7 @@ function StackCanvasFlow({
         onOpenVolume={liveMode ? undefined : openVolume}
         liveStatusResources={liveStatusResources}
         publicUrls={publicEndpoints?.find((e) => e.service === resources[frontEntry.index]?.name)?.urls}
-        live={liveMode ? { resources: liveView!.resources, volumes: liveView!.volumes } : undefined}
+        live={liveMode ? liveView : undefined}
       />
     ) : frontEntry ? (
       <VolumeDrawer

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
@@ -63,6 +63,7 @@ import {
   truncateTo,
   popEntry,
   entryKey,
+  remapStackByName,
   type DrawerEntry,
 } from "@/pages/stacks/lib/canvas/drawer-stack";
 import { computeDrawerInset } from "@/pages/stacks/lib/canvas/drawer-inset";
@@ -391,12 +392,52 @@ function StackCanvasFlow({
     requestAnimationFrame(() => fitView(FIT_OPTIONS));
   }, [mergedGraph, setNodes, fitView]);
 
-  // Switching views closes any open drawers — resource indexes are not stable
-  // across the draft and live lists, so re-binding an open panel would be a lie.
-  const onViewModeChange = useCallback((mode: CanvasViewMode) => {
-    setViewMode(mode);
-    setDrawerStack([]);
-  }, []);
+  // Switching views keeps drawers open on the same-named resource/volume in
+  // the target view; entries with no counterpart there (undeployed additions,
+  // since-removed resources) close.
+  const onViewModeChange = useCallback(
+    (mode: CanvasViewMode) => {
+      const target =
+        mode === "live" && liveView
+          ? { resources: liveView.resources, volumes: liveView.volumes }
+          : session.isActive
+            ? session.draft
+            : { resources: draftResources, volumes: draftVolumes };
+      const remapped = remapStackByName(drawerStack, { resources }, {
+        resources: target.resources,
+        volumeNames: new Set(target.volumes.map((v) => v.name).filter((n): n is string => !!n)),
+      });
+      // Draft drawers edit through a session — make sure one exists before a
+      // surviving drawer lands on the draft side.
+      if (mode === "draft" && remapped.length > 0 && !session.isActive) {
+        const front = [...remapped]
+          .reverse()
+          .find((e): e is Extract<DrawerEntry, { kind: "resource" }> => e.kind === "resource");
+        session.start(
+          { resources: baselineResources, volumes: baselineVolumes },
+          {
+            linkedAddonIds: new Set(connectionAddonIds),
+            openResourceIdx: front?.index,
+            openTab: "configuration",
+            draft: { resources: draftResources, volumes: draftVolumes },
+          },
+        );
+      }
+      setDrawerStack(remapped);
+      setViewMode(mode);
+    },
+    [
+      drawerStack,
+      resources,
+      liveView,
+      session,
+      draftResources,
+      draftVolumes,
+      baselineResources,
+      baselineVolumes,
+      connectionAddonIds,
+    ],
+  );
 
   const openResourceDrawer = useCallback(
     (idx: number, tab: EditSessionTab = "configuration") => {

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/architecture-tab.tsx
@@ -42,6 +42,7 @@ function attachmentAwareFallbackSize(node: CollidableNode): { width: number; hei
 import { addBlockToStack } from "@/pages/stacks/lib/block-to-form";
 import { blockCatalog, getBlockById } from "@/pages/stacks/data/blocks/registry";
 import { CanvasEditor } from "./canvas-editor";
+import { LiveViewToggle, type CanvasViewMode } from "./live-view-toggle";
 import { ResourceDrawer } from "./resource-drawer";
 import { VolumeDrawer } from "./volume-drawer";
 import { AddVolumeDialog } from "./add-volume-dialog";
@@ -113,7 +114,18 @@ interface ArchitectureTabProps {
    *  error") on the tab holding the field; the nonce distinguishes repeat jumps
    *  to the same resource. */
   openResourceSignal?: { index: number; tab: EditSessionTab; nonce: number } | null;
+  /** The converged (live) release's snapshot as form data. Present once a
+   *  converged release exists and its detail has loaded — enables the
+   *  Draft/Live canvas toggle; the Live view is read-only. */
+  liveView?: {
+    resources: Partial<FormStackResourceData>[];
+    volumes: Partial<VolumeFormData>[];
+    linkedAddonIds: ReadonlySet<string>;
+  };
 }
+
+/** Live view is read-only, so nothing is ever "edited" — an empty dirty set. */
+const NO_DIRTY_IDX: ReadonlySet<number> = new Set();
 
 function StackCanvasFlow({
   session,
@@ -135,23 +147,38 @@ function StackCanvasFlow({
   liveStatusResources,
   publicEndpoints,
   openResourceSignal,
+  liveView,
 }: ArchitectureTabProps) {
-  // Read from the live draft when the session is active, server state otherwise.
-  const resources = session.isActive ? session.draft.resources : draftResources;
-  const linkedAddonIds = session.isActive ? session.linkedAddonIds : connectionAddonIds;
-  const volumes = session.isActive ? session.draft.volumes : draftVolumes;
+  const [viewMode, setViewMode] = useState<CanvasViewMode>("draft");
+  // Live mode needs the snapshot data — never trust a stale "live" viewMode
+  // if the converged detail hasn't loaded (or went away).
+  const liveMode = viewMode === "live" && !!liveView;
+
+  // Read from the live snapshot in live mode; otherwise the draft when the
+  // session is active, server state when not.
+  const resources = liveMode ? liveView!.resources : session.isActive ? session.draft.resources : draftResources;
+  const linkedAddonIds = liveMode ? liveView!.linkedAddonIds : session.isActive ? session.linkedAddonIds : connectionAddonIds;
+  const volumes = liveMode ? liveView!.volumes : session.isActive ? session.draft.volumes : draftVolumes;
   const volumeNames = useMemo(
     () => volumes.map((v) => v.name).filter((n): n is string => !!n),
     [volumes],
   );
 
   const dirty = useMemo(
-    () => ({
-      dirtyResourceIdx: session.dirty.dirtyResourceIdx,
-      baselineResourceCount: baselineResources.length,
-      baselineAddonIds: connectionAddonIds,
-    }),
-    [session.dirty, baselineResources.length, connectionAddonIds],
+    () =>
+      liveMode
+        ? {
+          // What's deployed can't be "edited"/"new" relative to itself.
+          dirtyResourceIdx: NO_DIRTY_IDX,
+          baselineResourceCount: resources.length,
+          baselineAddonIds: linkedAddonIds,
+        }
+        : {
+          dirtyResourceIdx: session.dirty.dirtyResourceIdx,
+          baselineResourceCount: baselineResources.length,
+          baselineAddonIds: connectionAddonIds,
+        },
+    [liveMode, resources.length, linkedAddonIds, session.dirty, baselineResources.length, connectionAddonIds],
   );
 
   const { topology } = useStackTopology({ ids: topologyIds, refreshKey: topologyRefreshKey });
@@ -306,6 +333,7 @@ function StackCanvasFlow({
 
   const onNodeContextMenu = useCallback<NodeMouseHandler<CanvasFlowNode>>(
     (event, node) => {
+      if (liveMode) return; // read-only: no mutation menu
       event.preventDefault();
       const { clientX: x, clientY: y } = event;
       const chipEl = (event.target as HTMLElement).closest("[data-volume-chip]");
@@ -323,7 +351,7 @@ function StackCanvasFlow({
         if (idx != null) setMenuTarget({ kind: "resource", resourceIdx: idx, resourceName: data.name, x, y });
       }
     },
-    [],
+    [liveMode],
   );
 
   // Re-layout ONLY when topology changes; preserve in-session drag positions by id.
@@ -363,8 +391,18 @@ function StackCanvasFlow({
     requestAnimationFrame(() => fitView(FIT_OPTIONS));
   }, [mergedGraph, setNodes, fitView]);
 
+  // Switching views closes any open drawers — resource indexes are not stable
+  // across the draft and live lists, so re-binding an open panel would be a lie.
+  const onViewModeChange = useCallback((mode: CanvasViewMode) => {
+    setViewMode(mode);
+    setDrawerStack([]);
+  }, []);
+
   const openResourceDrawer = useCallback(
     (idx: number, tab: EditSessionTab = "configuration") => {
+      // Draft-indexed entry point (banner jump, context menu): indexes only
+      // make sense against the draft list, so leave live view first.
+      setViewMode("draft");
       // Activate an edit session lazily so drawer edits land in a draft.
       if (!session.isActive) {
         session.start(
@@ -410,6 +448,13 @@ function StackCanvasFlow({
 
   const onNodeClick = useCallback<NodeMouseHandler<CanvasFlowNode>>(
     (event, node) => {
+      if (liveMode) {
+        // Read-only inspection: resource cards open the disabled drawer, no
+        // session is started. Volume/attachment nodes stay display-only.
+        const idx = node.type === "resource" ? (node.data as ResourceNodeData).resourceIdx : null;
+        if (idx != null) setDrawerStack(replaceStack({ kind: "resource", index: idx }));
+        return;
+      }
       if (node.type === "attachment") {
         const data = node.data as AttachmentNodeData;
         if (data.kind === NODE_KIND.volume) openVolumeFromCanvas(data.name);
@@ -425,7 +470,7 @@ function StackCanvasFlow({
       if (idx == null) return; // addon node — managed via the Environment tab, no drawer in v1
       openResourceDrawer(idx);
     },
-    [openResourceDrawer, openVolumeFromCanvas],
+    [liveMode, openResourceDrawer, openVolumeFromCanvas],
   );
 
   // Block ids already present in the stack (drives the picker's "added" badge).
@@ -631,18 +676,17 @@ function StackCanvasFlow({
     [session],
   );
 
-  // Drop panels whose target no longer exists in the draft (deleted resource/volume).
+  // Drop panels whose target no longer exists in the shown list (deleted
+  // resource/volume — or a view switch shrinking the list).
   useEffect(() => {
     setDrawerStack((s) => {
       const next = s.filter((e) =>
-        e.kind === "resource"
-          ? e.index < resources.length
-          : (session.isActive ? session.draft.volumes : draftVolumes).some((v) => v.name === e.name),
+        e.kind === "resource" ? e.index < resources.length : volumes.some((v) => v.name === e.name),
       );
       // Same-ref bailout: skip the state update (and re-render) when nothing was dropped.
       return next.length === s.length ? s : next;
     });
-  }, [resources.length, session.isActive, session.draft.volumes, draftVolumes]);
+  }, [resources.length, volumes]);
 
   const panels: DrawerPanelDescriptor[] = useMemo(
     () =>
@@ -680,13 +724,14 @@ function StackCanvasFlow({
         baselineResources={baselineResources}
         serverOutputsByName={serverOutputsByName}
         connectionAddonIds={connectionAddonIds}
-        errors={errors[frontEntry.index] ?? {}}
+        errors={liveMode ? {} : errors[frontEntry.index] ?? {}}
         onClose={popDrawer}
         onRemove={removeResource}
         onViewLogs={onViewLogs}
-        onOpenVolume={openVolume}
+        onOpenVolume={liveMode ? undefined : openVolume}
         liveStatusResources={liveStatusResources}
         publicUrls={publicEndpoints?.find((e) => e.service === resources[frontEntry.index]?.name)?.urls}
+        live={liveMode ? { resources: liveView!.resources, volumes: liveView!.volumes } : undefined}
       />
     ) : frontEntry ? (
       <VolumeDrawer
@@ -702,6 +747,15 @@ function StackCanvasFlow({
   return (
     <div className="flex h-full w-full">
       <div className="relative min-w-0 flex-1">
+        {liveView && (
+          <div className="absolute left-3 top-3 z-10">
+            <LiveViewToggle
+              mode={liveMode ? "live" : "draft"}
+              onModeChange={onViewModeChange}
+              draftDirty={session.dirty.dirtyResourceIdx.size + session.dirty.dirtyVolumeIdx.size > 0}
+            />
+          </div>
+        )}
         <CanvasEditor
           nodes={nodes}
           edges={showConnections ? edges : []}
@@ -722,6 +776,7 @@ function StackCanvasFlow({
           onLinkAddon={onLinkAddon}
           canAddVolume={resources.length > 0}
           onAddVolume={() => setAddVolumeOpen(true)}
+          readOnly={liveMode}
         />
       </div>
       <DrawerStack

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/canvas-controls.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/canvas-controls.tsx
@@ -34,7 +34,12 @@ export function CanvasControls({ showConnections, onToggleConnections, onAutoLay
     const next = !zenActive;
     setHeaderCollapsed(next);
     setSidebarOpen(!next);
-  }, [zenActive, setHeaderCollapsed, setSidebarOpen]);
+    // Entering zen reclaims the header + sidebar space — re-layout once the
+    // collapse has settled so the fit measures the final pane size.
+    // ponytail: 250ms outlasts the sidebar's 200ms transition; switch to a
+    // transitionend listener if the timing ever drifts.
+    if (next) window.setTimeout(onAutoLayout, 250);
+  }, [zenActive, setHeaderCollapsed, setSidebarOpen, onAutoLayout]);
 
   // ⌘. toggles zen. Lives here (not the shell) because zen also needs the
   // sidebar; the canvas stays mounted across tabs, so the shortcut is global.

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/canvas-editor.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/canvas-editor.tsx
@@ -11,7 +11,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useCallback, useState } from "react";
-import { Move } from "lucide-react";
+import { Lock, Move } from "lucide-react";
 import { useTheme } from "@/hooks/use-theme";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { ResourceNode, type ResourceFlowNode } from "./nodes/resource-node";
@@ -54,6 +54,9 @@ interface CanvasEditorProps {
   onLinkAddon: (addonId: string) => void;
   canAddVolume: boolean;
   onAddVolume: () => void;
+  /** Live view: nodes are locked in place and every mutation affordance
+   *  (add-resource panel, pane context menu) is hidden. */
+  readOnly?: boolean;
 }
 
 /**
@@ -80,6 +83,7 @@ export function CanvasEditor({
   onLinkAddon,
   canAddVolume,
   onAddVolume,
+  readOnly = false,
 }: CanvasEditorProps) {
   // Right-clicking empty canvas opens the same add-resource picker at the
   // cursor (anchored via an invisible fixed-position point).
@@ -105,7 +109,8 @@ export function CanvasEditor({
         onNodeDragStart={onNodeDragStart}
         onNodeDrag={onNodeDrag}
         onNodeDragStop={onNodeDragStop}
-        onPaneContextMenu={onPaneContextMenu}
+        onPaneContextMenu={readOnly ? undefined : onPaneContextMenu}
+        nodesDraggable={!readOnly}
         fitView
         fitViewOptions={FIT_OPTIONS}
         // Follow the app's theme toggle, not the OS preference — "system"
@@ -125,22 +130,33 @@ export function CanvasEditor({
           onToggleConnections={onToggleConnections}
           onAutoLayout={onAutoLayout}
         />
-        <Panel position="top-right">
-          <AddResourcePopover
-            addedIds={addedBlockIds}
-            onAdd={onAddBlock}
-            addons={addons}
-            linkedAddonIds={linkedAddonIds}
-            onLinkAddon={onLinkAddon}
-            canAddVolume={canAddVolume}
-            onAddVolume={onAddVolume}
-          />
-        </Panel>
+        {!readOnly && (
+          <Panel position="top-right">
+            <AddResourcePopover
+              addedIds={addedBlockIds}
+              onAdd={onAddBlock}
+              addons={addons}
+              linkedAddonIds={linkedAddonIds}
+              onLinkAddon={onLinkAddon}
+              canAddVolume={canAddVolume}
+              onAddVolume={onAddVolume}
+            />
+          </Panel>
+        )}
         {nodes.length > 0 && (
           <Panel position="bottom-center" className="pointer-events-none !mb-[18px]">
             <div className="flex items-center gap-2 text-[11.5px] text-fg-muted">
-              <Move className="size-[13px]" aria-hidden />
-              drag to rearrange · click a node to configure · edges show stack connections
+              {readOnly ? (
+                <>
+                  <Lock className="size-[13px]" aria-hidden />
+                  viewing the live deployment · read-only · click a node to inspect
+                </>
+              ) : (
+                <>
+                  <Move className="size-[13px]" aria-hidden />
+                  drag to rearrange · click a node to configure · edges show stack connections
+                </>
+              )}
             </div>
           </Panel>
         )}

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/live-view-toggle.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/live-view-toggle.tsx
@@ -15,8 +15,8 @@ const SEGMENT_BASE =
 
 /**
  * Draft/Live segmented control overlaid on the canvas. "Live" switches the
- * canvas to a read-only view of the converged release; the caption spells the
- * read-only contract out so the disabled drawer downstream isn't a surprise.
+ * canvas to a read-only view of the converged release; the canvas footer
+ * caption spells the read-only contract out.
  */
 export function LiveViewToggle({ mode, onModeChange, draftDirty }: LiveViewToggleProps) {
   const segment = (value: CanvasViewMode, label: React.ReactNode) => (
@@ -33,37 +33,30 @@ export function LiveViewToggle({ mode, onModeChange, draftDirty }: LiveViewToggl
   );
 
   return (
-    <div className="flex items-center gap-2">
-      <div
-        role="group"
-        aria-label="Canvas view"
-        className="flex items-center gap-0.5 rounded-md border border-border bg-background p-0.5 shadow-sm"
-      >
-        {segment(
-          "draft",
-          <>
-            Draft
-            {draftDirty && (
-              <span
-                aria-hidden
-                data-testid="draft-dirty-dot"
-                className="inline-block size-1.5 rounded-full bg-brand"
-              />
-            )}
-          </>,
-        )}
-        {segment(
-          "live",
-          <>
-            <Eye className="size-3.5" aria-hidden />
-            Live
-          </>,
-        )}
-      </div>
-      {mode === "live" && (
-        <span className="rounded-md border border-success-border bg-success-bg px-2 py-0.5 text-[11px] font-medium text-success">
-          read-only · what&rsquo;s currently deployed
-        </span>
+    <div
+      role="group"
+      aria-label="Canvas view"
+      className="flex items-center gap-0.5 rounded-md border border-border bg-background p-0.5 shadow-sm"
+    >
+      {segment(
+        "draft",
+        <>
+          Draft
+          {draftDirty && (
+            <span
+              aria-hidden
+              data-testid="draft-dirty-dot"
+              className="inline-block size-1.5 rounded-full bg-brand"
+            />
+          )}
+        </>,
+      )}
+      {segment(
+        "live",
+        <>
+          <Eye className="size-3.5" aria-hidden />
+          Live
+        </>,
       )}
     </div>
   );

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/live-view-toggle.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/live-view-toggle.tsx
@@ -1,0 +1,70 @@
+import { Eye } from "lucide-react";
+
+export type CanvasViewMode = "draft" | "live";
+
+interface LiveViewToggleProps {
+  mode: CanvasViewMode;
+  onModeChange: (mode: CanvasViewMode) => void;
+  /** Undeployed edits exist — marks the Draft segment so switching away from
+   *  it doesn't read as "nothing pending". */
+  draftDirty: boolean;
+}
+
+const SEGMENT_BASE =
+  "flex items-center gap-1.5 rounded-[5px] px-2.5 py-1 text-[12px] font-medium transition-colors";
+
+/**
+ * Draft/Live segmented control overlaid on the canvas. "Live" switches the
+ * canvas to a read-only view of the converged release; the caption spells the
+ * read-only contract out so the disabled drawer downstream isn't a surprise.
+ */
+export function LiveViewToggle({ mode, onModeChange, draftDirty }: LiveViewToggleProps) {
+  const segment = (value: CanvasViewMode, label: React.ReactNode) => (
+    <button
+      type="button"
+      aria-pressed={mode === value}
+      onClick={() => onModeChange(value)}
+      className={`${SEGMENT_BASE} ${
+        mode === value ? "bg-brand-bg text-brand" : "text-fg-muted hover:text-foreground"
+      }`}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        role="group"
+        aria-label="Canvas view"
+        className="flex items-center gap-0.5 rounded-md border border-border bg-background p-0.5 shadow-sm"
+      >
+        {segment(
+          "draft",
+          <>
+            Draft
+            {draftDirty && (
+              <span
+                aria-hidden
+                data-testid="draft-dirty-dot"
+                className="inline-block size-1.5 rounded-full bg-brand"
+              />
+            )}
+          </>,
+        )}
+        {segment(
+          "live",
+          <>
+            <Eye className="size-3.5" aria-hidden />
+            Live
+          </>,
+        )}
+      </div>
+      {mode === "live" && (
+        <span className="rounded-md border border-success-border bg-success-bg px-2 py-0.5 text-[11px] font-medium text-success">
+          read-only · what&rsquo;s currently deployed
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/resource-drawer.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/resource-drawer.tsx
@@ -205,7 +205,7 @@ export function ResourceDrawer({
           )}
         </div>
         {readOnly && (
-          <span className="shrink-0 rounded-md border border-success-border bg-success-bg px-2 py-0.5 font-mono text-[9px] font-medium uppercase tracking-[0.12em] text-success">
+          <span className="shrink-0 rounded-md border border-border px-2 py-0.5 font-mono text-[9px] font-medium uppercase tracking-[0.12em] text-fg-muted">
             Live · read-only
           </span>
         )}

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/resource-drawer.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/resource-drawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { X, ScrollText, Trash2 } from "lucide-react";
@@ -7,7 +7,7 @@ import { usePostgresAddons } from "@/pages/addons/hooks/use-postgres-addons";
 import type { PostgresAddon } from "@/api/addons";
 import type { ReleaseLiveStatus } from "@/api/releases";
 import type { UseStackEditSession, EditSessionTab } from "@/pages/stacks/hooks/use-stack-edit-session";
-import type { FormStackResourceData } from "@/pages/stacks/schemas/form-schema";
+import type { FormStackResourceData, FormVolumeExtendedData } from "@/pages/stacks/schemas/form-schema";
 import { StackResourceConfigurationTab } from "@/pages/stacks/components/editor/tabs/architecture/drawer-tabs/configuration-tab";
 import { StackResourceDeploymentTab } from "@/pages/stacks/components/editor/tabs/architecture/drawer-tabs/deployment-tab";
 import { StackResourceEnvironmentTab } from "@/pages/stacks/components/editor/tabs/architecture/drawer-tabs/environment-tab";
@@ -50,6 +50,10 @@ interface ResourceDrawerProps {
   /** This resource's live public URLs, best-first (same order as the header's
    *  PUBLIC row). Absent when the resource has no live public ingress. */
   publicUrls?: EndpointUrl[];
+  /** Read-only live view: the drawer renders this data (the converged release's
+   *  snapshot) instead of the edit session's draft, and every field is disabled.
+   *  `resourceIndex` then indexes into `live.resources`. */
+  live?: { resources: Partial<FormStackResourceData>[]; volumes: Partial<FormVolumeExtendedData>[] };
 }
 
 /**
@@ -71,9 +75,15 @@ export function ResourceDrawer({
   onOpenVolume,
   liveStatusResources,
   publicUrls,
+  live,
 }: ResourceDrawerProps) {
-  const resource = session.draft.resources[resourceIndex] ?? {};
-  const baselineResource = baselineResources[resourceIndex];
+  const readOnly = !!live;
+  const shownResources = live?.resources ?? session.draft.resources;
+  const shownVolumes = live?.volumes ?? session.draft.volumes;
+  const resource = shownResources[resourceIndex] ?? {};
+  // Read-only view: baseline == shown resource, so every dirty computation
+  // (tab dots, "N changes" chip, per-field discards) reads as clean.
+  const baselineResource = readOnly ? resource : baselineResources[resourceIndex];
   const liveStatus = resource.name ? liveStatusResources?.[resource.name] : undefined;
 
   const secrets = useSecrets();
@@ -96,22 +106,24 @@ export function ResourceDrawer({
   // resource added on the canvas has none in its draft copy until saved.
   const allResources = useMemo(
     () =>
-      session.draft.resources.map((r, i) => ({
+      shownResources.map((r, i) => ({
         name: r.name || `Resource ${i + 1}`,
         index: i,
         outputs:
           serverOutputsByName?.get(r.name ?? "") ??
           deriveResourceOutputNames(r),
       })),
-    [session.draft.resources, serverOutputsByName],
+    [shownResources, serverOutputsByName],
   );
 
-  // Replace just this resource in the draft.
+  // Replace just this resource in the draft. The read-only guard is a belt on
+  // top of the disabled fieldset — no edit may ever reach the session.
   const onChange = useCallback(
     (index: number, updated: Partial<FormStackResourceData>) => {
+      if (readOnly) return;
       session.updateResources((prev) => prev.map((r, i) => (i === index ? updated : r)));
     },
-    [session],
+    [session, readOnly],
   );
 
   const { dirtyTabs, isDirty, statusDotColor, configurationProps, deploymentProps, environmentProps } =
@@ -125,8 +137,9 @@ export function ResourceDrawer({
         errors,
         // Draft volumes, not baseline: an inline-added volume must be pickable
         // (and resolvable by existing mount rows) before the next autosave
-        // cycle advances the baseline.
-        volumes: session.draft.volumes,
+        // cycle advances the baseline. In the read-only live view these are
+        // the snapshot's volumes instead, so mount rows resolve consistently.
+        volumes: shownVolumes,
         allResources,
         serverOutputsByName,
         secrets,
@@ -141,7 +154,15 @@ export function ResourceDrawer({
 
   // Controlled tab: driven by session.openTab so a banner "jump to error" can
   // switch to the tab holding the offending field even while the drawer is open.
-  const activeTab = session.openTab ? TAB_VALUE[session.openTab] : TAB_VALUE.configuration;
+  // The read-only view keeps its own tab state — session.setOpenTab no-ops when
+  // no session is active (read-only viewers), and the live drawer must not
+  // steer the draft drawer's tab anyway.
+  const [localTab, setLocalTab] = useState<string>(TAB_VALUE.configuration);
+  const activeTab = readOnly
+    ? localTab
+    : session.openTab
+      ? TAB_VALUE[session.openTab]
+      : TAB_VALUE.configuration;
 
   // Kind glyph + summary sub-line, derived the same way the node card is.
   const pres = useMemo(
@@ -183,6 +204,11 @@ export function ResourceDrawer({
             <EndpointInlineList service={resource.name || "resource"} urls={publicUrls} />
           )}
         </div>
+        {readOnly && (
+          <span className="shrink-0 rounded-md border border-success-border bg-success-bg px-2 py-0.5 font-mono text-[9px] font-medium uppercase tracking-[0.12em] text-success">
+            Live · read-only
+          </span>
+        )}
         {isDirty ? (
           <span className="flex shrink-0 items-center gap-1 rounded-md border border-brand pl-2 pr-1 py-0.5 text-[11px] font-medium text-brand">
             {changeCount === 1 ? "1 change" : `${changeCount} changes`}
@@ -214,7 +240,7 @@ export function ResourceDrawer({
       {/* Tabs */}
       <Tabs
         value={activeTab}
-        onValueChange={(v) => session.setOpenTab(TAB_FROM_VALUE[v] ?? "configuration")}
+        onValueChange={(v) => (readOnly ? setLocalTab(v) : session.setOpenTab(TAB_FROM_VALUE[v] ?? "configuration"))}
         className="flex min-h-0 flex-1 flex-col"
       >
         <TabsList className="h-auto w-full flex-none justify-start gap-1 rounded-none border-b border-border bg-transparent p-0 px-1">
@@ -232,11 +258,14 @@ export function ResourceDrawer({
           </TabsTrigger>
         </TabsList>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        {/* One disabled fieldset covers every native input and Radix
+            button-based control across all three tabs — read-only without
+            threading a flag through each field. */}
+        <fieldset disabled={readOnly} className="min-h-0 min-w-0 flex-1 overflow-y-auto px-4 py-4">
           <StackResourceConfigurationTab {...configurationProps} />
           <StackResourceDeploymentTab {...deploymentProps} />
           <StackResourceEnvironmentTab {...environmentProps} />
-        </div>
+        </fieldset>
       </Tabs>
 
       {/* Footer */}
@@ -252,16 +281,18 @@ export function ResourceDrawer({
           <ScrollText className="size-3.5" />
           View logs
         </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1.5 px-2 text-[12.5px] text-danger hover:bg-danger-bg hover:text-danger"
-          onClick={() => onRemove(resourceIndex)}
-        >
-          <Trash2 className="size-3.5" />
-          Remove resource
-        </Button>
+        {!readOnly && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 px-2 text-[12.5px] text-danger hover:bg-danger-bg hover:text-danger"
+            onClick={() => onRemove(resourceIndex)}
+          >
+            <Trash2 className="size-3.5" />
+            Remove resource
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/tests/architecture-tab-live-view.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/tests/architecture-tab-live-view.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { ArchitectureTab } from "../architecture-tab";
+import { ConfirmProvider } from "@/components/branded/confirm";
+import { useStackEditSession } from "@/pages/stacks/hooks/use-stack-edit-session";
+
+afterEach(cleanup);
+
+// Same rationale as architecture-tab-volume-delete.test.tsx: the real
+// <ReactFlow> never stabilizes under jsdom. The stub keeps the node list and
+// click wiring, and surfaces the readOnly flag so the live view's canvas
+// lockdown is assertable.
+vi.mock("../canvas-editor", () => ({
+  CanvasEditor: (props: {
+    nodes: { id: string; data: { name?: string } }[];
+    onNodeClick?: (e: unknown, n: unknown) => void;
+    readOnly?: boolean;
+  }) => (
+    <div data-testid={props.readOnly ? "canvas-readonly" : "canvas-editable"}>
+      {props.nodes.map((n) => (
+        <button key={n.id} type="button" onClick={(e) => props.onNodeClick?.(e, n)}>
+          {n.data?.name ?? n.id}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const EMPTY_ADDONS: never[] = [];
+const EMPTY_SECRETS: never[] = [];
+const NO_TOPOLOGY = { topology: null };
+vi.mock("@/pages/addons/hooks/use-postgres-addons", () => ({
+  usePostgresAddons: () => ({ addons: EMPTY_ADDONS }),
+}));
+vi.mock("@/pages/stacks/hooks/use-secrets", () => ({
+  useSecrets: () => ({ secrets: EMPTY_SECRETS, isLoading: false }),
+}));
+vi.mock("@/pages/stacks/hooks/use-stack-topology", () => ({
+  useStackTopology: () => NO_TOPOLOGY,
+}));
+
+// Module-scoped for referential stability (see the volume-delete harness).
+// The draft and the live snapshot deliberately hold differently-named
+// resources, so which list the canvas is rendering is directly observable.
+const DRAFT_RESOURCE = { name: "web-draft" };
+const DRAFT_RESOURCES = [DRAFT_RESOURCE];
+const LIVE_RESOURCE = { name: "api-live" };
+const NO_VOLUMES: never[] = [];
+const NO_ADDON_IDS = new Set<string>();
+const NO_ADDON_NAMES = new Map<string, string>();
+const NO_ERRORS = {};
+const LIVE_VIEW = {
+  resources: [LIVE_RESOURCE],
+  volumes: NO_VOLUMES,
+  linkedAddonIds: NO_ADDON_IDS,
+};
+
+function Harness(props: { liveView?: typeof LIVE_VIEW }) {
+  const session = useStackEditSession();
+  if (!session.isActive) {
+    session.start({ resources: DRAFT_RESOURCES, volumes: NO_VOLUMES }, { openTab: "configuration" });
+  }
+  return (
+    <ConfirmProvider>
+      <ArchitectureTab
+        session={session}
+        baselineResources={DRAFT_RESOURCES}
+        baselineVolumes={NO_VOLUMES}
+        draftResources={DRAFT_RESOURCES}
+        draftVolumes={NO_VOLUMES}
+        connectionAddonIds={NO_ADDON_IDS}
+        addonNameById={NO_ADDON_NAMES}
+        errors={NO_ERRORS}
+        topologyIds={{ orgId: "o", projectName: "t", stackId: "s" }}
+        topologyRefreshKey={0}
+        liveView={props.liveView}
+      />
+    </ConfirmProvider>
+  );
+}
+
+describe("ArchitectureTab live view", () => {
+  it("renders no Draft/Live toggle without a live view (never deployed)", () => {
+    render(<Harness />);
+    expect(screen.queryByRole("group", { name: "Canvas view" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("canvas-editable")).toBeInTheDocument();
+  });
+
+  it("switches the canvas to the live snapshot's resources, read-only", () => {
+    render(<Harness liveView={LIVE_VIEW} />);
+    // Draft view first: draft node shown, live node absent.
+    expect(screen.getByRole("button", { name: "web-draft" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "api-live" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Live" }));
+
+    expect(screen.getByTestId("canvas-readonly")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "api-live" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "web-draft" })).not.toBeInTheDocument();
+    expect(screen.getByText(/read-only/)).toBeInTheDocument();
+  });
+
+  it("opens a disabled, mutation-free drawer for a live node", () => {
+    render(<Harness liveView={LIVE_VIEW} />);
+    fireEvent.click(screen.getByRole("button", { name: "Live" }));
+    fireEvent.click(screen.getByRole("button", { name: "api-live" }));
+
+    const drawer = screen.getByTestId("resource-drawer");
+    expect(drawer).toHaveTextContent("Live · read-only");
+    expect(screen.queryByRole("button", { name: /remove resource/i })).not.toBeInTheDocument();
+    // jest-dom's toBeDisabled honours the ancestor <fieldset disabled> — every
+    // form field in the drawer body is dead.
+    const nameInput = screen.getByLabelText(/name/i);
+    expect(nameInput).toBeDisabled();
+  });
+
+  it("closes the drawer when switching back to Draft (indexes are not stable across views)", () => {
+    render(<Harness liveView={LIVE_VIEW} />);
+    fireEvent.click(screen.getByRole("button", { name: "Live" }));
+    fireEvent.click(screen.getByRole("button", { name: "api-live" }));
+    expect(screen.getByTestId("resource-drawer")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+    expect(screen.queryByTestId("resource-drawer")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "web-draft" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/tests/architecture-tab-live-view.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/tests/architecture-tab-live-view.test.tsx
@@ -56,19 +56,28 @@ const LIVE_VIEW = {
   volumes: NO_VOLUMES,
   linkedAddonIds: NO_ADDON_IDS,
 };
+// "both" lives in the draft (at index 1) and the live snapshot (at index 0) —
+// the drawer surviving a view switch proves the name-based index remap.
+const BOTH_DRAFT_RESOURCES = [DRAFT_RESOURCE, { name: "both" }];
+const BOTH_LIVE_VIEW = {
+  resources: [{ name: "both" }],
+  volumes: NO_VOLUMES,
+  linkedAddonIds: NO_ADDON_IDS,
+};
 
-function Harness(props: { liveView?: typeof LIVE_VIEW }) {
+function Harness(props: { liveView?: typeof LIVE_VIEW; draftResources?: { name: string }[] }) {
+  const draftResources = props.draftResources ?? DRAFT_RESOURCES;
   const session = useStackEditSession();
   if (!session.isActive) {
-    session.start({ resources: DRAFT_RESOURCES, volumes: NO_VOLUMES }, { openTab: "configuration" });
+    session.start({ resources: draftResources, volumes: NO_VOLUMES }, { openTab: "configuration" });
   }
   return (
     <ConfirmProvider>
       <ArchitectureTab
         session={session}
-        baselineResources={DRAFT_RESOURCES}
+        baselineResources={draftResources}
         baselineVolumes={NO_VOLUMES}
-        draftResources={DRAFT_RESOURCES}
+        draftResources={draftResources}
         draftVolumes={NO_VOLUMES}
         connectionAddonIds={NO_ADDON_IDS}
         addonNameById={NO_ADDON_NAMES}
@@ -99,7 +108,6 @@ describe("ArchitectureTab live view", () => {
     expect(screen.getByTestId("canvas-readonly")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "api-live" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "web-draft" })).not.toBeInTheDocument();
-    expect(screen.getByText(/read-only/)).toBeInTheDocument();
   });
 
   it("opens a disabled, mutation-free drawer for a live node", () => {
@@ -116,7 +124,7 @@ describe("ArchitectureTab live view", () => {
     expect(nameInput).toBeDisabled();
   });
 
-  it("closes the drawer when switching back to Draft (indexes are not stable across views)", () => {
+  it("closes the drawer on switch when the resource has no counterpart in the target view", () => {
     render(<Harness liveView={LIVE_VIEW} />);
     fireEvent.click(screen.getByRole("button", { name: "Live" }));
     fireEvent.click(screen.getByRole("button", { name: "api-live" }));
@@ -125,5 +133,22 @@ describe("ArchitectureTab live view", () => {
     fireEvent.click(screen.getByRole("button", { name: "Draft" }));
     expect(screen.queryByTestId("resource-drawer")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "web-draft" })).toBeInTheDocument();
+  });
+
+  it("keeps the drawer open across view switches when the resource exists in both", () => {
+    render(<Harness draftResources={BOTH_DRAFT_RESOURCES} liveView={BOTH_LIVE_VIEW} />);
+    fireEvent.click(screen.getByRole("button", { name: "both" }));
+    expect(screen.getByTestId("resource-drawer")).toBeInTheDocument();
+
+    // Draft → Live: same resource, remapped from draft index 1 to live index 0.
+    fireEvent.click(screen.getByRole("button", { name: "Live" }));
+    const liveDrawer = screen.getByTestId("resource-drawer");
+    expect(liveDrawer).toHaveTextContent("Live · read-only");
+    expect(screen.getByLabelText(/name/i)).toBeDisabled();
+
+    // Live → Draft: drawer survives the trip back and is editable again.
+    fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+    expect(screen.getByTestId("resource-drawer")).toBeInTheDocument();
+    expect(screen.getByLabelText(/name/i)).not.toBeDisabled();
   });
 });

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/tests/live-view-toggle.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/tests/live-view-toggle.test.tsx
@@ -18,14 +18,6 @@ describe("LiveViewToggle", () => {
     expect(onModeChange).toHaveBeenCalledWith("live");
   });
 
-  it("shows the read-only caption only in live mode", () => {
-    const { rerender } = render(<LiveViewToggle mode="draft" onModeChange={vi.fn()} draftDirty={false} />);
-    expect(screen.queryByText(/read-only/)).not.toBeInTheDocument();
-
-    rerender(<LiveViewToggle mode="live" onModeChange={vi.fn()} draftDirty={false} />);
-    expect(screen.getByText(/read-only/)).toBeInTheDocument();
-  });
-
   it("dots the Draft segment when undeployed edits exist", () => {
     const { rerender } = render(<LiveViewToggle mode="live" onModeChange={vi.fn()} draftDirty />);
     expect(screen.getByTestId("draft-dirty-dot")).toBeInTheDocument();

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/tests/live-view-toggle.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/tests/live-view-toggle.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { LiveViewToggle } from "../live-view-toggle";
+
+afterEach(cleanup);
+
+describe("LiveViewToggle", () => {
+  it("marks the active segment and reports switches", () => {
+    const onModeChange = vi.fn();
+    render(<LiveViewToggle mode="draft" onModeChange={onModeChange} draftDirty={false} />);
+
+    expect(screen.getByRole("button", { name: "Draft" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Live" })).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(screen.getByRole("button", { name: "Live" }));
+    expect(onModeChange).toHaveBeenCalledWith("live");
+  });
+
+  it("shows the read-only caption only in live mode", () => {
+    const { rerender } = render(<LiveViewToggle mode="draft" onModeChange={vi.fn()} draftDirty={false} />);
+    expect(screen.queryByText(/read-only/)).not.toBeInTheDocument();
+
+    rerender(<LiveViewToggle mode="live" onModeChange={vi.fn()} draftDirty={false} />);
+    expect(screen.getByText(/read-only/)).toBeInTheDocument();
+  });
+
+  it("dots the Draft segment when undeployed edits exist", () => {
+    const { rerender } = render(<LiveViewToggle mode="live" onModeChange={vi.fn()} draftDirty />);
+    expect(screen.getByTestId("draft-dirty-dot")).toBeInTheDocument();
+
+    rerender(<LiveViewToggle mode="live" onModeChange={vi.fn()} draftDirty={false} />);
+    expect(screen.queryByTestId("draft-dirty-dot")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/stacks/lib/canvas/drawer-stack.ts
+++ b/frontend/src/pages/stacks/lib/canvas/drawer-stack.ts
@@ -24,3 +24,21 @@ export function truncateTo(stack: DrawerEntry[], depth: number): DrawerEntry[] {
 export function popEntry(stack: DrawerEntry[]): DrawerEntry[] {
   return stack.slice(0, -1);
 }
+
+/**
+ * Rebind open drawers onto another resource/volume list by name (names are
+ * unique in a stack), remapping resource indexes — the two lists don't line
+ * up. Entries with no same-named counterpart drop out.
+ */
+export function remapStackByName(
+  stack: DrawerEntry[],
+  from: { resources: { name?: string }[] },
+  to: { resources: { name?: string }[]; volumeNames: ReadonlySet<string> },
+): DrawerEntry[] {
+  return stack.flatMap((e): DrawerEntry[] => {
+    if (e.kind === "volume") return to.volumeNames.has(e.name) ? [e] : [];
+    const name = from.resources[e.index]?.name;
+    const index = name ? to.resources.findIndex((r) => r.name === name) : -1;
+    return index >= 0 ? [{ kind: "resource", index }] : [];
+  });
+}

--- a/frontend/src/pages/stacks/lib/canvas/tests/drawer-stack.test.ts
+++ b/frontend/src/pages/stacks/lib/canvas/tests/drawer-stack.test.ts
@@ -5,6 +5,7 @@ import {
   pushEntry,
   truncateTo,
   popEntry,
+  remapStackByName,
   type DrawerEntry,
 } from "../drawer-stack";
 
@@ -41,5 +42,17 @@ describe("drawer-stack", () => {
   it("popEntry removes the front entry; empty stays empty", () => {
     expect(popEntry([r(0), v("data")])).toEqual([r(0)]);
     expect(popEntry([])).toEqual([]);
+  });
+
+  it("remapStackByName rebinds indexes by name and drops entries without a counterpart", () => {
+    const from = { resources: [{ name: "web" }, { name: "api" }] };
+    const to = { resources: [{ name: "api" }], volumeNames: new Set(["data"]) };
+    expect(remapStackByName([r(0), r(1), v("data"), v("gone")], from, to)).toEqual([r(0), v("data")]);
+  });
+
+  it("remapStackByName drops resources with no name", () => {
+    const from = { resources: [{}] };
+    const to = { resources: [{}], volumeNames: new Set<string>() };
+    expect(remapStackByName([r(0)], from, to)).toEqual([]);
   });
 });

--- a/frontend/src/pages/stacks/lib/connection-mapping.ts
+++ b/frontend/src/pages/stacks/lib/connection-mapping.ts
@@ -239,3 +239,13 @@ export function connectionsToMounts(resourceName: string, connections: StackConn
   }
   return rows;
 }
+
+/** Distinct postgres-addon ids appearing as connection sources — the addons a
+ *  stack (or a release snapshot) is linked to. */
+export function addonIdsFromConnections(connections: StackConnection[] | undefined): Set<string> {
+  return new Set(
+    (connections ?? [])
+      .filter((c) => c.from?.type === "addon/postgres" && c.from?.id)
+      .map((c) => c.from!.id as string),
+  );
+}


### PR DESCRIPTION
## 📝 What this does
Adds a Draft/Live toggle to the stack canvas: once a converged release exists, you can flip the graph between the editable draft and a read-only view of what's actually running — without leaving the editor. Open drawers survive the switch, so you can compare a resource's draft config against its live config side by side.

## 🔀 Changes
- Added a segmented Draft/Live control on the canvas; Live renders the converged release's snapshot read-only (no dragging, no mutation affordances, disabled drawer fields).
- Kept open drawers across view switches by rebinding them to the same-named resource/volume in the target view; drawers with no counterpart close.
- Restyled the read-only indicators from success-green to neutral muted chips, and dropped the redundant toggle caption (the canvas footer already states the contract).
- Made entering zen mode re-run auto layout once the header/sidebar collapse settles, with the viewport gliding onto the new layout instead of snapping.
- Marked the Draft segment with a dot while undeployed edits exist.

## 🧪 How to test
- [x] Open a stack that has at least one successful deploy — the Draft/Live toggle appears on the canvas
- [x] Switch to Live — nodes lock, mutation affordances disappear, drawers open read-only with a muted "Live · read-only" chip
- [x] Open a resource drawer, flip Draft ↔ Live — the drawer stays open on the same resource in both directions
- [x] Add a new (undeployed) resource, open its drawer, switch to Live — the drawer closes (no live counterpart)
- [x] Enter zen mode — header and sidebar collapse, then the graph glides into a centered layout in the larger pane