### PR TITLE
Fix: least-privilege RBAC for the hub service account

### DIFF
--- a/install/manifests/rbac.yaml
+++ b/install/manifests/rbac.yaml
@@ -21,6 +21,10 @@ rules:
   - apiGroups: ["core.stackdome.io"]
     resources: ["stacks", "stackresources"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]
+  # Agent-owned cluster inventory: hub only observes.
+  - apiGroups: ["core.stackdome.io"]
+    resources: ["clusterinfoes"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.stackdome.io"]
     resources: ["volumes"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/install/manifests/rbac.yaml
+++ b/install/manifests/rbac.yaml
@@ -17,9 +17,63 @@ metadata:
     app.kubernetes.io/managed-by: stackdome-installer
     stackdome.io/bootstrap: "true"
 rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]
+  # Stackdome CRs: hub writes desired state, watches status (informers need list+watch).
+  - apiGroups: ["core.stackdome.io"]
+    resources: ["stacks", "stackresources"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["storage.stackdome.io"]
+    resources: ["volumes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["users.stackdome.io"]
+    resources: ["users"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["registry.stackdome.io"]
+    resources: ["clusterregistries"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["addons.stackdome.io"]
+    resources: ["postgresclusters"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  # Agent-created build CRs: hub only observes.
+  - apiGroups: ["builds.stackdome.io"]
+    resources: ["imagebuilds"]
+    verbs: ["get", "list", "watch"]
+  # TLS issuer provisioned once per cluster at registration.
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "create"]
+  # Postgres addon dependencies.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["imagecatalogs"]
+    verbs: ["get", "create"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["backups"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["barmancloud.cnpg.io"]
+    resources: ["objectstores"]
+    verbs: ["get", "create", "update", "delete"]
+  # Workload namespaces and app/registry/backup secrets.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "delete"]
+  # Log streaming and metrics.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/magefile.go
+++ b/magefile.go
@@ -1251,57 +1251,14 @@ metadata:
 		return fmt.Errorf("failed to ensure namespace: %w", err)
 	}
 
-	// Create ServiceAccount
-	if err := runKubectlApply(ctx, kubeconfig, fmt.Sprintf(`
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: %s
-  namespace: %s`, DevSAName, DevSANamespace)); err != nil {
-		return fmt.Errorf("failed to create service account: %w", err)
-	}
-
-	// Create ClusterRole with full permissions for API server
-	if err := runKubectlApply(ctx, kubeconfig, fmt.Sprintf(`
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: %s
-rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]`, DevRoleName)); err != nil {
-		return fmt.Errorf("failed to create cluster role: %w", err)
-	}
-
-	// Create ClusterRoleBinding
-	if err := runKubectlApply(ctx, kubeconfig, fmt.Sprintf(`
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: %s-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: %s
-subjects:
-  - kind: ServiceAccount
-    name: %s
-    namespace: %s`, DevRoleName, DevRoleName, DevSAName, DevSANamespace)); err != nil {
-		return fmt.Errorf("failed to create cluster role binding: %w", err)
-	}
-
-	// Create Secret for ServiceAccount token
-	if err := runKubectlApply(ctx, kubeconfig, fmt.Sprintf(`
-apiVersion: v1
-kind: Secret
-metadata:
-  name: %s
-  namespace: %s
-  annotations:
-    kubernetes.io/service-account.name: %s
-type: kubernetes.io/service-account-token`, DevSecretName, DevSANamespace, DevSAName)); err != nil {
-		return fmt.Errorf("failed to create secret: %w", err)
+	// SA, ClusterRole, binding and token secret come from the install manifest
+	// (single source of truth for the hub's least-privilege rules).
+	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig,
+		"apply", "-f", "install/manifests/rbac.yaml")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to apply install/manifests/rbac.yaml: %w", err)
 	}
 
 	// Wait for token to be populated

--- a/pkg/clustermanager/manager.go
+++ b/pkg/clustermanager/manager.go
@@ -14,6 +14,7 @@ import (
 	barmancloudv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
 	"github.com/openshift-online/ocm-sdk-go/leadership"
 	suture "github.com/thejerf/suture/v4"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -111,6 +112,13 @@ func (cc *ClusterControl) createManager() (ctrl.Manager, error) {
 		LeaderElection: false,
 		Controller: config.Controller{
 			SkipNameValidation: ptr.To(true),
+		},
+		Client: client.Options{
+			// Secrets are read by name only. Caching them would open a
+			// cluster-wide list/watch on every managed cluster's secrets.
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&corev1.Secret{}},
+			},
 		},
 	})
 	if err != nil {

--- a/test/int/bootstrap/client.go
+++ b/test/int/bootstrap/client.go
@@ -177,6 +177,11 @@ func deployAPIServerServiceAccount(ctx context.Context, cluster *testutil.TestCl
 				Verbs:     verbsFull,
 			},
 			{
+				APIGroups: []string{"core.stackdome.io"},
+				Resources: []string{"clusterinfoes"},
+				Verbs:     verbsReadOnly,
+			},
+			{
 				APIGroups: []string{"storage.stackdome.io"},
 				Resources: []string{"volumes"},
 				Verbs:     verbsFull,

--- a/test/int/bootstrap/client.go
+++ b/test/int/bootstrap/client.go
@@ -19,6 +19,19 @@ import (
 const (
 	controlPlaneNamespace   = "stackdome-control-plane"
 	apiServerServiceAccount = "stackdome-api-server-account"
+
+	verbGet    = "get"
+	verbList   = "list"
+	verbWatch  = "watch"
+	verbCreate = "create"
+	verbUpdate = "update"
+	verbDelete = "delete"
+)
+
+var (
+	verbsFull      = []string{verbGet, verbList, verbWatch, verbCreate, verbUpdate, verbDelete}
+	verbsReadOnly  = []string{verbGet, verbList, verbWatch}
+	verbsGetCreate = []string{verbGet, verbCreate}
 )
 
 type ClientManager struct {
@@ -161,87 +174,87 @@ func deployAPIServerServiceAccount(ctx context.Context, cluster *testutil.TestCl
 			{
 				APIGroups: []string{"core.stackdome.io"},
 				Resources: []string{"stacks", "stackresources"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+				Verbs:     verbsFull,
 			},
 			{
 				APIGroups: []string{"storage.stackdome.io"},
 				Resources: []string{"volumes"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+				Verbs:     verbsFull,
 			},
 			{
 				APIGroups: []string{"users.stackdome.io"},
 				Resources: []string{"users"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+				Verbs:     verbsFull,
 			},
 			{
 				APIGroups: []string{"registry.stackdome.io"},
 				Resources: []string{"clusterregistries"},
-				Verbs:     []string{"get", "list", "watch", "create", "delete"},
+				Verbs:     []string{verbGet, verbList, verbWatch, verbCreate, verbDelete},
 			},
 			{
 				APIGroups: []string{"addons.stackdome.io"},
 				Resources: []string{"postgresclusters"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+				Verbs:     verbsFull,
 			},
 			{
 				APIGroups: []string{"builds.stackdome.io"},
 				Resources: []string{"imagebuilds"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     verbsReadOnly,
 			},
 			{
 				APIGroups: []string{"cert-manager.io"},
 				Resources: []string{"clusterissuers"},
-				Verbs:     []string{"get", "create"},
+				Verbs:     verbsGetCreate,
 			},
 			{
 				APIGroups: []string{"postgresql.cnpg.io"},
 				Resources: []string{"imagecatalogs"},
-				Verbs:     []string{"get", "create"},
+				Verbs:     verbsGetCreate,
 			},
 			{
 				APIGroups: []string{"postgresql.cnpg.io"},
 				Resources: []string{"backups"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     verbsReadOnly,
 			},
 			{
 				APIGroups: []string{"barmancloud.cnpg.io"},
 				Resources: []string{"objectstores"},
-				Verbs:     []string{"get", "create", "update", "delete"},
+				Verbs:     []string{verbGet, verbCreate, verbUpdate, verbDelete},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"namespaces"},
-				Verbs:     []string{"get", "create", "delete"},
+				Verbs:     []string{verbGet, verbCreate, verbDelete},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"secrets"},
-				Verbs:     []string{"get", "create", "update", "delete"},
+				Verbs:     []string{verbGet, verbCreate, verbUpdate, verbDelete},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
+				Verbs:     []string{verbGet, verbList},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods/log"},
-				Verbs:     []string{"get"},
+				Verbs:     []string{verbGet},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"services"},
-				Verbs:     []string{"get"},
+				Verbs:     []string{verbGet},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"nodes"},
-				Verbs:     []string{"list"},
+				Verbs:     []string{verbList},
 			},
 			{
 				APIGroups: []string{"metrics.k8s.io"},
 				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
+				Verbs:     []string{verbGet, verbList},
 			},
 		},
 	}

--- a/test/int/bootstrap/client.go
+++ b/test/int/bootstrap/client.go
@@ -8,31 +8,40 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Stackdome/stackdome/install"
 	"github.com/Stackdome/stackdome/pkg/api/openapi"
 	"github.com/Stackdome/stackdome/pkg/testutil"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 const (
 	controlPlaneNamespace   = "stackdome-control-plane"
 	apiServerServiceAccount = "stackdome-api-server-account"
-
-	verbGet    = "get"
-	verbList   = "list"
-	verbWatch  = "watch"
-	verbCreate = "create"
-	verbUpdate = "update"
-	verbDelete = "delete"
+	rbacManifestName        = "rbac.yaml"
 )
 
-var (
-	verbsFull      = []string{verbGet, verbList, verbWatch, verbCreate, verbUpdate, verbDelete}
-	verbsReadOnly  = []string{verbGet, verbList, verbWatch}
-	verbsGetCreate = []string{verbGet, verbCreate}
-)
+// hubClusterRoleRules reads the hub's least-privilege rules straight out of the
+// install manifest so the integration environment cannot drift from production.
+func hubClusterRoleRules() ([]rbacv1.PolicyRule, error) {
+	raw, err := install.ReadManifest(rbacManifestName)
+	if err != nil {
+		return nil, err
+	}
+	for _, doc := range strings.Split(string(raw), "\n---") {
+		role := &rbacv1.ClusterRole{}
+		if err := yaml.Unmarshal([]byte(doc), role); err != nil {
+			continue
+		}
+		if role.Kind == "ClusterRole" {
+			return role.Rules, nil
+		}
+	}
+	return nil, fmt.Errorf("no ClusterRole found in install manifest %s", rbacManifestName)
+}
 
 type ClientManager struct {
 	client       *openapi.APIClient
@@ -165,103 +174,17 @@ func deployAPIServerServiceAccount(ctx context.Context, cluster *testutil.TestCl
 		return fmt.Errorf("failed to create service account: %w", err)
 	}
 
-	// Create cluster role — rules mirror install/manifests/rbac.yaml (keep in sync)
+	// Cluster role rules come from install/manifests/rbac.yaml — the same manifest
+	// the installer and mage dev:setup apply.
+	rules, err := hubClusterRoleRules()
+	if err != nil {
+		return err
+	}
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "stackdome-api-server-role",
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"core.stackdome.io"},
-				Resources: []string{"stacks", "stackresources"},
-				Verbs:     verbsFull,
-			},
-			{
-				APIGroups: []string{"core.stackdome.io"},
-				Resources: []string{"clusterinfoes"},
-				Verbs:     verbsReadOnly,
-			},
-			{
-				APIGroups: []string{"storage.stackdome.io"},
-				Resources: []string{"volumes"},
-				Verbs:     verbsFull,
-			},
-			{
-				APIGroups: []string{"users.stackdome.io"},
-				Resources: []string{"users"},
-				Verbs:     verbsFull,
-			},
-			{
-				APIGroups: []string{"registry.stackdome.io"},
-				Resources: []string{"clusterregistries"},
-				Verbs:     []string{verbGet, verbList, verbWatch, verbCreate, verbDelete},
-			},
-			{
-				APIGroups: []string{"addons.stackdome.io"},
-				Resources: []string{"postgresclusters"},
-				Verbs:     verbsFull,
-			},
-			{
-				APIGroups: []string{"builds.stackdome.io"},
-				Resources: []string{"imagebuilds"},
-				Verbs:     verbsReadOnly,
-			},
-			{
-				APIGroups: []string{"cert-manager.io"},
-				Resources: []string{"clusterissuers"},
-				Verbs:     verbsGetCreate,
-			},
-			{
-				APIGroups: []string{"postgresql.cnpg.io"},
-				Resources: []string{"imagecatalogs"},
-				Verbs:     verbsGetCreate,
-			},
-			{
-				APIGroups: []string{"postgresql.cnpg.io"},
-				Resources: []string{"backups"},
-				Verbs:     verbsReadOnly,
-			},
-			{
-				APIGroups: []string{"barmancloud.cnpg.io"},
-				Resources: []string{"objectstores"},
-				Verbs:     []string{verbGet, verbCreate, verbUpdate, verbDelete},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"namespaces"},
-				Verbs:     []string{verbGet, verbCreate, verbDelete},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     []string{verbGet, verbCreate, verbUpdate, verbDelete},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{verbGet, verbList},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods/log"},
-				Verbs:     []string{verbGet},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"services"},
-				Verbs:     []string{verbGet},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"nodes"},
-				Verbs:     []string{verbList},
-			},
-			{
-				APIGroups: []string{"metrics.k8s.io"},
-				Resources: []string{"pods"},
-				Verbs:     []string{verbGet, verbList},
-			},
-		},
+		Rules: rules,
 	}
 	_, err = kubeClient.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
 	if err != nil {

--- a/test/int/bootstrap/client.go
+++ b/test/int/bootstrap/client.go
@@ -152,22 +152,107 @@ func deployAPIServerServiceAccount(ctx context.Context, cluster *testutil.TestCl
 		return fmt.Errorf("failed to create service account: %w", err)
 	}
 
-	// Create cluster role
+	// Create cluster role — rules mirror install/manifests/rbac.yaml (keep in sync)
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "stackdome-api-server-role",
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups: []string{"*"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
+				APIGroups: []string{"core.stackdome.io"},
+				Resources: []string{"stacks", "stackresources"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{"storage.stackdome.io"},
+				Resources: []string{"volumes"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{"users.stackdome.io"},
+				Resources: []string{"users"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{"registry.stackdome.io"},
+				Resources: []string{"clusterregistries"},
+				Verbs:     []string{"get", "list", "watch", "create", "delete"},
+			},
+			{
+				APIGroups: []string{"addons.stackdome.io"},
+				Resources: []string{"postgresclusters"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{"builds.stackdome.io"},
+				Resources: []string{"imagebuilds"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"cert-manager.io"},
+				Resources: []string{"clusterissuers"},
+				Verbs:     []string{"get", "create"},
+			},
+			{
+				APIGroups: []string{"postgresql.cnpg.io"},
+				Resources: []string{"imagecatalogs"},
+				Verbs:     []string{"get", "create"},
+			},
+			{
+				APIGroups: []string{"postgresql.cnpg.io"},
+				Resources: []string{"backups"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"barmancloud.cnpg.io"},
+				Resources: []string{"objectstores"},
+				Verbs:     []string{"get", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs:     []string{"get", "create", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get", "create", "update", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods/log"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes"},
+				Verbs:     []string{"list"},
+			},
+			{
+				APIGroups: []string{"metrics.k8s.io"},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list"},
 			},
 		},
 	}
 	_, err = kubeClient.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
-	if err != nil && !strings.Contains(err.Error(), "already exists") {
-		return fmt.Errorf("failed to create cluster role: %w", err)
+	if err != nil {
+		if !strings.Contains(err.Error(), "already exists") {
+			return fmt.Errorf("failed to create cluster role: %w", err)
+		}
+		if _, err := kubeClient.RbacV1().ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update cluster role: %w", err)
+		}
 	}
 
 	// Create cluster role binding

--- a/test/int/platform_provisioning_test.go
+++ b/test/int/platform_provisioning_test.go
@@ -176,6 +176,8 @@ var _ = Describe("Platform provisioning", func() {
 			clusterURL = strings.Replace(clusterURL, "127.0.0.1", "localhost", 1)
 		case strings.Contains(clusterURL, "localhost"):
 			clusterURL = strings.Replace(clusterURL, "localhost", "127.0.0.1", 1)
+		case strings.Contains(clusterURL, "0.0.0.0"):
+			clusterURL = strings.Replace(clusterURL, "0.0.0.0", "127.0.0.1", 1)
 		default:
 			Fail(fmt.Sprintf("cannot derive an alias for cluster URL %q", clusterURL))
 		}


### PR DESCRIPTION
## 📝 What this does
Replaces the hub service account's `*:*` ClusterRole with an audited least-privilege rule set, and makes every environment consume the same manifest. The hub registers the control-plane cluster as a managed cluster using this SA's token, so this role is the exact permission boundary the API server operates under.

Supersedes #180 (same work, rebased onto `main` now that #179 has merged, plus the ClusterInfo fix below). Close #180 in favour of this one.

## 🔀 Changes
- Replaced the wildcard ClusterRole in the install manifest with scoped rules covering exactly what the hub does: Stackdome CRs, cert-manager issuer setup, CNPG/barman backup dependencies, and core namespaces, secrets, pod logs, and metrics.
- Left out everything the audit proved the hub never does: `pods/exec` and `portforward` (agent-provisioned user grants), events, leases (leadership is DB-based), workload kinds (the agent's job), and `patch`.
- Unified all environments on the manifest: `mage dev:setup` (and therefore `hack/run_local.sh`) now applies `install/manifests/rbac.yaml` instead of its own inline wildcard role.
- Mirrored the rules in the integration-test bootstrap and made it update the role in place so rule changes apply to reused clusters.
- Added read-only `core.stackdome.io/clusterinfoes` — the ClusterInfo controller landed in #189, after the original audit was written. Without `list`/`watch` its informer never syncs, so the per-cluster supervisor fails cache sync in a restart loop and no CR status reaches the DB.

## 🔁 Re-audit against current `main`
Re-swept every Kubernetes call in `main` against the rule set. `clusterinfoes` was the only gap. Confirmed still accurate: no `Patch`/`Apply`/`DeleteAllOf` anywhere in the hub, no Kubernetes `SecretList`, and `storages`/`nfsservers`/`objectstorages` are untouched because the `stackstorage` controller is fully commented out.

## 🧪 How to test
- [ ] Run the integration suite — it provisions the SA with these rules; the full run passes with zero Forbidden errors
- [ ] Run `mage dev:setup` and confirm the dev cluster's role matches the manifest (`kubectl get clusterrole stackdome-api-server-role -o yaml`)
- [ ] Deploy a stack with a postgres addon and delete the addon — CR deletion was the one verb the initial audit missed, caught by e2e
- [ ] Check API-server logs for `is forbidden` after exercising builds, logs, metrics, and volume flows

> Note: `log.SetLogger` is never called in the integration test env, so controller-runtime swallows reflector errors — RBAC denials surface only as cache-sync timeouts, not as `is forbidden` lines. Worth wiring up separately.
