### PR TITLE
Feature: auto-detect datastore images as stateful workloads

### DIFF
--- a/pkg/services/stack_resource_service.go
+++ b/pkg/services/stack_resource_service.go
@@ -204,6 +204,7 @@ func (s *stackResourceService) populateRegistryUrlForResource(ctx context.Contex
 }
 
 func (s *stackResourceService) InternalCreateWithTx(ctx context.Context, stack *models.Stack, resource *models.StackResource) (*models.StackResource, *errors.ServiceError) {
+	applyStatefulWorkloadDefault(resource)
 	if err := s.prepareResource(ctx, stack, resource); err != nil {
 		return nil, err
 	}

--- a/pkg/services/stack_resource_service_test.go
+++ b/pkg/services/stack_resource_service_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/mocks"
 	"github.com/Stackdome/stackdome/pkg/models"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -165,3 +167,63 @@ func TestStackResourceService_Restart(t *testing.T) {
 		assert.Equal(t, "error: resource not found", err.Error())
 	})
 }
+
+var _ = ginkgo.Describe("stackResourceService workload type defaulting", func() {
+	var (
+		ctrl              *gomock.Controller
+		mockResourceStore *mocks.MockStackResourceStore
+		svc               *stackResourceService
+		ctx               context.Context
+		stack             *models.Stack
+	)
+
+	datastoreSpec := func() *models.StackResource {
+		return &models.StackResource{
+			Name:         "db",
+			WorkloadType: models.WorkloadTypeService,
+			ImageConfig:  &models.ImageConfigSpec{Image: "postgres:16"},
+		}
+	}
+
+	ginkgo.BeforeEach(func() {
+		ctrl = gomock.NewController(ginkgo.GinkgoT())
+		mockResourceStore = mocks.NewMockStackResourceStore(ctrl)
+		svc = &stackResourceService{stackResourceStore: mockResourceStore}
+		ctx = context.Background()
+		stack = &models.Stack{ID: "stack-1", UserID: "user-1", Namespace: "ns-1"}
+	})
+
+	ginkgo.AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	ginkgo.It("promotes a datastore image to StatefulService on create", func() {
+		var persisted *models.StackResource
+		mockResourceStore.EXPECT().
+			CreateWithTx(ctx, gomock.Any(), stack).
+			DoAndReturn(func(_ context.Context, resource *models.StackResource, _ *models.Stack) (*models.StackResource, *errors.ServiceError) {
+				persisted = resource
+				return resource, nil
+			})
+
+		_, err := svc.InternalCreateWithTx(ctx, stack, datastoreSpec())
+
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(persisted.WorkloadType).To(gomega.Equal(models.WorkloadTypeStatefulService))
+	})
+
+	ginkgo.It("leaves the workload type untouched on update", func() {
+		var persisted *models.StackResource
+		mockResourceStore.EXPECT().
+			UpdateWithTx(ctx, "resource-1", gomock.Any(), stack).
+			DoAndReturn(func(_ context.Context, _ string, resource *models.StackResource, _ *models.Stack) (*models.StackResource, *errors.ServiceError) {
+				persisted = resource
+				return resource, nil
+			})
+
+		_, err := svc.InternalUpdateWithTx(ctx, stack, "resource-1", datastoreSpec())
+
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(persisted.WorkloadType).To(gomega.Equal(models.WorkloadTypeService))
+	})
+})

--- a/pkg/services/stateful_images.go
+++ b/pkg/services/stateful_images.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"strings"
+
+	"github.com/Stackdome/stackdome/pkg/models"
+)
+
+// statefulImages are datastores that corrupt when two instances write the same
+// data directory, so they must never be rolled with surge. Keyed by the final
+// path segment of the image reference, or by the final two segments where the
+// product name sits in the penultimate one.
+var statefulImages = map[string]struct{}{
+	"postgres":             {},
+	"postgresql":           {},
+	"mysql":                {},
+	"mariadb":              {},
+	"percona-server-mysql": {},
+	"mssql":                {},
+	"mssql/server":         {},
+	"mongo":                {},
+	"mongodb":              {},
+	"redis":                {},
+	"valkey":               {},
+	"keydb":                {},
+	"rabbitmq":             {},
+	"kafka":                {},
+	"zookeeper":            {},
+	"nats":                 {},
+	"elasticsearch":        {},
+	"opensearch":           {},
+	"cassandra":            {},
+	"scylla":               {},
+	"clickhouse":           {},
+	"clickhouse-server":    {},
+	"minio":                {},
+	"etcd":                 {},
+	"influxdb":             {},
+	"neo4j":                {},
+	"couchdb":              {},
+	"couchbase":            {},
+	"prometheus":           {},
+	"grafana":              {},
+	"otel-lgtm":            {},
+	"gitea":                {},
+}
+
+// applyStatefulWorkloadDefault promotes a known datastore image to
+// StatefulService. A Deployment rolls with surge, so the replacement pod mounts
+// the data directory while the old one is still writing it; a StatefulSet
+// terminates before it replaces. Only an unset or Service type is promoted.
+//
+// Deliberately keyed on the image rather than on the presence of a volume:
+// plenty of application workloads keep state on a volume and tolerate an
+// overlapping rollout, and promoting those would trade their zero-downtime
+// deploys for nothing.
+func applyStatefulWorkloadDefault(resource *models.StackResource) {
+	if resource.ImageConfig == nil {
+		return
+	}
+	if resource.WorkloadType != "" && resource.WorkloadType != models.WorkloadTypeService {
+		return
+	}
+	for _, key := range imageNameKeys(resource.ImageConfig.Image) {
+		if _, ok := statefulImages[key]; ok {
+			resource.WorkloadType = models.WorkloadTypeStatefulService
+			return
+		}
+	}
+}
+
+// imageNameKeys reduces an image reference to its final path segment and, when
+// there is one, its final two segments — vendors such as
+// mcr.microsoft.com/mssql/server put the product name in the penultimate
+// segment. The registry host, the tag and the digest are dropped.
+func imageNameKeys(image string) []string {
+	ref := image
+	if idx := strings.Index(ref, "@"); idx >= 0 {
+		ref = ref[:idx]
+	}
+	segments := strings.Split(ref, "/")
+	last := segments[len(segments)-1]
+	if idx := strings.Index(last, ":"); idx >= 0 {
+		last = last[:idx]
+	}
+	last = strings.ToLower(last)
+	if len(segments) < 2 {
+		return []string{last}
+	}
+	return []string{last, strings.ToLower(segments[len(segments)-2]) + "/" + last}
+}

--- a/pkg/services/stateful_images_test.go
+++ b/pkg/services/stateful_images_test.go
@@ -1,0 +1,113 @@
+package services
+
+import (
+	"github.com/Stackdome/stackdome/pkg/models"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("applyStatefulWorkloadDefault", func() {
+	resourceWith := func(image string, workloadType models.WorkloadType) *models.StackResource {
+		return &models.StackResource{
+			ImageConfig:  &models.ImageConfigSpec{Image: image},
+			WorkloadType: workloadType,
+		}
+	}
+
+	ginkgo.DescribeTable("promotes a datastore image",
+		func(image string) {
+			resource := resourceWith(image, models.WorkloadTypeService)
+
+			applyStatefulWorkloadDefault(resource)
+
+			gomega.Expect(resource.WorkloadType).To(gomega.Equal(models.WorkloadTypeStatefulService))
+		},
+		ginkgo.Entry("bare name", "postgres"),
+		ginkgo.Entry("with tag", "postgres:16"),
+		ginkgo.Entry("fully qualified", "docker.io/library/postgres:16"),
+		ginkgo.Entry("with digest", "postgres@sha256:abc123"),
+		ginkgo.Entry("private registry", "ghcr.io/acme/redis:7"),
+		ginkgo.Entry("registry with port", "registry.internal:5000/mysql:8"),
+		ginkgo.Entry("vendor prefixed", "bitnami/postgresql:15"),
+		ginkgo.Entry("mixed case", "Postgres:16"),
+		ginkgo.Entry("product name in the penultimate segment", "mcr.microsoft.com/mssql/server:2022-latest"),
+	)
+
+	// Every datastore offered by the frontend block catalog and template
+	// browser, so the list cannot drift away from what users can actually pick.
+	ginkgo.DescribeTable("promotes everything the frontend offers as a data store",
+		func(image string) {
+			resource := resourceWith(image, models.WorkloadTypeService)
+
+			applyStatefulWorkloadDefault(resource)
+
+			gomega.Expect(resource.WorkloadType).To(gomega.Equal(models.WorkloadTypeStatefulService))
+		},
+		ginkgo.Entry("blocks: Postgres", "postgres:16"),
+		ginkgo.Entry("blocks: Redis", "redis:7"),
+		ginkgo.Entry("blocks: MySQL", "mysql:8"),
+		ginkgo.Entry("blocks: MongoDB", "mongo:7"),
+		ginkgo.Entry("blocks: MariaDB", "mariadb:11.4"),
+		ginkgo.Entry("blocks: MS SQL Server", "mcr.microsoft.com/mssql/server:2022-latest"),
+		ginkgo.Entry("blocks: Elasticsearch", "docker.elastic.co/elasticsearch/elasticsearch:8.15.0"),
+		ginkgo.Entry("blocks: CouchDB", "couchdb:3.3"),
+		ginkgo.Entry("blocks: InfluxDB", "influxdb:2.7"),
+		ginkgo.Entry("blocks: ClickHouse", "clickhouse/clickhouse-server:24.8"),
+		ginkgo.Entry("template: grafana", "grafana/grafana:13.0.2"),
+		ginkgo.Entry("template: prometheus", "prom/prometheus:v3.12.0"),
+		ginkgo.Entry("template: gitea", "gitea/gitea:1.26.4"),
+		ginkgo.Entry("template: immich valkey", "valkey/valkey:9"),
+		ginkgo.Entry("template: immich postgres", "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0"),
+		ginkgo.Entry("template: tooljet otel-lgtm", "grafana/otel-lgtm:0.29.1"),
+	)
+
+	ginkgo.It("promotes when no workload type was chosen", func() {
+		resource := resourceWith("postgres:16", "")
+
+		applyStatefulWorkloadDefault(resource)
+
+		gomega.Expect(resource.WorkloadType).To(gomega.Equal(models.WorkloadTypeStatefulService))
+	})
+
+	ginkgo.DescribeTable("leaves an application image alone",
+		func(image string) {
+			resource := resourceWith(image, models.WorkloadTypeService)
+
+			applyStatefulWorkloadDefault(resource)
+
+			gomega.Expect(resource.WorkloadType).To(gomega.Equal(models.WorkloadTypeService))
+		},
+		ginkgo.Entry("n8n keeps its zero-downtime rollout", "n8nio/n8n:2.27.4"),
+		ginkgo.Entry("metrics scraper is not a datastore", "oliver006/redis-exporter:v1.55"),
+		ginkgo.Entry("suffixed name does not match", "acme/postgres-backup:1.0"),
+		ginkgo.Entry("prefixed name does not match", "acme/my-postgres:1.0"),
+		ginkgo.Entry("postgrest is a stateless API, not postgres", "postgrest/postgrest:v12.2.0"),
+		ginkgo.Entry("a generic penultimate segment does not match", "acme/server:1.0"),
+		ginkgo.Entry("template: tooljet", "tooljet/tooljet:v3.20.189-lts"),
+		ginkgo.Entry("template: immich server", "ghcr.io/immich-app/immich-server:v2.7.5"),
+		ginkgo.Entry("template: openclaw", "ghcr.io/openclaw/openclaw:2026.6.10"),
+		ginkgo.Entry("unrelated image", "nginx:1.27"),
+	)
+
+	ginkgo.It("leaves a git-built resource alone", func() {
+		resource := &models.StackResource{WorkloadType: models.WorkloadTypeService}
+
+		applyStatefulWorkloadDefault(resource)
+
+		gomega.Expect(resource.WorkloadType).To(gomega.Equal(models.WorkloadTypeService))
+	})
+
+	ginkgo.DescribeTable("leaves an explicitly chosen workload type alone",
+		func(workloadType models.WorkloadType) {
+			resource := resourceWith("postgres:16", workloadType)
+
+			applyStatefulWorkloadDefault(resource)
+
+			gomega.Expect(resource.WorkloadType).To(gomega.Equal(workloadType))
+		},
+		ginkgo.Entry("Worker", models.WorkloadTypeWorker),
+		ginkgo.Entry("Job", models.WorkloadTypeJob),
+		ginkgo.Entry("CronJob", models.WorkloadTypeCronJob),
+		ginkgo.Entry("StatefulService", models.WorkloadTypeStatefulService),
+	)
+})


### PR DESCRIPTION
## 📝 What this does

A resource whose image is a known datastore — `postgres`, `mysql`, `redis`, `mongo`, `clickhouse` and friends — is now created as a `StatefulService` instead of a `Service`, so the agent reconciles it into a StatefulSet rather than a Deployment. Users no longer have to know that a database needs a different workload type, and can no longer silently corrupt their data by not knowing.

## 🔀 Changes

- Added `applyStatefulWorkloadDefault`, promoting a known datastore image to `StatefulService`
- Matched on the final path segment of the image, or the final two where the product name sits in the penultimate one (`mcr.microsoft.com/mssql/server`)
- Wired it into `InternalCreateWithTx`, the single path every resource row is created through
- Left `Worker`, `Job`, `CronJob`, an explicitly chosen `StatefulService`, and git-built resources untouched
- Covered every datastore the frontend block catalog and template browser offer, so the list cannot drift from what users can pick

## 🏗️ Why a Deployment is wrong for a datastore

Deployments roll with surge — the agent sets `maxSurge: 25%` and `maxUnavailable: 0` at one replica, so the replacement pod is created before the old one is terminated. Both then reference the same volume:

- **Same node** — RWO is scoped to a node, not a pod, so the volume is bind-mounted twice and two database processes write the same data directory. Silent corruption. This is always the case on single-node k3s.
- **Different node** — the RWO volume fails to attach (`Multi-Attach error for volume ...`), the new pod hangs in `ContainerCreating`, and since `maxUnavailable` is `0` the old pod is never evicted. The rollout deadlocks until the progress deadline.

A StatefulSet terminates a pod before it creates its replacement, so neither happens. This is plain Kubernetes object semantics, so it holds on GKE, EKS, AKS, LKE and k3s alike.

## 🎯 Why the image and not the volume mount

Detecting on "has a volume mount" was tried and rejected. Plenty of application workloads keep state on a volume and tolerate an overlapping rollout perfectly well — the n8n template mounts `/home/node/.n8n` for its config while its actual database is a sibling Postgres. Promoting those would trade their zero-downtime deploys for a terminate-then-start gap on every release, for nothing. The image list separates the two cases correctly: `postgres` is promoted, `n8nio/n8n` is not.

Matching is exact rather than substring, which is what keeps `postgrest/postgrest` and `redis-exporter` out. The trade is upkeep — a private or renamed datastore image (`acme/pg-custom`) is missed and stays a Deployment, which is the behaviour it has today.

## ⚠️ Why creation only

The agent does not delete the old Deployment when a resource's workload type changes — `reconcileWorkload` just dispatches on the new type. Promoting a resource that is already live would leave a Deployment and a StatefulSet running side by side against one volume, which is the exact corruption this change exists to prevent. So only new resources are promoted; existing ones keep their stored type. A new datastore added to an existing stack still routes through `InternalCreateWithTx`, so it is covered.

## 📋 Follow-ups (not in this PR)

- Volumes are mounted as a shared named PVC, not `volumeClaimTemplates`, so `replicas > 1` still gives concurrent writers in either workload type. Needs agent-side work.
- Migrating existing live datastore Deployments onto StatefulSets is blocked on agent-side orphan cleanup.

## 🧪 How to test

- [ ] Deploy the n8n template, then confirm Postgres runs as a StatefulSet and n8n stays a Deployment
- [ ] Redeploy the n8n stack and confirm the n8n pod still rolls without a gap
- [ ] Add a data store from the resource picker and confirm it comes up as a StatefulSet
- [ ] Create a resource with an explicit `Worker` or `Job` type on a `postgres` image and confirm the type is unchanged
- [ ] Update an existing Postgres resource (change an env var) and confirm no second workload object appears