### PR TITLE
Feature: TLS issuance release events, header ingress URLs self-heal

### DIFF
--- a/.github/workflows/deploy-main.yaml
+++ b/.github/workflows/deploy-main.yaml
@@ -52,6 +52,9 @@ jobs:
       - uses: golangci/golangci-lint-action@v8
         with:
           version: v2.12.2
+          # Stale analysis cache corrupts staticcheck's noreturn facts,
+          # producing false SA5011 on `if x == nil { t.Fatal }` patterns.
+          skip-cache: true
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,3 +36,6 @@ jobs:
       - uses: golangci/golangci-lint-action@v8
         with:
           version: v2.12.2
+          # Stale analysis cache corrupts staticcheck's noreturn facts,
+          # producing false SA5011 on `if x == nil { t.Fatal }` patterns.
+          skip-cache: true

--- a/frontend/src/pages/stacks/components/editor/hooks/tests/use-release-anchors.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/hooks/tests/use-release-anchors.test.tsx
@@ -85,4 +85,39 @@ describe("useReleaseAnchors", () => {
     vi.advanceTimersByTime(15000);
     expect(refresh.mock.calls.length).toBe(calls);
   });
+
+  // TLS certs issue after the release converges; ingress URLs arrive late.
+  const detailWithIngress = (ingress: { url: string }[]) => ({
+    ensure: vi.fn(),
+    refresh: vi.fn(),
+    peek: vi.fn(() => ({
+      data: {
+        snapshot: { resources: [{ name: "web", ports: [{ exposed_to_public: true }] }] },
+        live_status: { resources: { web: { public_ingress: ingress } } },
+      },
+    })),
+  }) as never;
+
+  it("keeps polling the converged release while a public port has no ingress URL", () => {
+    const detail = detailWithIngress([]);
+    renderHook(() =>
+      useReleaseAnchors({ stack: stackWith("cur-1", ReleaseState.Released), releases: [], activeRelease: undefined, releaseDetail: detail }),
+    );
+    const refresh = (detail as { refresh: ReturnType<typeof vi.fn> }).refresh;
+    const calls = refresh.mock.calls.length;
+    vi.advanceTimersByTime(5000);
+    expect(refresh.mock.calls.length).toBe(calls + 1);
+    expect(refresh).toHaveBeenLastCalledWith("cur-1");
+  });
+
+  it("stops polling once every public port has an ingress URL", () => {
+    const detail = detailWithIngress([{ url: "https://web.example.com" }]);
+    renderHook(() =>
+      useReleaseAnchors({ stack: stackWith("cur-1", ReleaseState.Released), releases: [], activeRelease: undefined, releaseDetail: detail }),
+    );
+    const refresh = (detail as { refresh: ReturnType<typeof vi.fn> }).refresh;
+    const calls = refresh.mock.calls.length;
+    vi.advanceTimersByTime(15000);
+    expect(refresh.mock.calls.length).toBe(calls);
+  });
 });

--- a/frontend/src/pages/stacks/components/editor/hooks/use-release-anchors.ts
+++ b/frontend/src/pages/stacks/components/editor/hooks/use-release-anchors.ts
@@ -61,5 +61,27 @@ export function useReleaseAnchors({
   }, [statusReleaseId, statusReleaseState, refreshRelease]);
   const statusLiveStatus = releaseDetail.peek(statusReleaseId).data?.live_status;
 
+  // TLS certs finish issuing after the release converges, so ingress URLs land on
+  // the release detail after the terminal refetch. Keep polling the converged
+  // release while a deployed public port still has no ingress URL.
+  // Always terminates: a failed issuance still populates ingress with http URLs.
+  const ingressPending = (() => {
+    if (!convergedReleaseDetail) return false;
+    const live = convergedReleaseDetail.live_status?.resources ?? {};
+    return (convergedReleaseDetail.snapshot?.resources ?? []).some(
+      (r) =>
+        r.name &&
+        (r.ports ?? []).some((p) => p.exposed_to_public) &&
+        !live[r.name]?.public_ingress?.length,
+    );
+  })();
+  useEffect(() => {
+    if (!convergedReleaseId || !ingressPending) return;
+    const t = setInterval(() => {
+      if (document.visibilityState !== "hidden") refreshRelease(convergedReleaseId);
+    }, 5000);
+    return () => clearInterval(t);
+  }, [convergedReleaseId, ingressPending, refreshRelease]);
+
   return { baselineReleaseId, deployedSnapshot, convergedReleaseDetail, statusReleaseId, statusLiveStatus };
 }

--- a/pkg/controllers/stackresource/stack_resource_controller.go
+++ b/pkg/controllers/stackresource/stack_resource_controller.go
@@ -156,7 +156,8 @@ type releaseEvent struct {
 func (w *stackResourceReconciler) recordResourceEvent(ctx context.Context, stackID string, resource *models.StackResource, cr *corev1alpha1.StackResource) {
 	workload := resourceEvent(cr)
 	ports := portsClosedEvent(cr)
-	if workload == nil && ports == nil {
+	tls := tlsEvent(cr)
+	if workload == nil && ports == nil && tls == nil {
 		return
 	}
 
@@ -167,6 +168,7 @@ func (w *stackResourceReconciler) recordResourceEvent(ctx context.Context, stack
 
 	w.recordOnRelease(ctx, release, resource.Name, workload)
 	w.recordOnRelease(ctx, release, resource.Name, ports)
+	w.recordOnRelease(ctx, release, resource.Name, tls)
 }
 
 func (w *stackResourceReconciler) resolveRelease(ctx context.Context, stackID string, cr *corev1alpha1.StackResource) *models.StackRelease {
@@ -225,6 +227,26 @@ func portsClosedEvent(cr *corev1alpha1.StackResource) *releaseEvent {
 		controllers.ReasonPortNotListening,
 		portDialMessage(cr.Status.PortCheck.FailingPortNumbers),
 	}
+}
+
+// tlsEvent maps the current-generation TLSConfigured condition to a TLS event.
+// Pre-0.6.11 agents set True on issuer discovery alone, so True is keyed on the
+// reason. Any other False reason is a terminal issuance failure (the site
+// serves plain HTTP).
+func tlsEvent(cr *corev1alpha1.StackResource) *releaseEvent {
+	cond := currentGenCondition(cr, string(corev1alpha1.StackResourceTLSConfigured))
+	if cond == nil {
+		return nil
+	}
+	switch {
+	case cond.Status == metav1.ConditionTrue && cond.Reason == controllers.ReasonTLSReady:
+		return &releaseEvent{models.ReleaseEventTypeResourceTLSReady, cond.Reason, cond.Message}
+	case cond.Status == metav1.ConditionFalse && cond.Reason == controllers.ReasonCertificateIssuing:
+		return &releaseEvent{models.ReleaseEventTypeResourceTLSIssuing, cond.Reason, cond.Message}
+	case cond.Status == metav1.ConditionFalse:
+		return &releaseEvent{models.ReleaseEventTypeResourceTLSFailed, cond.Reason, cond.Message}
+	}
+	return nil
 }
 
 // resourceEvent maps the agent's summary verdict to one workload event.

--- a/pkg/controllers/stackresource/stack_resource_controller_test.go
+++ b/pkg/controllers/stackresource/stack_resource_controller_test.go
@@ -372,6 +372,67 @@ var _ = Describe("portsClosedEvent", func() {
 	})
 })
 
+var _ = Describe("tlsEvent", func() {
+	DescribeTable("mapping the TLSConfigured condition to a TLS event",
+		func(tc resourceEventCase) {
+			ev := tlsEvent(eventCaseCR(tc))
+			Expect(ev != nil).To(Equal(tc.wantEmit))
+			if !tc.wantEmit {
+				return
+			}
+			Expect(ev.Type).To(Equal(tc.wantType))
+			Expect(ev.Reason).To(Equal(tc.wantReason))
+			Expect(ev.Message).To(Equal(tc.wantMessage))
+		},
+		Entry("an issued certificate emits tls_ready", resourceEventCase{
+			conditions: []metav1.Condition{
+				cond(string(corev1alpha1.StackResourceTLSConfigured), metav1.ConditionTrue, controllers.ReasonTLSReady, "certificate issued"),
+			},
+			wantType:    models.ReleaseEventTypeResourceTLSReady,
+			wantReason:  controllers.ReasonTLSReady,
+			wantMessage: "certificate issued",
+			wantEmit:    true,
+		}),
+		Entry("an in-progress issuance emits tls_issuing", resourceEventCase{
+			conditions: []metav1.Condition{
+				cond(string(corev1alpha1.StackResourceTLSConfigured), metav1.ConditionFalse, controllers.ReasonCertificateIssuing, "waiting for cert-manager"),
+			},
+			wantType:    models.ReleaseEventTypeResourceTLSIssuing,
+			wantReason:  controllers.ReasonCertificateIssuing,
+			wantMessage: "waiting for cert-manager",
+			wantEmit:    true,
+		}),
+		Entry("any other False reason emits tls_failed", resourceEventCase{
+			conditions: []metav1.Condition{
+				cond(string(corev1alpha1.StackResourceTLSConfigured), metav1.ConditionFalse, "CertificateTimedOut", "no certificate after 10m"),
+			},
+			wantType:    models.ReleaseEventTypeResourceTLSFailed,
+			wantReason:  "CertificateTimedOut",
+			wantMessage: "no certificate after 10m",
+			wantEmit:    true,
+		}),
+		// Pre-0.6.11 agents set True on issuer discovery alone.
+		Entry("True without ReasonTLSReady emits nothing", resourceEventCase{
+			conditions: []metav1.Condition{
+				cond(string(corev1alpha1.StackResourceTLSConfigured), metav1.ConditionTrue, "IssuerFound", "issuer resolved"),
+			},
+			wantEmit: false,
+		}),
+		Entry("no TLSConfigured condition emits nothing", resourceEventCase{
+			conditions: []metav1.Condition{},
+			wantEmit:   false,
+		}),
+		Entry("a stale-generation condition emits nothing", resourceEventCase{
+			crGen:   2,
+			condGen: 1,
+			conditions: []metav1.Condition{
+				cond(string(corev1alpha1.StackResourceTLSConfigured), metav1.ConditionTrue, controllers.ReasonTLSReady, "certificate issued"),
+			},
+			wantEmit: false,
+		}),
+	)
+})
+
 func stackResourceTestScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())

--- a/pkg/services/organisation_service.go
+++ b/pkg/services/organisation_service.go
@@ -145,8 +145,19 @@ func (s *organisationService) seedPlatformInfra(ctx context.Context, orgID, orgN
 	return s.seedOrgRegistry(ctx, orgID, orgName, platformCluster.ID)
 }
 
+// slugRepeatsBaseLabel reports whether "<orgSlug>.<baseDomain>" would start
+// with identical sequential labels ("test.test.…") — Let's Encrypt rejects
+// those as recursive on-demand issuance.
+func slugRepeatsBaseLabel(orgSlug, baseDomain string) bool {
+	firstLabel, _, _ := strings.Cut(baseDomain, ".")
+	return firstLabel == orgSlug
+}
+
 func (s *organisationService) seedOrgDomain(ctx context.Context, orgID, orgSlug, baseDomain string) *errors.ServiceError {
 	candidate := fmt.Sprintf("%s.%s", orgSlug, baseDomain)
+	if slugRepeatsBaseLabel(orgSlug, baseDomain) {
+		candidate = fmt.Sprintf("%s-%s.%s", orgSlug, slug.RandomSuffix(), baseDomain)
+	}
 	for attempt := 0; attempt < maxDomainSeedAttempts; attempt++ {
 		_, err := s.organisationDomainService.Create(ctx, &models.OrganisationDomain{
 			OrganisationID: orgID,

--- a/pkg/services/organisation_service_test.go
+++ b/pkg/services/organisation_service_test.go
@@ -217,6 +217,39 @@ var _ = Describe("OrganisationService platform-infra seeding", func() {
 	})
 })
 
+var _ = DescribeTable("slugRepeatsBaseLabel",
+	func(orgSlug, base string, want bool) {
+		Expect(slugRepeatsBaseLabel(orgSlug, base)).To(Equal(want))
+	},
+	Entry("slug equals the base's first label", "test", "test.stackdome.io", true),
+	Entry("slug distinct from every base label", "acme", "apps.example.com", false),
+	Entry("slug matching a deeper base label only", "stackdome", "test.stackdome.io", false),
+)
+
+var _ = Describe("seedOrgDomain", func() {
+	DescribeTable("picks a candidate that avoids identical sequential labels",
+		func(orgSlug, base, wantFirstCandidate string) {
+			ctrl := gomock.NewController(GinkgoT())
+			defer ctrl.Finish()
+			domainSvc := mocks.NewMockOrganisationDomainsService(ctrl)
+			svc := &organisationService{organisationDomainService: domainSvc, logger: logger.NewLogger()}
+			domainSvc.EXPECT().Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, spec *models.OrganisationDomain) (*models.OrganisationDomain, *errors.ServiceError) {
+					Expect(spec.Domain).To(MatchRegexp(wantFirstCandidate))
+					return &models.OrganisationDomain{}, nil
+				})
+
+			Expect(svc.seedOrgDomain(context.Background(), "org-1", orgSlug, base)).To(BeNil())
+		},
+		Entry("a slug distinct from the base stays plain",
+			"acme", "apps.example.com", `^acme\.apps\.example\.com$`),
+		Entry("a slug equal to the base's first label goes straight to the suffixed form",
+			"test", "test.stackdome.io", `^test-[0-9a-f]{6}\.test\.stackdome\.io$`),
+		Entry("a slug matching a deeper base label stays plain",
+			"stackdome", "test.stackdome.io", `^stackdome\.test\.stackdome\.io$`),
+	)
+})
+
 var _ = Describe("orgRegistryName", func() {
 	const (
 		nameOrgID     = "11112222-3333-4444-5555-666677778888"


### PR DESCRIPTION
## 📝 What this does
TLS certificate issuance now shows up on the release timeline, and the header's PUBLIC row fills in on its own once the cert issues — no page refresh. Certs finish issuing after the release converges, so both surfaces previously went stale at exactly the moment users were watching. Also fixes the org-domain shape that made Let's Encrypt reject issuance outright on installs where the org slug repeats the base domain's first label.

## 🔀 Changes
- Mapped the agent's TLSConfigured condition to timeline events: issuing, HTTPS ready, and failed-falling-back-to-HTTP, generation-gated and recorded through the same release-ID gate as other resource events
- Kept polling the converged release while a deployed public port still has no ingress URL, so the header endpoints appear once the cert issues (a failed issuance publishes http URLs, so the poll always terminates)
- Org slugs equal to the base domain's first label now seed a suffixed domain (`test-a1b2c3.test.stackdome.io`) — `test.test.<base>` trips Let's Encrypt's recursive on-demand issuance heuristic and can never get a cert

## 🧪 How to test
- [ ] Deploy a stack with a public TLS port — timeline shows "Issuing TLS certificate", then "HTTPS ready"
- [ ] Keep the editor open through the deploy — the PUBLIC header row appears without refreshing once the cert issues
- [ ] Point a custom domain at a bad issuer — timeline shows the TLS failure with the serving-over-HTTP fallback
- [ ] Create an org named after the base domain's first label — its seeded domain comes out suffixed and TLS issues cleanly

https://claude.ai/code/session_01TpRLszVTJudSd86RreufSC