### PR TITLE
Feature: integrate cluster-agent port-readiness failures into release events

### DIFF
--- a/cmd/installer/helm.go
+++ b/cmd/installer/helm.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	chartRepo      = "oci://quay.io/stackdome/charts/stackdome-agent"
-	chartVersion   = "0.6.7-alpha"
+	chartVersion   = "0.6.10-alpha"
 	chartRelease   = "stackdome-agent"
 	chartNamespace = "stackdome-control-plane"
 )

--- a/config/openapi/stackdome_api.yaml
+++ b/config/openapi/stackdome_api.yaml
@@ -5738,6 +5738,7 @@ components:
             - image_pull_failed
             - create_container_error
             - exit_error
+            - port_not_listening
         reason:
           type: string
         message:
@@ -5759,6 +5760,7 @@ components:
             - image_pull_failed
             - create_container_error
             - exit_error
+            - port_not_listening
         reason:
           type: string
         message:
@@ -5777,6 +5779,7 @@ components:
           enum:
             - runtime_crash
             - build_failure
+            - readiness_failure
         container:
           $ref: '#/components/schemas/ContainerFailureDetail'
         init_container:

--- a/frontend/src/api/types/openapi.d.ts
+++ b/frontend/src/api/types/openapi.d.ts
@@ -8316,7 +8316,7 @@ export interface components {
         };
         ContainerFailureDetail: {
             /** @enum {string} */
-            failure_type?: "crash_loop" | "out_of_memory" | "image_pull_failed" | "create_container_error" | "exit_error";
+            failure_type?: "crash_loop" | "out_of_memory" | "image_pull_failed" | "create_container_error" | "exit_error" | "port_not_listening";
             reason?: string;
             message?: string;
             /** Format: int32 */
@@ -8326,7 +8326,7 @@ export interface components {
         };
         BuildFailureDetail: {
             /** @enum {string} */
-            failure_type?: "crash_loop" | "out_of_memory" | "image_pull_failed" | "create_container_error" | "exit_error";
+            failure_type?: "crash_loop" | "out_of_memory" | "image_pull_failed" | "create_container_error" | "exit_error" | "port_not_listening";
             reason?: string;
             message?: string;
             /** Format: int32 */
@@ -8336,7 +8336,7 @@ export interface components {
         };
         StackResourceFailure: {
             /** @enum {string} */
-            type?: "runtime_crash" | "build_failure";
+            type?: "runtime_crash" | "build_failure" | "readiness_failure";
             container?: components["schemas"]["ContainerFailureDetail"];
             init_container?: components["schemas"]["ContainerFailureDetail"];
             build?: components["schemas"]["BuildFailureDetail"];

--- a/frontend/src/api/zod-schemas.ts
+++ b/frontend/src/api/zod-schemas.ts
@@ -795,6 +795,7 @@ const BuildFailureDetail = z
       "image_pull_failed",
       "create_container_error",
       "exit_error",
+      "port_not_listening",
     ]),
     reason: z.string(),
     message: z.string(),
@@ -979,6 +980,7 @@ const ContainerFailureDetail = z
       "image_pull_failed",
       "create_container_error",
       "exit_error",
+      "port_not_listening",
     ]),
     reason: z.string(),
     message: z.string(),
@@ -989,7 +991,7 @@ const ContainerFailureDetail = z
   .passthrough();
 const StackResourceFailure = z
   .object({
-    type: z.enum(["runtime_crash", "build_failure"]),
+    type: z.enum(["runtime_crash", "build_failure", "readiness_failure"]),
     container: ContainerFailureDetail,
     init_container: ContainerFailureDetail,
     build: BuildFailureDetail,

--- a/frontend/src/components/branded/status-variant.ts
+++ b/frontend/src/components/branded/status-variant.ts
@@ -260,12 +260,14 @@ export function statusVariant(domain: StatusDomain, state?: string | null): Stat
         case "crashloopbackoff":
         case "unhealthy":
         case "runtime_crash":
+        case "readiness_failure":
         case "build_failure":
         case "crash_loop":
         case "out_of_memory":
         case "image_pull_failed":
         case "create_container_error":
         case "exit_error":
+        case "port_not_listening":
           return "error";
         case "superseded":
         case "cancelled":

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/derive.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/derive.ts
@@ -110,6 +110,7 @@ export type ResourceFailureTypeValue = NonNullable<StackResourceFailure["type"]>
 export const ResourceFailureType = {
   Build: "build_failure",
   Runtime: "runtime_crash",
+  Readiness: "readiness_failure",
 } as const satisfies Record<string, ResourceFailureTypeValue>;
 
 export interface FailingResource {
@@ -121,6 +122,8 @@ export interface FailingResource {
   exitCode?: number;
   restartCount?: number;
   failureType?: string;
+  /** Resource state is terminal (Failed), not a mid-rollout diagnosis. */
+  terminal?: boolean;
 }
 
 export interface RecoveredResource {
@@ -135,6 +138,7 @@ const FAILURE_TYPE_LABELS: Record<string, string> = {
   image_pull_failed: "Image pull failed",
   create_container_error: "Container create error",
   exit_error: "Exit error",
+  port_not_listening: "Port not listening",
 };
 
 export function humanizeFailureType(failureType?: string): string {
@@ -142,11 +146,16 @@ export function humanizeFailureType(failureType?: string): string {
   return FAILURE_TYPE_LABELS[failureType] ?? failureType;
 }
 
-/** Pick the active detail block from a last_failure (build vs container vs init). */
+/** Pick the active detail block from a last_failure (build vs container vs init).
+ *  A readiness failure never crashed, so its restart count is dropped here. */
 function failureDetail(f: StackResourceFailure) {
   if (f.type === ResourceFailureType.Build) return { detail: f.build, stage: "build" as const };
-  if (f.init_container) return { detail: f.init_container, stage: "init" as const };
-  return { detail: f.container, stage: "runtime" as const };
+  const stage = f.init_container ? ("init" as const) : ("runtime" as const);
+  const detail = f.init_container ?? f.container;
+  if (detail && f.type === ResourceFailureType.Readiness) {
+    return { detail: { ...detail, restart_count: undefined }, stage };
+  }
+  return { detail, stage };
 }
 
 /** Live per-resource statuses come from the release's live_status (present only while the
@@ -157,9 +166,9 @@ export function deriveFailingResources(_release: StackRelease, liveStatus?: Rele
   const out: FailingResource[] = [];
   for (const [name, r] of Object.entries(resources)) {
     const f = r.last_failure;
-    const state = r.state ?? "";
+    const variant = statusVariant("resource", r.state ?? "");
     // Only surface as ACTIVE failure when the resource is not currently healthy.
-    if (!f || isHealthyState(state)) continue;
+    if (!f || variant === "ready") continue;
     const { detail, stage } = failureDetail(f);
     out.push({
       name,
@@ -170,6 +179,7 @@ export function deriveFailingResources(_release: StackRelease, liveStatus?: Rele
       exitCode: detail?.exit_code,
       restartCount: detail?.restart_count,
       failureType: detail?.failure_type,
+      terminal: variant === "error",
     });
   }
   return out;
@@ -243,6 +253,13 @@ function hasBuildResources(release: StackRelease): boolean {
   return releaseGitSha(release) !== undefined;
 }
 
+/** A crash always condemns the deploy; a port-readiness diagnosis only does once the
+ *  resource itself went terminal — mid-rollout it is the normal bind-in-progress state. */
+function isDeployFailure(f: FailingResource): boolean {
+  if (f.type === ResourceFailureType.Runtime) return true;
+  return f.type === ResourceFailureType.Readiness && !!f.terminal;
+}
+
 /**
  * Build→Deploy→Ready tracker state. `failing` MUST be the live unhealthy set from
  * deriveFailingResources(release, liveStatus) — recovered resources excluded, so any
@@ -252,7 +269,7 @@ function hasBuildResources(release: StackRelease): boolean {
  */
 export function deriveStages(release: StackRelease, failing: FailingResource[], _liveStatus?: ReleaseLiveStatus): Stages {
   const buildFailed = failing.some((f) => f.type === ResourceFailureType.Build);
-  const runtimeFailed = failing.some((f) => f.type === ResourceFailureType.Runtime);
+  const deployFailed = failing.some(isDeployFailure);
   const hasBuild = hasBuildResources(release);
   const state = release.state;
 
@@ -270,7 +287,7 @@ export function deriveStages(release: StackRelease, failing: FailingResource[], 
   if (state === ReleaseState.InProgress) {
     return {
       build: hasBuild ? "done" : "skipped",
-      deploy: runtimeFailed ? "failed" : "active",
+      deploy: deployFailed ? "failed" : "active",
       ready: "todo",
     };
   }
@@ -279,7 +296,7 @@ export function deriveStages(release: StackRelease, failing: FailingResource[], 
     // (render+apply succeeded, workload deployed). Pre-cluster failures store none.
     const reachedCluster = Object.keys(release.outcome?.resources ?? {}).length > 0;
     // Reached cluster but never Ready (timeout/runtime crash) → failure on Ready.
-    if (runtimeFailed || reachedCluster) {
+    if (deployFailed || reachedCluster) {
       return { build: hasBuild ? "done" : "skipped", deploy: "done", ready: "failed" };
     }
     // Pre-cluster failure (render/apply/secret): nothing deployed. Lands on Build if
@@ -296,10 +313,13 @@ export function deriveStages(release: StackRelease, failing: FailingResource[], 
 export function deriveReleaseTitle(release: StackRelease, failing: FailingResource[], stages: Stages): string {
   const state = release.state ?? "";
   const build = failing.find((f) => f.type === ResourceFailureType.Build);
-  const crash = failing.find((f) => f.type === ResourceFailureType.Runtime);
+  const crash = failing.find(isDeployFailure);
   if (build) return `Build failed: ${build.name}`;
   // A terminal Failed crash reads as "Deploy failed"; an in-flight one names the resource.
-  if (crash && state !== ReleaseState.Failed) return `Runtime crash: ${crash.name}`;
+  if (crash && state !== ReleaseState.Failed) {
+    const label = crash.type === ResourceFailureType.Runtime ? "Runtime crash" : humanizeFailureType(crash.failureType);
+    return `${label}: ${crash.name}`;
+  }
   switch (state) {
     case ReleaseState.Pending: return stages.build === "active" ? "Build queued" : "Deploying";
     case ReleaseState.InProgress: return "Deploying";

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/derive.test.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/derive.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { deriveFailingResources, deriveRecovered, humanizeFailureType, causeLabel, formatDuration, formatReleaseTime } from "../derive";
+import { deriveFailingResources, deriveRecovered, humanizeFailureType, causeLabel, formatDuration, formatReleaseTime, ResourceFailureType } from "../derive";
 import { deriveStages, deriveReleaseTitle, releaseGitSha, phaseTone, toneTextClass, toneDotClass, stateTone, toneFromVariant } from "../derive";
 import { deriveHeaderHealth, latestDeployFailed, stackSummariesStale, stripUnpinnedGitRevisions } from "../derive";
 import type { FailingResource, Stack, StackResource } from "../derive";
@@ -11,6 +11,13 @@ function release(partial: Partial<StackRelease>): StackRelease {
 
 function liveStatusWith(resources: Record<string, Record<string, unknown>>): ReleaseLiveStatus {
   return { resources } as unknown as ReleaseLiveStatus;
+}
+
+function readinessLiveStatus(state: string): ReleaseLiveStatus {
+  return liveStatusWith({
+    web: { state, last_failure: {
+      type: ResourceFailureType.Readiness, container: { failure_type: "port_not_listening", reason: "PortNotListening" } } },
+  });
 }
 
 function stackWithReleases(current?: Partial<ReleaseSummary>, latest?: Partial<ReleaseSummary>): Stack {
@@ -45,6 +52,18 @@ describe("deriveFailingResources", () => {
     expect(deriveFailingResources(release({}), liveStatus)[0]).toMatchObject({ name: "migrate", stage: "init", reason: "InitFailed", exitCode: 2 });
   });
 
+  it("maps a readiness failure without a restart count", () => {
+    const liveStatus = liveStatusWith({
+      web: { state: "Pending", last_failure: {
+        type: ResourceFailureType.Readiness, container: { failure_type: "port_not_listening", reason: "PortNotListening", message: "readiness check failed: nothing listening on port 8080", restart_count: 0 } } },
+    });
+    const out = deriveFailingResources(release({}), liveStatus);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ name: "web", type: ResourceFailureType.Readiness, reason: "PortNotListening", failureType: "port_not_listening" });
+    expect(out[0].restartCount).toBeUndefined();
+    expect(out[0].exitCode).toBeUndefined();
+  });
+
   it("returns nothing without a live status (not live or active)", () => {
     expect(deriveFailingResources(release({}))).toEqual([]);
   });
@@ -59,6 +78,14 @@ describe("deriveRecovered", () => {
     expect(deriveRecovered(release({}), liveStatus)).toEqual([{ name: "tooljet", reason: "CrashLoopBackOff", restartCount: 5 }]);
   });
 
+  it("drops the restart count for a recovered readiness failure", () => {
+    const liveStatus = liveStatusWith({
+      web: { state: "Ready", last_failure: {
+        type: ResourceFailureType.Readiness, container: { failure_type: "port_not_listening", reason: "PortNotListening", restart_count: 0 } } },
+    });
+    expect(deriveRecovered(release({}), liveStatus)).toEqual([{ name: "web", reason: "PortNotListening", restartCount: undefined }]);
+  });
+
   it("does not flag a failing resource as recovered", () => {
     const liveStatus = liveStatusWith({
       tooljet: { state: "CrashLoopBackOff", last_failure: { type: "runtime_crash", container: { reason: "x" } } },
@@ -71,6 +98,9 @@ describe("humanizeFailureType", () => {
   it("maps known types", () => {
     expect(humanizeFailureType("out_of_memory")).toBe("Out of memory");
     expect(humanizeFailureType("crash_loop")).toBe("Crash loop");
+  });
+  it("labels a port_not_listening detail", () => {
+    expect(humanizeFailureType("port_not_listening")).toBe("Port not listening");
   });
   it("falls back to the raw value", () => {
     expect(humanizeFailureType("weird_thing")).toBe("weird_thing");
@@ -175,6 +205,18 @@ describe("deriveStages", () => {
       .toEqual({ build: "done", deploy: "failed", ready: "todo" });
   });
 
+  it("deploy failed when a condemned readiness failure occurs", () => {
+    const rel = release({ state: "InProgress", pins: imagePins });
+    const failing = deriveFailingResources(rel, readinessLiveStatus("Failed"));
+    expect(deriveStages(rel, failing)).toEqual({ build: "done", deploy: "failed", ready: "todo" });
+  });
+
+  it("deploy still active for a provisional readiness failure mid-rollout", () => {
+    const rel = release({ state: "InProgress", pins: imagePins });
+    const failing = deriveFailingResources(rel, readinessLiveStatus("Pending"));
+    expect(deriveStages(rel, failing)).toEqual({ build: "done", deploy: "active", ready: "todo" });
+  });
+
   it("terminal Failed runtime crash maps to Deploy done / Ready ✕", () => {
     const failing = [{ name: "api", type: "runtime_crash" as const, stage: "runtime" as const, reason: "CrashLoopBackOff" }];
     expect(deriveStages(release({ state: "Failed", pins: imagePins }), failing))
@@ -223,6 +265,13 @@ describe("deriveReleaseTitle", () => {
   it("names the failing resource for build / runtime crashes", () => {
     expect(deriveReleaseTitle(release({ state: "InProgress" }), [buildFail], stages)).toBe("Build failed: api");
     expect(deriveReleaseTitle(release({ state: "InProgress" }), [crash], stages)).toBe("Runtime crash: tooljet");
+  });
+  it("names the port failure for a condemned readiness failure, but not a provisional one", () => {
+    const rel = release({ state: "InProgress" });
+    const condemned = deriveFailingResources(rel, readinessLiveStatus("Failed"));
+    const provisional = deriveFailingResources(rel, readinessLiveStatus("Pending"));
+    expect(deriveReleaseTitle(rel, condemned, stages)).toBe("Port not listening: web");
+    expect(deriveReleaseTitle(rel, provisional, stages)).toBe("Deploying");
   });
   it("a terminal crash reads as Deploy failed", () => {
     expect(deriveReleaseTitle(release({ state: "Failed" }), [crash], stages)).toBe("Deploy failed");

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.23.1
 	sigs.k8s.io/kind v0.29.0
 	sigs.k8s.io/yaml v1.6.0
-	stackdome.io/cluster-agent v0.6.7-alpha
+	stackdome.io/cluster-agent v0.6.10-alpha
 )
 
 require (
@@ -207,4 +207,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
 
-replace stackdome.io/cluster-agent => github.com/Stackdome/cluster-agent v0.6.7-alpha
+replace stackdome.io/cluster-agent => github.com/Stackdome/cluster-agent v0.6.10-alpha

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Stackdome/cluster-agent v0.6.7-alpha h1:/E3ittFQGnqDElLQnQrTlBdkxuvj1ivGjcTB2DQxD34=
-github.com/Stackdome/cluster-agent v0.6.7-alpha/go.mod h1:1o76givNdNw9Tgj29ZbuPqNvNKbY2HqFkVF6yLxyq9M=
+github.com/Stackdome/cluster-agent v0.6.10-alpha h1:kOZW4D1Cu2PzoRHheBkwnYdDMS4SSQZR+psoXP04Ujk=
+github.com/Stackdome/cluster-agent v0.6.10-alpha/go.mod h1:1o76givNdNw9Tgj29ZbuPqNvNKbY2HqFkVF6yLxyq9M=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/magefile.go
+++ b/magefile.go
@@ -102,7 +102,7 @@ const (
 	PnpmVersion      = "v10.33.2"
 
 	// Stackdome agent Helm chart
-	DefaultStackdomeChartVersion = "0.6.7-alpha"
+	DefaultStackdomeChartVersion = "0.6.10-alpha"
 	StackdomeChartRepo           = "oci://quay.io/stackdome/charts/stackdome-agent"
 	StackdomeChartReleaseName    = "stackdome-agent"
 	StackdomeChartNamespace      = "stackdome-control-plane"

--- a/pkg/api/openapi/api/openapi.yaml
+++ b/pkg/api/openapi/api/openapi.yaml
@@ -11111,6 +11111,7 @@ components:
           - image_pull_failed
           - create_container_error
           - exit_error
+          - port_not_listening
           type: string
         reason:
           type: string
@@ -11138,6 +11139,7 @@ components:
           - image_pull_failed
           - create_container_error
           - exit_error
+          - port_not_listening
           type: string
         reason:
           type: string
@@ -11176,6 +11178,7 @@ components:
           enum:
           - runtime_crash
           - build_failure
+          - readiness_failure
           type: string
         container:
           $ref: '#/components/schemas/ContainerFailureDetail'

--- a/pkg/controllers/controllers_suite_test.go
+++ b/pkg/controllers/controllers_suite_test.go
@@ -1,0 +1,13 @@
+package controllers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controllers Suite")
+}

--- a/pkg/controllers/failure.go
+++ b/pkg/controllers/failure.go
@@ -5,18 +5,42 @@ import (
 	corev1alpha1 "stackdome.io/cluster-agent/api/core/v1alpha1"
 )
 
+// Termination reasons written by the kubelet, plus ReasonPortNotListening which
+// the cluster agent writes when a declared port is proven closed. Neither
+// exports these strings.
+const (
+	ReasonCrashLoopBackOff     = "CrashLoopBackOff"
+	ReasonOOMKilled            = "OOMKilled"
+	ReasonImagePullBackOff     = "ImagePullBackOff"
+	ReasonErrImagePull         = "ErrImagePull"
+	ReasonCreateContainerError = "CreateContainerError"
+	ReasonPortNotListening     = "PortNotListening"
+)
+
+// Container-detail failure types exposed by the API.
+const (
+	FailureTypeCrashLoop            = "crash_loop"
+	FailureTypeOutOfMemory          = "out_of_memory"
+	FailureTypeImagePullFailed      = "image_pull_failed"
+	FailureTypeCreateContainerError = "create_container_error"
+	FailureTypeExitError            = "exit_error"
+	FailureTypePortNotListening     = "port_not_listening"
+)
+
 func MapFailureType(reason string) string {
 	switch reason {
-	case "CrashLoopBackOff":
-		return "crash_loop"
-	case "OOMKilled":
-		return "out_of_memory"
-	case "ImagePullBackOff", "ErrImagePull":
-		return "image_pull_failed"
-	case "CreateContainerError":
-		return "create_container_error"
+	case ReasonCrashLoopBackOff:
+		return FailureTypeCrashLoop
+	case ReasonOOMKilled:
+		return FailureTypeOutOfMemory
+	case ReasonImagePullBackOff, ReasonErrImagePull:
+		return FailureTypeImagePullFailed
+	case ReasonCreateContainerError:
+		return FailureTypeCreateContainerError
+	case ReasonPortNotListening:
+		return FailureTypePortNotListening
 	default:
-		return "exit_error"
+		return FailureTypeExitError
 	}
 }
 
@@ -24,7 +48,7 @@ func MapLastFailureDetails(resourceName string, details []corev1alpha1.LastFailu
 	if len(details) == 0 {
 		return nil
 	}
-	failure := &models.StackResourceFailure{Type: models.FailureTypeRuntimeCrash}
+	failure := &models.StackResourceFailure{Type: failureTypeForDetails(details)}
 	initName := resourceName + "-init"
 	for _, d := range details {
 		fd := mapContainerFailureDetail(d)
@@ -36,6 +60,18 @@ func MapLastFailureDetails(resourceName string, details []corev1alpha1.LastFailu
 		}
 	}
 	return failure
+}
+
+// failureTypeForDetails picks the server-side failure type from the agent's
+// per-detail classification. An empty Type means runtime_crash: older agents do
+// not set the field.
+func failureTypeForDetails(details []corev1alpha1.LastFailureDetail) models.StackResourceFailureType {
+	for _, d := range details {
+		if d.Type == corev1alpha1.FailureTypeReadinessFailure {
+			return models.FailureTypeReadinessFailure
+		}
+	}
+	return models.FailureTypeRuntimeCrash
 }
 
 func MapBuildFailureDetail(d *corev1alpha1.LastFailureDetail) *models.BuildFailureDetail {

--- a/pkg/controllers/failure_test.go
+++ b/pkg/controllers/failure_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/Stackdome/stackdome/pkg/controllers"
 	"github.com/Stackdome/stackdome/pkg/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	corev1alpha1 "stackdome.io/cluster-agent/api/core/v1alpha1"
 )
@@ -14,14 +16,15 @@ func TestMapFailureType(t *testing.T) {
 		reason   string
 		expected string
 	}{
-		{"CrashLoopBackOff", "crash_loop"},
-		{"OOMKilled", "out_of_memory"},
-		{"ImagePullBackOff", "image_pull_failed"},
-		{"ErrImagePull", "image_pull_failed"},
-		{"CreateContainerError", "create_container_error"},
-		{"Error", "exit_error"},
-		{"", "exit_error"},
-		{"SomethingUnknown", "exit_error"},
+		{controllers.ReasonCrashLoopBackOff, controllers.FailureTypeCrashLoop},
+		{controllers.ReasonOOMKilled, controllers.FailureTypeOutOfMemory},
+		{controllers.ReasonImagePullBackOff, controllers.FailureTypeImagePullFailed},
+		{controllers.ReasonErrImagePull, controllers.FailureTypeImagePullFailed},
+		{controllers.ReasonCreateContainerError, controllers.FailureTypeCreateContainerError},
+		{controllers.ReasonPortNotListening, controllers.FailureTypePortNotListening},
+		{"Error", controllers.FailureTypeExitError},
+		{"", controllers.FailureTypeExitError},
+		{"SomethingUnknown", controllers.FailureTypeExitError},
 	}
 	for _, tc := range cases {
 		t.Run(tc.reason, func(t *testing.T) {
@@ -45,7 +48,7 @@ func TestMapLastFailureDetails_mainContainer(t *testing.T) {
 		{
 			ContainerName:           "web",
 			RestartCount:            3,
-			LastTerminationReason:   "CrashLoopBackOff",
+			LastTerminationReason:   controllers.ReasonCrashLoopBackOff,
 			LastTerminationMessage:  "back-off restarting",
 			LastTerminationExitCode: ptr.To(int32(1)),
 		},
@@ -60,8 +63,8 @@ func TestMapLastFailureDetails_mainContainer(t *testing.T) {
 	if got.Container == nil {
 		t.Fatal("expected Container to be set")
 	}
-	if got.Container.FailureType != "crash_loop" {
-		t.Errorf("Container.FailureType = %q, want crash_loop", got.Container.FailureType)
+	if got.Container.FailureType != controllers.FailureTypeCrashLoop {
+		t.Errorf("Container.FailureType = %q, want %q", got.Container.FailureType, controllers.FailureTypeCrashLoop)
 	}
 	if got.Container.RestartCount != 3 {
 		t.Errorf("Container.RestartCount = %d, want 3", got.Container.RestartCount)
@@ -87,8 +90,8 @@ func TestMapLastFailureDetails_initContainer(t *testing.T) {
 	if got.InitContainer == nil {
 		t.Fatal("expected InitContainer to be set")
 	}
-	if got.InitContainer.FailureType != "exit_error" {
-		t.Errorf("InitContainer.FailureType = %q, want exit_error", got.InitContainer.FailureType)
+	if got.InitContainer.FailureType != controllers.FailureTypeExitError {
+		t.Errorf("InitContainer.FailureType = %q, want %q", got.InitContainer.FailureType, controllers.FailureTypeExitError)
 	}
 	if got.Container != nil {
 		t.Errorf("expected Container to be nil")
@@ -114,8 +117,8 @@ func TestMapBuildFailureDetail(t *testing.T) {
 	if got == nil {
 		t.Fatal("expected non-nil result")
 	}
-	if got.FailureType != "exit_error" {
-		t.Errorf("FailureType = %q, want exit_error", got.FailureType)
+	if got.FailureType != controllers.FailureTypeExitError {
+		t.Errorf("FailureType = %q, want %q", got.FailureType, controllers.FailureTypeExitError)
 	}
 	if got.Message != "COPY failed: file not found" {
 		t.Errorf("Message = %q", got.Message)
@@ -124,3 +127,44 @@ func TestMapBuildFailureDetail(t *testing.T) {
 		t.Errorf("ExitCode = %v, want 1", got.ExitCode)
 	}
 }
+
+var _ = Describe("MapLastFailureDetails", func() {
+	const resourceName = "web"
+
+	It("types a readiness failure from the agent's detail type", func() {
+		failure := controllers.MapLastFailureDetails(resourceName, []corev1alpha1.LastFailureDetail{{
+			Type:                   corev1alpha1.FailureTypeReadinessFailure,
+			ContainerName:          resourceName,
+			LastTerminationReason:  controllers.ReasonPortNotListening,
+			LastTerminationMessage: "readiness check failed: nothing listening on port 8080",
+		}})
+
+		Expect(failure.Type).To(Equal(models.FailureTypeReadinessFailure))
+		Expect(failure.Container).NotTo(BeNil())
+		Expect(failure.Container.FailureType).To(Equal(controllers.FailureTypePortNotListening))
+		Expect(failure.Container.Reason).To(Equal(controllers.ReasonPortNotListening))
+		Expect(failure.Container.Message).To(ContainSubstring("nothing listening on port 8080"))
+		Expect(failure.Container.ExitCode).To(BeNil())
+		Expect(failure.Container.RestartCount).To(BeZero())
+	})
+
+	It("treats an empty detail type as a runtime crash, for older agents", func() {
+		failure := controllers.MapLastFailureDetails(resourceName, []corev1alpha1.LastFailureDetail{{
+			ContainerName:         resourceName,
+			LastTerminationReason: controllers.ReasonCrashLoopBackOff,
+			RestartCount:          5,
+		}})
+
+		Expect(failure.Type).To(Equal(models.FailureTypeRuntimeCrash))
+		Expect(failure.Container.FailureType).To(Equal(controllers.FailureTypeCrashLoop))
+	})
+
+	It("types a mixed slice as a readiness failure", func() {
+		failure := controllers.MapLastFailureDetails(resourceName, []corev1alpha1.LastFailureDetail{
+			{Type: corev1alpha1.FailureTypeRuntimeCrash, ContainerName: resourceName + "-init"},
+			{Type: corev1alpha1.FailureTypeReadinessFailure, ContainerName: resourceName},
+		})
+
+		Expect(failure.Type).To(Equal(models.FailureTypeReadinessFailure))
+	})
+})

--- a/pkg/controllers/stackresource/stack_resource_controller.go
+++ b/pkg/controllers/stackresource/stack_resource_controller.go
@@ -202,7 +202,8 @@ func convergedForGeneration(cr *corev1alpha1.StackResource) bool {
 // when only the previous revision is still serving (Phase=Degraded). Ready
 // therefore additionally requires converged, and the not-converged path keeps
 // the Converged condition's detail so a stuck rollout is diagnosable from the
-// timeline.
+// timeline — or the agent's readiness diagnosis when it has one, since the
+// condition only ever says "not ready yet".
 func resourceEvent(conditions []models.Condition, failure *models.StackResourceFailure, converged bool) (eventType models.ReleaseEventType, reason, message string, emit bool) {
 	if cond := models.FindCondition(conditions, string(corev1alpha1.StackResourceStalled)); cond != nil && cond.Status == string(models.ConditionTrue) {
 		if cond.Reason == stalledReasonBuildFailed {
@@ -228,6 +229,9 @@ func resourceEvent(conditions []models.Condition, failure *models.StackResourceF
 	if convergedCond != nil && !converged {
 		if convergedCond.Status == string(models.ConditionFalse) {
 			reason, message = convergedCond.Reason, convergedCond.Message
+		}
+		if failure != nil && failure.Type == models.FailureTypeReadinessFailure && failure.Container != nil {
+			reason, message = failure.Container.Reason, failure.Container.Message
 		}
 		if availableTrue {
 			if message == "" {

--- a/pkg/controllers/stackresource/stack_resource_controller_test.go
+++ b/pkg/controllers/stackresource/stack_resource_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/Stackdome/stackdome/pkg/controllers"
 	apperrors "github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/mocks"
@@ -32,7 +33,7 @@ var _ = Describe("mapClusterStatusToServerStatus", func() {
 				{
 					ContainerName:           "web",
 					RestartCount:            5,
-					LastTerminationReason:   "CrashLoopBackOff",
+					LastTerminationReason:   controllers.ReasonCrashLoopBackOff,
 					LastTerminationMessage:  "back-off restarting",
 					LastTerminationExitCode: ptr.To(int32(1)),
 				},
@@ -44,7 +45,7 @@ var _ = Describe("mapClusterStatusToServerStatus", func() {
 		Expect(got.LastFailure).NotTo(BeNil())
 		Expect(got.LastFailure.Type).To(Equal(models.FailureTypeRuntimeCrash))
 		Expect(got.LastFailure.Container).NotTo(BeNil())
-		Expect(got.LastFailure.Container.FailureType).To(Equal("crash_loop"))
+		Expect(got.LastFailure.Container.FailureType).To(Equal(controllers.FailureTypeCrashLoop))
 		Expect(got.LastFailure.Container.RestartCount).To(Equal(int32(5)))
 		Expect(got.LastFailure.InitContainer).To(BeNil())
 	})
@@ -69,7 +70,7 @@ var _ = Describe("mapClusterStatusToServerStatus", func() {
 
 		Expect(got.LastFailure).NotTo(BeNil())
 		Expect(got.LastFailure.InitContainer).NotTo(BeNil())
-		Expect(got.LastFailure.InitContainer.FailureType).To(Equal("exit_error"))
+		Expect(got.LastFailure.InitContainer.FailureType).To(Equal(controllers.FailureTypeExitError))
 		Expect(got.LastFailure.Container).To(BeNil())
 	})
 
@@ -132,7 +133,7 @@ var _ = Describe("computeStatusRewrite", func() {
 				{
 					ContainerName:           "web",
 					RestartCount:            3,
-					LastTerminationReason:   "CrashLoopBackOff",
+					LastTerminationReason:   controllers.ReasonCrashLoopBackOff,
 					LastTerminationExitCode: ptr.To(int32(1)),
 				},
 			},
@@ -204,8 +205,16 @@ var _ = Describe("resourceEvent", func() {
 	runtimeCrash := &models.StackResourceFailure{
 		Type: models.FailureTypeRuntimeCrash,
 		Container: &models.ContainerFailureDetail{
-			Reason:  "CrashLoopBackOff",
+			Reason:  controllers.ReasonCrashLoopBackOff,
 			Message: "back-off restarting failed container",
+		},
+	}
+	portNotListening := &models.StackResourceFailure{
+		Type: models.FailureTypeReadinessFailure,
+		Container: &models.ContainerFailureDetail{
+			FailureType: controllers.FailureTypePortNotListening,
+			Reason:      controllers.ReasonPortNotListening,
+			Message:     "readiness check failed: nothing listening on port 8080",
 		},
 	}
 
@@ -266,7 +275,7 @@ var _ = Describe("resourceEvent", func() {
 			},
 			failure:     runtimeCrash,
 			wantType:    models.ReleaseEventTypeResourceFailed,
-			wantReason:  "CrashLoopBackOff",
+			wantReason:  controllers.ReasonCrashLoopBackOff,
 			wantMessage: "back-off restarting failed container",
 			wantEmit:    true,
 		}),
@@ -320,6 +329,49 @@ var _ = Describe("resourceEvent", func() {
 			wantType:    models.ReleaseEventTypeResourceDeploying,
 			wantReason:  "",
 			wantMessage: "previous revision still serving",
+			wantEmit:    true,
+		}),
+		Entry("a condemned port failure records failed with the agent's diagnosis", resourceEventCase{
+			conditions: []models.Condition{
+				cond(string(corev1alpha1.StackResourceStatusAvailable), string(models.ConditionTrue), "ServingButStalled", "workload serving; terminal failure: readiness check failed: nothing listening on port 8080"),
+				cond(string(corev1alpha1.StackResourceStalled), string(models.ConditionTrue), controllers.ReasonPortNotListening, "readiness check failed: nothing listening on port 8080"),
+				cond(string(corev1alpha1.StackResourceConverged), string(models.ConditionFalse), controllers.ReasonPortNotListening, "readiness check failed: nothing listening on port 8080"),
+			},
+			failure:     portNotListening,
+			wantType:    models.ReleaseEventTypeResourceFailed,
+			wantReason:  controllers.ReasonPortNotListening,
+			wantMessage: "readiness check failed: nothing listening on port 8080",
+			wantEmit:    true,
+		}),
+		Entry("a provisional port diagnosis mid-rollout records deploying, not a failure", resourceEventCase{
+			conditions: []models.Condition{
+				cond(string(corev1alpha1.StackResourceStatusAvailable), string(models.ConditionFalse), "StackResourceDeploymentNotReady", "deployment is not yet available"),
+				cond(string(corev1alpha1.StackResourceConverged), string(models.ConditionFalse), "StackResourceDeploymentNotReady", "deployment is not yet available"),
+			},
+			failure:     portNotListening,
+			wantType:    models.ReleaseEventTypeResourceDeploying,
+			wantReason:  controllers.ReasonPortNotListening,
+			wantMessage: "readiness check failed: nothing listening on port 8080",
+			wantEmit:    true,
+		}),
+		Entry("a crash outranks a stale port reason on the converged condition", resourceEventCase{
+			conditions: []models.Condition{
+				cond(string(corev1alpha1.StackResourceConverged), string(models.ConditionFalse), controllers.ReasonPortNotListening, "readiness check failed: nothing listening on port 8080"),
+			},
+			failure:     runtimeCrash,
+			wantType:    models.ReleaseEventTypeResourceFailed,
+			wantReason:  controllers.ReasonCrashLoopBackOff,
+			wantMessage: "back-off restarting failed container",
+			wantEmit:    true,
+		}),
+		Entry("a readiness failure without a container detail keeps the condition's text", resourceEventCase{
+			conditions: []models.Condition{
+				cond(string(corev1alpha1.StackResourceConverged), string(models.ConditionFalse), "StackResourceDeploymentNotReady", "deployment is not yet available"),
+			},
+			failure:     &models.StackResourceFailure{Type: models.FailureTypeReadinessFailure},
+			wantType:    models.ReleaseEventTypeResourceDeploying,
+			wantReason:  "StackResourceDeploymentNotReady",
+			wantMessage: "deployment is not yet available",
 			wantEmit:    true,
 		}),
 		Entry("no conditions emits nothing", resourceEventCase{
@@ -404,7 +456,7 @@ func failedStackResourceCR(hash string, conditions []metav1.Condition) *corev1al
 				{
 					ContainerName:           "web",
 					RestartCount:            3,
-					LastTerminationReason:   "CrashLoopBackOff",
+					LastTerminationReason:   controllers.ReasonCrashLoopBackOff,
 					LastTerminationMessage:  "back-off restarting failed container",
 					LastTerminationExitCode: ptr.To(int32(1)),
 				},
@@ -499,7 +551,7 @@ var _ = Describe("Reconcile", func() {
 		svc.EXPECT().UpdateStatus(gomock.Any(), "sr-1", gomock.Any()).Return(nil)
 		checker.EXPECT().InternalGetActiveByStackID(gomock.Any(), "stack-1").Return(release, nil)
 		recorder.EXPECT().
-			RecordResourceEvent(gomock.Any(), release, "web", models.ReleaseEventTypeResourceFailed, "CrashLoopBackOff", "back-off restarting failed container").
+			RecordResourceEvent(gomock.Any(), release, "web", models.ReleaseEventTypeResourceFailed, controllers.ReasonCrashLoopBackOff, "back-off restarting failed container").
 			Return(nil)
 
 		_, err := r.Reconcile(context.Background(), reconcileRequest())

--- a/pkg/models/stack_resource.go
+++ b/pkg/models/stack_resource.go
@@ -144,8 +144,9 @@ type Ingress struct {
 type StackResourceFailureType string
 
 const (
-	FailureTypeRuntimeCrash StackResourceFailureType = "runtime_crash"
-	FailureTypeBuildFailure StackResourceFailureType = "build_failure"
+	FailureTypeRuntimeCrash     StackResourceFailureType = "runtime_crash"
+	FailureTypeBuildFailure     StackResourceFailureType = "build_failure"
+	FailureTypeReadinessFailure StackResourceFailureType = "readiness_failure"
 )
 
 type ContainerFailureDetail struct {

--- a/pkg/services/release_event_recorder.go
+++ b/pkg/services/release_event_recorder.go
@@ -271,7 +271,7 @@ func (r *releaseEventRecorder) RecordResourceEvent(
 		ResourceName: resourceName,
 		Type:         eventType,
 		Message:      text,
-		DedupeKey:    fmt.Sprintf("resource:%s:%s", resourceName, eventType),
+		DedupeKey:    fmt.Sprintf("resource:%s:%s:%s", resourceName, eventType, reason),
 		Metadata:     metadata,
 	})
 	return serr

--- a/pkg/services/release_event_recorder_test.go
+++ b/pkg/services/release_event_recorder_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/Stackdome/stackdome/pkg/controllers"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/mocks"
 	"github.com/Stackdome/stackdome/pkg/models"
@@ -192,6 +193,18 @@ var _ = Describe("ReleaseEventRecorder", func() {
 			})
 
 			Expect(rec.RecordResourceEvent(context.Background(), newTestRelease(), resourceName, models.ReleaseEventTypeResourceReady, "", "")).To(BeNil())
+		})
+
+		It("gives each distinct reason its own dedupe key so a later diagnosis is not swallowed", func() {
+			expectInsert(func(ev *models.ReleaseEvent) {
+				Expect(ev.DedupeKey).To(Equal("resource:api:resource_deploying:StackResourceDeploymentNotReady"))
+			})
+			Expect(rec.RecordResourceEvent(context.Background(), newTestRelease(), resourceName, models.ReleaseEventTypeResourceDeploying, "StackResourceDeploymentNotReady", "deployment is not yet available")).To(BeNil())
+
+			expectInsert(func(ev *models.ReleaseEvent) {
+				Expect(ev.DedupeKey).To(Equal("resource:api:resource_deploying:PortNotListening"))
+			})
+			Expect(rec.RecordResourceEvent(context.Background(), newTestRelease(), resourceName, models.ReleaseEventTypeResourceDeploying, controllers.ReasonPortNotListening, "readiness check failed: nothing listening on port 8080")).To(BeNil())
 		})
 
 		It("rejects a non-resource event type", func() {

--- a/pkg/testutil/deps.go
+++ b/pkg/testutil/deps.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Stackdome agent Helm chart (bundles cluster-agent + all dependencies)
-	DefaultChartVersion = "0.6.7-alpha"
+	DefaultChartVersion = "0.6.10-alpha"
 	ChartRepo           = "oci://quay.io/stackdome/charts/stackdome-agent"
 	ChartReleaseName    = "stackdome-agent"
 	ChartNamespace      = "stackdome-control-plane"

--- a/test/int/shared/fixtures.go
+++ b/test/int/shared/fixtures.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Stackdome/stackdome/pkg/api/openapi"
 	"github.com/Stackdome/stackdome/pkg/models"
@@ -9,6 +10,22 @@ import (
 
 // Shared test image used across all stack fixtures
 const TestImage = "nginx:1.25-alpine"
+
+// ServeDeclaredPorts makes TestImage listen on every port the resource declares.
+// The cluster-agent synthesizes a TCP readiness probe on the primary declared
+// port, so a resource declaring a port stock nginx does not serve never becomes
+// Ready and its stack never converges.
+func ServeDeclaredPorts(r *openapi.StackResource) {
+	var b strings.Builder
+	for _, p := range r.GetPorts() {
+		fmt.Fprintf(&b, "echo 'server{listen %d;}' > /etc/nginx/conf.d/listen-%d.conf; ", p.GetNumber(), p.GetNumber())
+	}
+	b.WriteString("exec nginx -g 'daemon off;'")
+
+	exec := r.GetExecutionConfig()
+	exec.SetCommand([]string{"sh", "-c", b.String()})
+	r.SetExecutionConfig(exec)
+}
 
 // InitContainer fixture values
 const (
@@ -376,6 +393,7 @@ func CreateMultiResourceStack(name string) *openapi.Stack {
 		}(),
 	})
 	backend.SetExecutionConfig(*backendExec)
+	ServeDeclaredPorts(backend)
 
 	frontend := openapi.NewStackResource(MultiResourceFrontendName)
 	frontendImageSource := openapi.SourceSpec{Image: openapi.NewImageSource(TestImage)}
@@ -408,6 +426,7 @@ func CreateStackWithDependencies(name string) *openapi.Stack {
 	resourceA.SetPorts([]openapi.Port{
 		*openapi.NewPort("postgres", 5432, false),
 	})
+	ServeDeclaredPorts(resourceA)
 
 	resourceB := openapi.NewStackResource("app")
 	imageBSource := openapi.SourceSpec{Image: openapi.NewImageSource("nginx:1.25-alpine")}
@@ -416,6 +435,7 @@ func CreateStackWithDependencies(name string) *openapi.Stack {
 		*openapi.NewPort("http", 8080, false),
 	})
 	resourceB.SetDependsOn([]string{"database"})
+	ServeDeclaredPorts(resourceB)
 
 	spec := openapi.NewStackSpec()
 	spec.SetStackResources([]openapi.StackResource{*resourceA, *resourceB})
@@ -449,6 +469,7 @@ func CreateStackWithEnvAndPorts(name string) *openapi.Stack {
 		}(),
 	})
 	resource.SetExecutionConfig(*exec)
+	ServeDeclaredPorts(resource)
 
 	spec := openapi.NewStackSpec()
 	spec.SetStackResources([]openapi.StackResource{*resource})
@@ -479,6 +500,7 @@ func CreateStackWithPostgresAddon(name string, addonID string, database string) 
 	resource.SetPorts([]openapi.Port{
 		*openapi.NewPort("http", 8080, false),
 	})
+	ServeDeclaredPorts(resource)
 
 	spec := openapi.NewStackSpec()
 	spec.SetStackResources([]openapi.StackResource{*resource})
@@ -495,6 +517,7 @@ func CreateStackWithPostgresAddonSuperuser(name string, addonID string) *openapi
 	resource.SetPorts([]openapi.Port{
 		*openapi.NewPort("http", 8080, false),
 	})
+	ServeDeclaredPorts(resource)
 
 	spec := openapi.NewStackSpec()
 	spec.SetStackResources([]openapi.StackResource{*resource})
@@ -549,6 +572,7 @@ func CreateFullStack(name string, addonID string, database string, secretID stri
 		*openapi.NewPort("http", int32(FullStackAPIPort), false),
 	})
 	api.SetDependsOn([]string{FullStackWorkerName})
+	ServeDeclaredPorts(api)
 
 	worker := openapi.NewStackResource(FullStackWorkerName)
 	workerImageSource := openapi.SourceSpec{Image: openapi.NewImageSource(TestImage)}
@@ -743,6 +767,7 @@ func ResourceWithPort(name string, port int32) openapi.StackResource {
 	r := openapi.NewStackResource(name)
 	r.SetSource(openapi.SourceSpec{Image: openapi.NewImageSource(TestImage)})
 	r.SetPorts([]openapi.Port{*openapi.NewPort("http", port, false)})
+	ServeDeclaredPorts(r)
 	return *r
 }
 

--- a/test/int/stack_dual_flow_test.go
+++ b/test/int/stack_dual_flow_test.go
@@ -133,6 +133,7 @@ var _ = Describe("Stack dual-flow (thin vs fat)", func() {
 			func() openapi.EnvVar { v := openapi.NewEnvVar("EXTRA"); v.SetValue("value"); return *v }(),
 		})
 		updated.SetExecutionConfig(*exec)
+		shared.ServeDeclaredPorts(updated)
 		shared.UpdateStackResourceH(client, orgID, projectName, thin.GetId(), shared.MultiResourceBackendName, updated)
 
 		By("Verifying both resource nodes are still present")


### PR DESCRIPTION
## What

Bumps the cluster agent to `v0.6.10-alpha` and teaches the hub to read the port-readiness failures it now reports, instead of mislabelling them as runtime crashes.

The agent TCP-dials every declared port. Kubernetes' own readiness probe only guards **one** port, so an app declaring three and listening on one used to look perfectly healthy while two thirds of its traffic hit a dead socket.

## The problem

`MapLastFailureDetails` hardcoded every failure as `runtime_crash` and ignored the per-detail `Type` the agent now sets. Two things broke:

- **The UI lied.** `MapFailureType("PortNotListening")` fell through to `"exit_error"`, so the user saw a red crash card with zero restarts and no exit code — and the frontend tried to fetch a crash-log snapshot for a container that never died.
- **The timeline lied.** Being typed `runtime_crash` meant `runtimeFailureDetail` matched, so every slow-to-bind deploy got a spurious red failure.

## Two situations, one detail

The agent writes the *identical* detail from two states that mean opposite things:

| | condemned | provisional |
|---|---|---|
| when | serving workload, secondary port refused past a 3-min grace window | workload not serving at all |
| verdict | Failed | NotReady |
| `Stalled` | **True**, `PortNotListening` | False |
| `Phase` | Failed | Pending |

**Condemned needs no new hub code.** Agent PR #55 routes it through a Failed verdict, which `deriveSummaryStatus` turns into `Stalled=True` — and `resourceEvent`'s first branch already emits `resource_failed` from that. A branch keyed on `Converged` would be unreachable. Covered by tests only.

**Provisional is the wrong-primary-port case.** The probe never passes, so the agent never condemns it and the detail is its only diagnosis. Two changes surface it:

- `resourceEvent` prefers the readiness detail's text — the `Converged` condition carries `StackResourceDeploymentNotReady` as both reason *and* message.
- the resource dedupe key takes the `reason`. Events are unique on `(release_id, dedupe_key)` and duplicate inserts are silent no-ops, so the generic first message burned the only `resource_deploying` slot and the port diagnosis was dropped.

## Notes for review

- **Dedupe-key blast radius.** This changes the key for *every* resource event. Every reason reaching the recorder is a compile-time literal except kubelet termination reasons, which are a fixed vocabulary and frozen per-rollout by the agent's `captureFailureDetailsOnce`. No timestamps, counts, or pod names in any reason — all dynamic data lives in messages, which are not part of the key.
- **`Available=True` on a condemned resource is deliberate**, reason `ServingButStalled`. The primary port really is serving. Don't key off it.
- Correcting the failure type broke `deriveStages` / `deriveReleaseTitle`, which keyed off `runtime_crash`; a condemned resource would have shown a deploy spinner beside a "Port not listening" card. They now gate on whether the resource state is itself terminal, so a slow-binding rollout stays blue.

## Rollout

- **CRDs do not upgrade with Helm.** Registered clusters need `status.portCheck` and `lastFailureDetails[].type` applied by hand, or the agent silently cannot persist them and the hub sees nothing.
- **Agents must actually be upgraded.** Old agents never set `Type`; the empty-means-`runtime_crash` rule handles them, but the feature is absent — and pre-#55 agents never set `Stalled=True` for `PortNotListening`, so condemnation stays invisible until a cluster is on v0.6.10-alpha.
- **Traefik error pages** ship in the same agent release (Service on 8082, `stackdome-errors` middleware). Clusters without Traefik CRDs need `errorPages.enabled=false`.

## Out of scope

- **Failing the release early.** A condemned resource is terminal but the hub still waits out the full deploy timeout. Tracked in `Stackdome/cluster-agent#53` alongside the same missing fail-fast for build failures.
- **A port-path integration test.** It would have to sit through the agent's 3-minute grace window, which is not tunable from the hub. The agent's own suite covers the lifecycle.

## Testing

`mage test:unit`, `make lint`, and 1461 frontend tests green.

⚠️ **`mage test:integration` has not been run.** The chart pin moved, so integration would now install the #55 agent — that is the largest untested surface here. No live wrong-port deploy has been verified end to end either.