### PR TITLE
Feature: platform GitHub App mode, installer-managed GitHub credentials

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -14,7 +14,20 @@ GHACCESS_TOKEN=
 # GitHub OAuth login (optional). When CLIENT_ID + CLIENT_SECRET are set, the
 # /api/v1/auth/github routes register and the web UI shows "Continue with GitHub".
 # GITHUB_REDIRECT_URI must equal <frontend-origin>/auth/github/callback and match
-# the GitHub OAuth app's registered Authorization callback URL.
+# the GitHub app's registered callback URL; it is derived from SERVER_EXTERNAL_URL
+# when left empty. A GitHub App's own client id/secret work here too.
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 GITHUB_REDIRECT_URI=
+
+# Externally reachable hub URL; required for GitHub App callbacks and webhooks.
+SERVER_EXTERNAL_URL=
+
+# Platform-wide GitHub App (optional). When all four are set, orgs install this
+# one app instead of creating their own through the manifest flow. Its setup URL
+# on GitHub must be <SERVER_EXTERNAL_URL>/api/v1/git-integrations/github/setup
+# and its webhook URL <SERVER_EXTERNAL_URL>/api/v1/webhooks/github.
+GITHUB_APP_ID=
+GITHUB_APP_SLUG=
+GITHUB_APP_PRIVATE_KEY=
+GITHUB_APP_WEBHOOK_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ pkg/web/dist/*
 
 # Integration test output (Makefile tees here)
 test/int/last-run.log
+.pnpm-store

--- a/cmd/environment/env.go
+++ b/cmd/environment/env.go
@@ -472,6 +472,7 @@ func (e *environmentImpl) loadServices(ctx context.Context) error {
 			BaseURL: e.Config.GitHubAPIBaseURL,
 		}),
 		ExternalURL:       e.Config.ServerExternalURL,
+		PlatformApp:       platformGitHubApp(e.Config.GitHubApp),
 		EncryptionService: encryptionService,
 		Permissions:       e.PermissionService,
 		Logger:            e.Logger,
@@ -714,6 +715,7 @@ func (e *environmentImpl) loadServices(ctx context.Context) error {
 		EncryptionService: encryptionService,
 		PreviewWebhook:    previewWebhookService,
 		Logger:            e.Logger,
+		PlatformApp:       platformGitHubApp(e.Config.GitHubApp),
 	})
 
 	e.Services = Services{
@@ -1009,4 +1011,19 @@ func (e *environmentImpl) Shutdown(ctx context.Context) error {
 
 	e.Logger.Infof("%s environment shutdown completed", e.Name)
 	return nil
+}
+
+// platformGitHubApp converts the GITHUB_APP_* config into app credentials, or
+// nil when the hub runs without a platform-wide app and each org creates its
+// own through the manifest flow.
+func platformGitHubApp(cfg *config.GitHubAppConfig) *githubapp.AppCredentials {
+	if !cfg.Configured() {
+		return nil
+	}
+	return &githubapp.AppCredentials{
+		AppID:         cfg.AppID,
+		Slug:          cfg.Slug,
+		PEM:           cfg.PrivateKey,
+		WebhookSecret: cfg.WebhookSecret,
+	}
 }

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -34,7 +34,14 @@ func usage() {
 	fmt.Println("Usage:")
 	fmt.Println("  stackdome-install install --email you@company.com [--domain stackdome.example.com]")
 	fmt.Println("                            [--image IMAGE] [--chart-version VERSION]")
-	fmt.Println("  stackdome-install upgrade [--image IMAGE] [--chart-version VERSION]")
+	fmt.Println("                            [GitHub flags]")
+	fmt.Println("  stackdome-install upgrade [--image IMAGE] [--chart-version VERSION] [GitHub flags]")
+	fmt.Println()
+	fmt.Println("GitHub flags (all optional, stored in the bootstrap secret and reused by")
+	fmt.Println("later upgrades unless given again):")
+	fmt.Println("  --github-client-id ID --github-client-secret SECRET   'Sign in with GitHub'")
+	fmt.Println("  --github-app-id ID --github-app-slug SLUG             platform GitHub App")
+	fmt.Println("  --github-app-key-file PATH --github-app-webhook-secret SECRET")
 	fmt.Println()
 	fmt.Println("upgrade reuses the email, domain and secrets of the existing install,")
 	fmt.Println("and keeps the deployed image unless --image is given.")
@@ -46,6 +53,7 @@ func runInstall(args []string) {
 	domain := fs.String("domain", "", "Dashboard domain (default: stackdome.<PUBLIC_IP>.nip.io)")
 	image := fs.String("image", defaultAPIServerImage, "API server container image")
 	chartVersion := fs.String("chart-version", defaultChartVersion, "stackdome-agent Helm chart version")
+	github := registerGitHubFlags(fs)
 	_ = fs.Parse(args)
 
 	if *email == "" {
@@ -76,6 +84,9 @@ func runInstall(args []string) {
 		APIServerImage: *image,
 		DBWorkloadType: string(models.WorkloadTypeStatefulService),
 		TLSEnabled:     isTLSDomain(preflight.Domain),
+	}
+	if err := github.applyTo(&vals); err != nil {
+		exitErr("Reading GitHub credentials failed", err)
 	}
 
 	secrets, err := loadOrCreateSecrets(&vals)

--- a/cmd/installer/secrets.go
+++ b/cmd/installer/secrets.go
@@ -4,8 +4,10 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"math/big"
+	"os"
 	"strings"
 
 	"github.com/Stackdome/stackdome/install"
@@ -17,10 +19,69 @@ const (
 )
 
 type BootstrapSecrets struct {
-	DBPassword    string
-	JWTSecret     string
-	EncryptionKey string
-	AdminPassword string
+	DBPassword             string
+	JWTSecret              string
+	EncryptionKey          string
+	AdminPassword          string
+	AdminEmail             string
+	GitHubClientID         string
+	GitHubClientSecret     string
+	GitHubAppID            string
+	GitHubAppSlug          string
+	GitHubAppPrivateKey    string
+	GitHubAppWebhookSecret string
+}
+
+// githubFlags are the GitHub credentials install and upgrade both accept.
+// Empty values keep whatever the bootstrap secret already stores.
+type githubFlags struct {
+	clientID         *string
+	clientSecret     *string
+	appID            *string
+	appSlug          *string
+	appKeyFile       *string
+	appWebhookSecret *string
+}
+
+func registerGitHubFlags(fs *flag.FlagSet) *githubFlags {
+	return &githubFlags{
+		clientID:         fs.String("github-client-id", "", "GitHub client ID for 'Sign in with GitHub'"),
+		clientSecret:     fs.String("github-client-secret", "", "GitHub client secret for 'Sign in with GitHub'"),
+		appID:            fs.String("github-app-id", "", "Platform GitHub App numeric ID"),
+		appSlug:          fs.String("github-app-slug", "", "Platform GitHub App URL slug"),
+		appKeyFile:       fs.String("github-app-key-file", "", "Path to the platform GitHub App private key (PEM)"),
+		appWebhookSecret: fs.String("github-app-webhook-secret", "", "Platform GitHub App webhook secret"),
+	}
+}
+
+func (f *githubFlags) applyTo(vals *install.TemplateValues) error {
+	// The hub enables the platform app only when all four values are set, so a
+	// partial set would silently disable the feature.
+	appFlagsGiven := 0
+	for _, v := range []string{*f.appID, *f.appSlug, *f.appKeyFile, *f.appWebhookSecret} {
+		if v != "" {
+			appFlagsGiven++
+		}
+	}
+	if appFlagsGiven != 0 && appFlagsGiven != 4 {
+		return fmt.Errorf("--github-app-id, --github-app-slug, --github-app-key-file and --github-app-webhook-secret must be given together")
+	}
+
+	vals.GitHubClientID = *f.clientID
+	vals.GitHubClientSecret = *f.clientSecret
+	vals.GitHubAppID = *f.appID
+	vals.GitHubAppSlug = *f.appSlug
+	vals.GitHubAppWebhookSecret = *f.appWebhookSecret
+
+	if *f.appKeyFile == "" {
+		return nil
+	}
+	pem, err := os.ReadFile(*f.appKeyFile)
+	if err != nil {
+		return fmt.Errorf("reading GitHub App private key: %w", err)
+	}
+	vals.GitHubAppPrivateKey = string(pem)
+	return nil
 }
 
 func loadOrCreateSecrets(vals *install.TemplateValues) (*BootstrapSecrets, error) {
@@ -31,6 +92,9 @@ func loadOrCreateSecrets(vals *install.TemplateValues) (*BootstrapSecrets, error
 		vals.JWTSecret = existing.JWTSecret
 		vals.EncryptionKey = existing.EncryptionKey
 		vals.AdminPassword = existing.AdminPassword
+		if err := mergeGitHubConfig(vals, existing); err != nil {
+			return nil, err
+		}
 		return existing, nil
 	}
 
@@ -57,6 +121,49 @@ func loadOrCreateSecrets(vals *install.TemplateValues) (*BootstrapSecrets, error
 	}
 
 	return secrets, nil
+}
+
+// mergeGitHubConfig reconciles the --github-* flags already on vals with what
+// the bootstrap secret holds: flags win, stored values fill the gaps, and the
+// secret is rewritten only when something actually changed. This is what keeps
+// GitHub credentials alive across upgrades, which re-render every manifest.
+func mergeGitHubConfig(vals *install.TemplateValues, existing *BootstrapSecrets) error {
+	fields := []struct{ flag, stored *string }{
+		{&vals.GitHubClientID, &existing.GitHubClientID},
+		{&vals.GitHubClientSecret, &existing.GitHubClientSecret},
+		{&vals.GitHubAppID, &existing.GitHubAppID},
+		{&vals.GitHubAppSlug, &existing.GitHubAppSlug},
+		{&vals.GitHubAppPrivateKey, &existing.GitHubAppPrivateKey},
+		{&vals.GitHubAppWebhookSecret, &existing.GitHubAppWebhookSecret},
+	}
+	changed := false
+	for _, f := range fields {
+		if *f.flag == "" {
+			*f.flag = *f.stored
+		}
+		if *f.flag != *f.stored {
+			*f.stored = *f.flag
+			changed = true
+		}
+	}
+	// The secret is re-rendered whole, so every field it carries must be on
+	// vals — upgrade only knows the email from the secret itself.
+	if vals.AdminEmail == "" {
+		vals.AdminEmail = existing.AdminEmail
+	}
+	if !changed {
+		return nil
+	}
+
+	manifest, err := install.RenderManifest("bootstrap-secret.yaml", *vals)
+	if err != nil {
+		return fmt.Errorf("rendering bootstrap secret: %w", err)
+	}
+	if err := kubectlApply(manifest); err != nil {
+		return fmt.Errorf("updating bootstrap secret: %w", err)
+	}
+	stepLog("GitHub credentials stored")
+	return nil
 }
 
 func readExistingSecrets() (*BootstrapSecrets, error) {
@@ -87,10 +194,18 @@ func readExistingSecrets() (*BootstrapSecrets, error) {
 	}
 
 	s := &BootstrapSecrets{
-		DBPassword:    decode("db-password"),
-		JWTSecret:     decode("jwt-secret"),
-		EncryptionKey: decode("encryption-key"),
-		AdminPassword: decode("admin-password"),
+		DBPassword:         decode("db-password"),
+		JWTSecret:          decode("jwt-secret"),
+		EncryptionKey:      decode("encryption-key"),
+		AdminPassword:      decode("admin-password"),
+		AdminEmail:         decode("admin-email"),
+		GitHubClientID:     decode("github-client-id"),
+		GitHubClientSecret: decode("github-client-secret"),
+
+		GitHubAppID:            decode("github-app-id"),
+		GitHubAppSlug:          decode("github-app-slug"),
+		GitHubAppPrivateKey:    decode("github-app-private-key"),
+		GitHubAppWebhookSecret: decode("github-app-webhook-secret"),
 	}
 
 	if s.DBPassword == "" || s.JWTSecret == "" || s.EncryptionKey == "" || s.AdminPassword == "" {

--- a/cmd/installer/upgrade.go
+++ b/cmd/installer/upgrade.go
@@ -12,6 +12,7 @@ func runUpgrade(args []string) {
 	fs := flag.NewFlagSet("upgrade", flag.ExitOnError)
 	image := fs.String("image", "", "API server container image (default: keep the currently deployed one)")
 	chartVersion := fs.String("chart-version", defaultChartVersion, "stackdome-agent Helm chart version")
+	github := registerGitHubFlags(fs)
 	_ = fs.Parse(args)
 
 	totalPhases = 4
@@ -70,6 +71,13 @@ func runUpgrade(args []string) {
 		JWTSecret:      secrets.JWTSecret,
 		EncryptionKey:  secrets.EncryptionKey,
 		AdminPassword:  secrets.AdminPassword,
+	}
+	if err := github.applyTo(&vals); err != nil {
+		exitErr("Reading GitHub credentials failed", err)
+	}
+
+	if err := mergeGitHubConfig(&vals, secrets); err != nil {
+		exitErr("Storing GitHub credentials failed", err)
 	}
 
 	if err := installStackdomeAgent(*chartVersion); err != nil {

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -179,6 +179,7 @@ func (s apiServer) routes() *mux.Router {
 	// GitHub App manifest callback (browser redirect) and webhook receiver;
 	// both are unauthenticated and validated by state / HMAC respectively.
 	apiV1Router.HandleFunc("/git-integrations/github/manifest/callback", gitIntegrationHandler.GitHubManifestCallback).Methods(http.MethodGet)
+	apiV1Router.HandleFunc("/git-integrations/github/setup", gitIntegrationHandler.GitHubAppSetup).Methods(http.MethodGet)
 	apiV1Router.HandleFunc("/webhooks/github", gitIntegrationHandler.GitHubWebhook).Methods(http.MethodPost)
 
 	authenticationRouter := apiV1Router.PathPrefix("/auth").Subrouter()

--- a/config/application_config.go
+++ b/config/application_config.go
@@ -20,6 +20,8 @@ type ApplicationConfig struct {
 	LogLevel      string             `json:"log_level"`
 	LogFormat     string             `json:"log_format"`
 	GitHubOAuth   *GitHubOAuthConfig `json:"github_oauth"`
+	// GitHubApp is the platform-wide GitHub App; unset means per-org apps.
+	GitHubApp *GitHubAppConfig `json:"github_app"`
 	// ServerExternalURL is the externally reachable base URL of the hub,
 	// required for the GitHub App manifest flow (browser redirects, webhooks).
 	ServerExternalURL string `json:"server_external_url"`
@@ -50,6 +52,7 @@ func (c *ApplicationConfig) LoadEnvVariables() {
 	}
 
 	c.GitHubOAuth.LoadEnvVariables()
+	c.GitHubApp.LoadEnvVariables()
 	c.PlatformCluster.LoadEnvVariables()
 
 	if val, ok := EnvServerExternalURL.Lookup(); ok {
@@ -67,10 +70,12 @@ func (c *ApplicationConfig) LoadEnvVariables() {
 	}
 }
 
-// gitHubOAuthCallbackPath is the route the GitHub OAuth handler is mounted on;
-// it must match the "/github/callback" route under /api/v1/auth in
-// cmd/server/routes.go.
-const gitHubOAuthCallbackPath = "/api/v1/auth/github/callback"
+// gitHubOAuthCallbackPath is the SPA route GitHub sends the browser back to
+// (frontend/src/App.tsx). That page reads code+state and calls the hub's
+// /api/v1/auth/github/callback itself, so the API route is never GitHub's
+// redirect target — sending the browser there would render raw JSON and no
+// session would be established.
+const gitHubOAuthCallbackPath = "/auth/github/callback"
 
 func (c *ApplicationConfig) Validate() error {
 	validateFuncs := []func() error{
@@ -215,6 +220,7 @@ func NewApplicationConfig() *ApplicationConfig {
 		LogLevel:        "info",
 		LogFormat:       "json",
 		GitHubOAuth:     NewGitHubOAuthConfig(),
+		GitHubApp:       &GitHubAppConfig{},
 		PlatformCluster: &ClusterConfig{},
 	}
 }
@@ -231,6 +237,35 @@ type GitHubOAuthConfig struct {
 
 func (c *GitHubOAuthConfig) Enabled() bool {
 	return c.ClientID != "" && c.ClientSecret != ""
+}
+
+// GitHubAppConfig is the platform-wide GitHub App every org installs. Not
+// configured: each org creates its own app through the manifest flow. Login
+// uses the same app's client id/secret via the GITHUB_CLIENT_* vars.
+type GitHubAppConfig struct {
+	AppID         int64  `json:"app_id"`
+	Slug          string `json:"slug"`
+	PrivateKey    string `json:"private_key"`
+	WebhookSecret string `json:"webhook_secret"`
+}
+
+func (c *GitHubAppConfig) Configured() bool {
+	return c.AppID != 0 && c.Slug != "" && c.PrivateKey != "" && c.WebhookSecret != ""
+}
+
+func (c *GitHubAppConfig) LoadEnvVariables() {
+	if val, ok := EnvGitHubAppID.Lookup(); ok {
+		c.AppID = int64(val)
+	}
+	if val, ok := EnvGitHubAppSlug.Lookup(); ok {
+		c.Slug = val
+	}
+	if val, ok := EnvGitHubAppPrivateKey.Lookup(); ok {
+		c.PrivateKey = val
+	}
+	if val, ok := EnvGitHubAppWebhookSecret.Lookup(); ok {
+		c.WebhookSecret = val
+	}
 }
 
 func (c *GitHubOAuthConfig) LoadEnvVariables() {

--- a/config/application_config_test.go
+++ b/config/application_config_test.go
@@ -9,7 +9,7 @@ func TestGitHubRedirectURIDerivedFromExternalURL(t *testing.T) {
 	c := NewApplicationConfig()
 	c.LoadEnvVariables()
 
-	want := "https://hub.example.com/api/v1/auth/github/callback"
+	want := "https://hub.example.com/auth/github/callback"
 	if c.GitHubOAuth.RedirectURI != want {
 		t.Fatalf("expected derived redirect %q, got %q", want, c.GitHubOAuth.RedirectURI)
 	}
@@ -22,7 +22,7 @@ func TestGitHubRedirectURITrimsTrailingSlash(t *testing.T) {
 	c := NewApplicationConfig()
 	c.LoadEnvVariables()
 
-	want := "https://hub.example.com/api/v1/auth/github/callback"
+	want := "https://hub.example.com/auth/github/callback"
 	if c.GitHubOAuth.RedirectURI != want {
 		t.Fatalf("expected no double slash, got %q", c.GitHubOAuth.RedirectURI)
 	}

--- a/config/env_registry.go
+++ b/config/env_registry.go
@@ -12,6 +12,13 @@ var (
 	EnvGitHubClientID     = StringVar("GITHUB_CLIENT_ID", "GitHub OAuth app client ID", nil, false)
 	EnvGitHubClientSecret = StringVar("GITHUB_CLIENT_SECRET", "GitHub OAuth app client secret", nil, false)
 	EnvGitHubRedirectURI  = StringVar("GITHUB_REDIRECT_URI", "GitHub OAuth app redirect URI (optional; derived from SERVER_EXTERNAL_URL when unset)", nil, false)
+	// The GITHUB_APP_* vars configure one platform-wide GitHub App that every
+	// org installs; unset leaves each org creating its own app via the
+	// manifest flow.
+	EnvGitHubAppID            = IntVar("GITHUB_APP_ID", "Platform GitHub App numeric ID", nil, false)
+	EnvGitHubAppSlug          = StringVar("GITHUB_APP_SLUG", "Platform GitHub App URL slug", nil, false)
+	EnvGitHubAppPrivateKey    = StringVar("GITHUB_APP_PRIVATE_KEY", "Platform GitHub App private key (PEM)", nil, false)
+	EnvGitHubAppWebhookSecret = StringVar("GITHUB_APP_WEBHOOK_SECRET", "Platform GitHub App webhook secret", nil, false)
 
 	// Server
 	EnvServerHostname    = StringVar("SERVER_HOSTNAME", "Server hostname/domain", nil, false)

--- a/config/openapi/stackdome_api.yaml
+++ b/config/openapi/stackdome_api.yaml
@@ -673,6 +673,30 @@ paths:
           description: Invalid or expired state
         '500':
           description: Internal server error
+  /api/v1/git-integrations/github/setup:
+    get:
+      summary: Platform GitHub App setup redirect target (unauthenticated, state-validated)
+      parameters:
+        - in: query
+          name: installation_id
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - in: query
+          name: state
+          required: true
+          schema:
+            type: string
+      responses:
+        '302':
+          description: Redirects the browser back to the git integrations page
+        '400':
+          description: Invalid or expired state
+        '404':
+          description: The installation was not found on the platform app
+        '500':
+          description: Internal server error
   /api/v1/webhooks/github:
     post:
       summary: GitHub webhook receiver (unauthenticated, HMAC-verified)
@@ -5386,7 +5410,10 @@ components:
         manifest:
           type: object
           additionalProperties: true
-          description: GitHub App manifest to POST to github_url as the manifest form field
+          description: >-
+            GitHub App manifest to POST to github_url as the manifest form field.
+            Absent when the hub runs a platform-wide GitHub App: github_url is
+            then the app's install page and the browser is redirected to it.
         github_url:
           type: string
         state:

--- a/frontend/src/api/types/openapi.d.ts
+++ b/frontend/src/api/types/openapi.d.ts
@@ -1491,6 +1491,64 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/git-integrations/github/setup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Platform GitHub App setup redirect target (unauthenticated, state-validated) */
+        get: {
+            parameters: {
+                query: {
+                    installation_id: number;
+                    state: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Redirects the browser back to the git integrations page */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Invalid or expired state */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description The installation was not found on the platform app */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Internal server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/webhooks/github": {
         parameters: {
             query?: never;
@@ -8144,7 +8202,7 @@ export interface components {
             value: string;
         };
         GitHubAppManifestFlow: {
-            /** @description GitHub App manifest to POST to github_url as the manifest form field */
+            /** @description GitHub App manifest to POST to github_url as the manifest form field. Absent when the hub runs a platform-wide GitHub App: github_url is then the app's install page and the browser is redirected to it. */
             manifest?: {
                 [key: string]: unknown;
             };

--- a/frontend/src/api/zod-schemas.ts
+++ b/frontend/src/api/zod-schemas.ts
@@ -2094,6 +2094,47 @@ const endpoints = makeApi([
   },
   {
     method: "get",
+    path: "/api/v1/git-integrations/github/setup",
+    alias: "getApiv1gitIntegrationsgithubsetup",
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "installation_id",
+        type: "Query",
+        schema: z.number().int(),
+      },
+      {
+        name: "state",
+        type: "Query",
+        schema: z.string(),
+      },
+    ],
+    response: z.void(),
+    errors: [
+      {
+        status: 302,
+        description: `Redirects the browser back to the git integrations page`,
+        schema: z.void(),
+      },
+      {
+        status: 400,
+        description: `Invalid or expired state`,
+        schema: z.void(),
+      },
+      {
+        status: 404,
+        description: `The installation was not found on the platform app`,
+        schema: z.void(),
+      },
+      {
+        status: 500,
+        description: `Internal server error`,
+        schema: z.void(),
+      },
+    ],
+  },
+  {
+    method: "get",
     path: "/api/v1/invites/:token/info",
     alias: "getApiv1invitesTokeninfo",
     requestFormat: "json",

--- a/frontend/src/hooks/tests/use-github-connect.test.ts
+++ b/frontend/src/hooks/tests/use-github-connect.test.ts
@@ -56,6 +56,26 @@ describe("useGithubConnect", () => {
     expect(createGitHubAppManifest).toHaveBeenCalledWith("org1");
   });
 
+  it("navigates the popup to the install page when there is no manifest", async () => {
+    const popup = { location: { href: "" } } as unknown as Window;
+    openSpy.mockReturnValue(popup);
+    (createGitHubAppManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      github_url: "https://github.com/apps/stackdome-cloud/installations/new?state=s2",
+      state: "s2",
+    });
+
+    const { result } = renderHook(() => useGithubConnect());
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(popup.location.href).toBe(
+      "https://github.com/apps/stackdome-cloud/installations/new?state=s2",
+    );
+    expect(document.querySelectorAll("form")).toHaveLength(0);
+    expect(result.current.state).toBe("waiting");
+  });
+
   it("errors when the popup is blocked", async () => {
     openSpy.mockReturnValue(null);
     const { result } = renderHook(() => useGithubConnect());

--- a/frontend/src/hooks/use-github-connect.ts
+++ b/frontend/src/hooks/use-github-connect.ts
@@ -98,7 +98,12 @@ export function useGithubConnect(): GithubConnect {
     }
     try {
       const flow = await createGitHubAppManifest(orgId);
-      postManifestToPopup(flow.github_url ?? "", flow.manifest);
+      if (flow.manifest) {
+        postManifestToPopup(flow.github_url ?? "", flow.manifest);
+      } else {
+        // Platform-wide app: nothing to create, github_url is the install page.
+        popup.location.href = flow.github_url ?? "";
+      }
       // Usually null here — the integration record appears only after the
       // user confirms app creation in the popup; the poll re-resolves it.
       const list = await listGitIntegrations(orgId);

--- a/install/embed.go
+++ b/install/embed.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bytes"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"text/template"
 )
@@ -21,6 +22,23 @@ type TemplateValues struct {
 	DBWorkloadType string
 	StackUID       string
 	TLSEnabled     bool
+	// GitHub OAuth login credentials; empty leaves login disabled.
+	GitHubClientID     string
+	GitHubClientSecret string
+	// Platform-wide GitHub App; empty leaves each org creating its own.
+	GitHubAppID            string
+	GitHubAppSlug          string
+	GitHubAppPrivateKey    string
+	GitHubAppWebhookSecret string
+}
+
+// manifestFuncs renders a Go string as a quoted YAML scalar — JSON encoding is
+// valid YAML — so multi-line values such as a PEM survive templating.
+var manifestFuncs = template.FuncMap{
+	"yamlStr": func(s string) (string, error) {
+		b, err := json.Marshal(s)
+		return string(b), err
+	},
 }
 
 func RenderManifest(name string, vals TemplateValues) ([]byte, error) {
@@ -30,7 +48,7 @@ func RenderManifest(name string, vals TemplateValues) ([]byte, error) {
 		return nil, fmt.Errorf("reading embedded manifest %s: %w", path, err)
 	}
 
-	tmpl, err := template.New(name).Parse(string(raw))
+	tmpl, err := template.New(name).Funcs(manifestFuncs).Parse(string(raw))
 	if err != nil {
 		return nil, fmt.Errorf("parsing template %s: %w", name, err)
 	}

--- a/install/embed_test.go
+++ b/install/embed_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
 	"github.com/Stackdome/stackdome/install"
 	"github.com/Stackdome/stackdome/pkg/models"
@@ -60,6 +61,68 @@ var _ = Describe("RenderManifest", func() {
 			Expect(string(out)).To(ContainSubstring("image: \"quay.io/stackdome/stackdome:main-abc1234\""))
 			Expect(string(out)).To(ContainSubstring("fqdn: \"stackdome.example.com\""))
 			Expect(string(out)).To(ContainSubstring("tls: true"))
+		})
+
+		It("derives SERVER_EXTERNAL_URL from the domain and TLS mode", func() {
+			out, err := install.RenderManifest("api-server-resource-cr.yaml", install.TemplateValues{
+				Domain:     "stackdome.example.com",
+				TLSEnabled: true,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(out)).To(ContainSubstring("value: \"https://stackdome.example.com\""))
+
+			out, err = install.RenderManifest("api-server-resource-cr.yaml", install.TemplateValues{
+				Domain:     "stackdome.10.0.0.1.nip.io",
+				TLSEnabled: false,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(out)).To(ContainSubstring("value: \"http://stackdome.10.0.0.1.nip.io\""))
+		})
+
+		It("renders the GitHub OAuth credentials only when set", func() {
+			out, err := install.RenderManifest("api-server-resource-cr.yaml", install.TemplateValues{
+				Domain:             "stackdome.example.com",
+				GitHubClientID:     "Iv1.abc",
+				GitHubClientSecret: "shhh",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(out)).To(ContainSubstring("name: GITHUB_CLIENT_ID"))
+			Expect(string(out)).To(ContainSubstring("value: \"Iv1.abc\""))
+			Expect(string(out)).To(ContainSubstring("value: \"shhh\""))
+
+			out, err = install.RenderManifest("api-server-resource-cr.yaml", install.TemplateValues{
+				Domain: "stackdome.example.com",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(out)).NotTo(ContainSubstring("GITHUB_CLIENT_ID"))
+		})
+
+		It("keeps a multi-line private key intact as a YAML scalar", func() {
+			pem := "-----BEGIN RSA PRIVATE KEY-----\nabc\ndef\n-----END RSA PRIVATE KEY-----\n"
+			out, err := install.RenderManifest("api-server-resource-cr.yaml", install.TemplateValues{
+				Domain:              "stackdome.example.com",
+				GitHubAppID:         "4242",
+				GitHubAppSlug:       "stackdome-cloud",
+				GitHubAppPrivateKey: pem,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var parsed struct {
+				Spec struct {
+					EnvironmentVariables []struct {
+						Name  string `yaml:"name"`
+						Value string `yaml:"value"`
+					} `yaml:"environmentVariables"`
+				} `yaml:"spec"`
+			}
+			Expect(yaml.Unmarshal(out, &parsed)).To(Succeed())
+
+			env := map[string]string{}
+			for _, e := range parsed.Spec.EnvironmentVariables {
+				env[e.Name] = e.Value
+			}
+			Expect(env["GITHUB_APP_PRIVATE_KEY"]).To(Equal(pem))
+			Expect(env["GITHUB_APP_ID"]).To(Equal("4242"))
 		})
 
 		It("omits the cluster-issuer annotation without TLS", func() {

--- a/install/manifests/api-server-resource-cr.yaml
+++ b/install/manifests/api-server-resource-cr.yaml
@@ -53,3 +53,21 @@ spec:
       value: "{{.EncryptionKey}}"
     - name: LOG_LEVEL
       value: info
+    - name: SERVER_EXTERNAL_URL
+      value: "{{if .TLSEnabled}}https{{else}}http{{end}}://{{.Domain}}"
+    {{- if .GitHubClientID }}
+    - name: GITHUB_CLIENT_ID
+      value: "{{.GitHubClientID}}"
+    - name: GITHUB_CLIENT_SECRET
+      value: "{{.GitHubClientSecret}}"
+    {{- end }}
+    {{- if .GitHubAppID }}
+    - name: GITHUB_APP_ID
+      value: "{{.GitHubAppID}}"
+    - name: GITHUB_APP_SLUG
+      value: "{{.GitHubAppSlug}}"
+    - name: GITHUB_APP_PRIVATE_KEY
+      value: {{yamlStr .GitHubAppPrivateKey}}
+    - name: GITHUB_APP_WEBHOOK_SECRET
+      value: "{{.GitHubAppWebhookSecret}}"
+    {{- end }}

--- a/install/manifests/bootstrap-secret.yaml
+++ b/install/manifests/bootstrap-secret.yaml
@@ -15,3 +15,9 @@ stringData:
   admin-password: "{{.AdminPassword}}"
   admin-email: "{{.AdminEmail}}"
   domain: "{{.Domain}}"
+  github-client-id: "{{.GitHubClientID}}"
+  github-client-secret: "{{.GitHubClientSecret}}"
+  github-app-id: "{{.GitHubAppID}}"
+  github-app-slug: "{{.GitHubAppSlug}}"
+  github-app-private-key: {{yamlStr .GitHubAppPrivateKey}}
+  github-app-webhook-secret: "{{.GitHubAppWebhookSecret}}"

--- a/pkg/api/openapi/README.md
+++ b/pkg/api/openapi/README.md
@@ -89,6 +89,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**ApiV1AuthRefreshPost**](docs/DefaultApi.md#apiv1authrefreshpost) | **Post** /api/v1/auth/refresh | Refresh JWT token
 *DefaultApi* | [**ApiV1ConfigGet**](docs/DefaultApi.md#apiv1configget) | **Get** /api/v1/config | Get public application configuration
 *DefaultApi* | [**ApiV1GitIntegrationsGithubManifestCallbackGet**](docs/DefaultApi.md#apiv1gitintegrationsgithubmanifestcallbackget) | **Get** /api/v1/git-integrations/github/manifest/callback | GitHub App manifest redirect target (unauthenticated, state-validated)
+*DefaultApi* | [**ApiV1GitIntegrationsGithubSetupGet**](docs/DefaultApi.md#apiv1gitintegrationsgithubsetupget) | **Get** /api/v1/git-integrations/github/setup | Platform GitHub App setup redirect target (unauthenticated, state-validated)
 *DefaultApi* | [**ApiV1InvitesTokenInfoGet**](docs/DefaultApi.md#apiv1invitestokeninfoget) | **Get** /api/v1/invites/{token}/info | Get public invite info (unauthenticated)
 *DefaultApi* | [**ApiV1OrganizationsIdGet**](docs/DefaultApi.md#apiv1organizationsidget) | **Get** /api/v1/organizations/{id} | Get an organization
 *DefaultApi* | [**ApiV1OrganizationsIdPut**](docs/DefaultApi.md#apiv1organizationsidput) | **Put** /api/v1/organizations/{id} | Update an organization

--- a/pkg/api/openapi/api/openapi.yaml
+++ b/pkg/api/openapi/api/openapi.yaml
@@ -812,6 +812,34 @@ paths:
         "500":
           description: Internal server error
       summary: "GitHub App manifest redirect target (unauthenticated, state-validated)"
+  /api/v1/git-integrations/github/setup:
+    get:
+      parameters:
+      - explode: true
+        in: query
+        name: installation_id
+        required: true
+        schema:
+          format: int64
+          type: integer
+        style: form
+      - explode: true
+        in: query
+        name: state
+        required: true
+        schema:
+          type: string
+        style: form
+      responses:
+        "302":
+          description: Redirects the browser back to the git integrations page
+        "400":
+          description: Invalid or expired state
+        "404":
+          description: The installation was not found on the platform app
+        "500":
+          description: Internal server error
+      summary: "Platform GitHub App setup redirect target (unauthenticated, state-validated)"
   /api/v1/webhooks/github:
     post:
       requestBody:
@@ -10454,8 +10482,9 @@ components:
       properties:
         manifest:
           additionalProperties: true
-          description: GitHub App manifest to POST to github_url as the manifest form
-            field
+          description: "GitHub App manifest to POST to github_url as the manifest\
+            \ form field. Absent when the hub runs a platform-wide GitHub App: github_url\
+            \ is then the app's install page and the browser is redirected to it."
           type: object
         github_url:
           type: string

--- a/pkg/api/openapi/api_default.go
+++ b/pkg/api/openapi/api_default.go
@@ -1251,6 +1251,112 @@ func (a *DefaultApiService) ApiV1GitIntegrationsGithubManifestCallbackGetExecute
 	return localVarHTTPResponse, nil
 }
 
+type ApiApiV1GitIntegrationsGithubSetupGetRequest struct {
+	ctx            context.Context
+	ApiService     *DefaultApiService
+	installationId *int64
+	state          *string
+}
+
+func (r ApiApiV1GitIntegrationsGithubSetupGetRequest) InstallationId(installationId int64) ApiApiV1GitIntegrationsGithubSetupGetRequest {
+	r.installationId = &installationId
+	return r
+}
+
+func (r ApiApiV1GitIntegrationsGithubSetupGetRequest) State(state string) ApiApiV1GitIntegrationsGithubSetupGetRequest {
+	r.state = &state
+	return r
+}
+
+func (r ApiApiV1GitIntegrationsGithubSetupGetRequest) Execute() (*http.Response, error) {
+	return r.ApiService.ApiV1GitIntegrationsGithubSetupGetExecute(r)
+}
+
+/*
+ApiV1GitIntegrationsGithubSetupGet Platform GitHub App setup redirect target (unauthenticated, state-validated)
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiApiV1GitIntegrationsGithubSetupGetRequest
+*/
+func (a *DefaultApiService) ApiV1GitIntegrationsGithubSetupGet(ctx context.Context) ApiApiV1GitIntegrationsGithubSetupGetRequest {
+	return ApiApiV1GitIntegrationsGithubSetupGetRequest{
+		ApiService: a,
+		ctx:        ctx,
+	}
+}
+
+// Execute executes the request
+func (a *DefaultApiService) ApiV1GitIntegrationsGithubSetupGetExecute(r ApiApiV1GitIntegrationsGithubSetupGetRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod = http.MethodGet
+		localVarPostBody   interface{}
+		formFiles          []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultApiService.ApiV1GitIntegrationsGithubSetupGet")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/git-integrations/github/setup"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+	if r.installationId == nil {
+		return nil, reportError("installationId is required and must be specified")
+	}
+	if r.state == nil {
+		return nil, reportError("state is required and must be specified")
+	}
+
+	localVarQueryParams.Add("installation_id", parameterToString(*r.installationId, ""))
+	localVarQueryParams.Add("state", parameterToString(*r.state, ""))
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
 type ApiApiV1InvitesTokenInfoGetRequest struct {
 	ctx        context.Context
 	ApiService *DefaultApiService

--- a/pkg/api/openapi/docs/DefaultApi.md
+++ b/pkg/api/openapi/docs/DefaultApi.md
@@ -15,6 +15,7 @@ Method | HTTP request | Description
 [**ApiV1AuthRefreshPost**](DefaultApi.md#ApiV1AuthRefreshPost) | **Post** /api/v1/auth/refresh | Refresh JWT token
 [**ApiV1ConfigGet**](DefaultApi.md#ApiV1ConfigGet) | **Get** /api/v1/config | Get public application configuration
 [**ApiV1GitIntegrationsGithubManifestCallbackGet**](DefaultApi.md#ApiV1GitIntegrationsGithubManifestCallbackGet) | **Get** /api/v1/git-integrations/github/manifest/callback | GitHub App manifest redirect target (unauthenticated, state-validated)
+[**ApiV1GitIntegrationsGithubSetupGet**](DefaultApi.md#ApiV1GitIntegrationsGithubSetupGet) | **Get** /api/v1/git-integrations/github/setup | Platform GitHub App setup redirect target (unauthenticated, state-validated)
 [**ApiV1InvitesTokenInfoGet**](DefaultApi.md#ApiV1InvitesTokenInfoGet) | **Get** /api/v1/invites/{token}/info | Get public invite info (unauthenticated)
 [**ApiV1OrganizationsIdGet**](DefaultApi.md#ApiV1OrganizationsIdGet) | **Get** /api/v1/organizations/{id} | Get an organization
 [**ApiV1OrganizationsIdPut**](DefaultApi.md#ApiV1OrganizationsIdPut) | **Put** /api/v1/organizations/{id} | Update an organization
@@ -811,6 +812,70 @@ Other parameters are passed through a pointer to a apiApiV1GitIntegrationsGithub
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **code** | **string** |  | 
+ **state** | **string** |  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## ApiV1GitIntegrationsGithubSetupGet
+
+> ApiV1GitIntegrationsGithubSetupGet(ctx).InstallationId(installationId).State(state).Execute()
+
+Platform GitHub App setup redirect target (unauthenticated, state-validated)
+
+### Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    openapiclient "./openapi"
+)
+
+func main() {
+    installationId := int64(789) // int64 | 
+    state := "state_example" // string | 
+
+    configuration := openapiclient.NewConfiguration()
+    apiClient := openapiclient.NewAPIClient(configuration)
+    resp, r, err := apiClient.DefaultApi.ApiV1GitIntegrationsGithubSetupGet(context.Background()).InstallationId(installationId).State(state).Execute()
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.ApiV1GitIntegrationsGithubSetupGet``: %v\n", err)
+        fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+    }
+}
+```
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiApiV1GitIntegrationsGithubSetupGetRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **installationId** | **int64** |  | 
  **state** | **string** |  | 
 
 ### Return type

--- a/pkg/api/openapi/docs/GitHubAppManifestFlow.md
+++ b/pkg/api/openapi/docs/GitHubAppManifestFlow.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Manifest** | Pointer to **map[string]interface{}** | GitHub App manifest to POST to github_url as the manifest form field | [optional] 
+**Manifest** | Pointer to **map[string]interface{}** | GitHub App manifest to POST to github_url as the manifest form field. Absent when the hub runs a platform-wide GitHub App: github_url is then the app&#39;s install page and the browser is redirected to it. | [optional] 
 **GithubUrl** | Pointer to **string** |  | [optional] 
 **State** | Pointer to **string** |  | [optional] 
 

--- a/pkg/api/openapi/model_git_hub_app_manifest_flow.go
+++ b/pkg/api/openapi/model_git_hub_app_manifest_flow.go
@@ -16,7 +16,7 @@ import (
 
 // GitHubAppManifestFlow struct for GitHubAppManifestFlow
 type GitHubAppManifestFlow struct {
-	// GitHub App manifest to POST to github_url as the manifest form field
+	// GitHub App manifest to POST to github_url as the manifest form field. Absent when the hub runs a platform-wide GitHub App: github_url is then the app's install page and the browser is redirected to it.
 	Manifest  map[string]interface{} `json:"manifest,omitempty"`
 	GithubUrl *string                `json:"github_url,omitempty"`
 	State     *string                `json:"state,omitempty"`

--- a/pkg/clients/githubapp/client.go
+++ b/pkg/clients/githubapp/client.go
@@ -82,6 +82,8 @@ type Client interface {
 	// ListInstallations lists every installation of the app (app JWT auth),
 	// following pagination.
 	ListInstallations(ctx context.Context, creds *AppCredentials) ([]Installation, error)
+	// GetInstallation fetches one installation of the app by its GitHub id.
+	GetInstallation(ctx context.Context, creds *AppCredentials, installationID int64) (*Installation, error)
 	// MintInstallationToken creates a short-lived installation access token.
 	MintInstallationToken(ctx context.Context, creds *AppCredentials, installationID int64) (*Token, error)
 	// ListInstallationRepos lists one page of repositories the installation
@@ -220,6 +222,24 @@ func (c *client) ListInstallations(ctx context.Context, creds *AppCredentials) (
 		}
 		opts.Page = resp.NextPage
 	}
+}
+
+func (c *client) GetInstallation(ctx context.Context, creds *AppCredentials, installationID int64) (*Installation, error) {
+	gh, err := c.appClient(creds)
+	if err != nil {
+		return nil, err
+	}
+	in, _, err := gh.Apps.GetInstallation(ctx, installationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get installation %d: %w", installationID, err)
+	}
+	return &Installation{
+		ID:                  in.GetID(),
+		AccountLogin:        in.GetAccount().GetLogin(),
+		AccountType:         in.GetAccount().GetType(),
+		RepositorySelection: in.GetRepositorySelection(),
+		Suspended:           !in.GetSuspendedAt().IsZero(),
+	}, nil
 }
 
 func (c *client) MintInstallationToken(ctx context.Context, creds *AppCredentials, installationID int64) (*Token, error) {

--- a/pkg/clients/githubapp/manifest.go
+++ b/pkg/clients/githubapp/manifest.go
@@ -5,6 +5,7 @@ const (
 	PermContents     = "contents"
 	PermMetadata     = "metadata"
 	PermPullRequests = "pull_requests"
+	PermIssues       = "issues"
 	PermLevelRead    = "read"
 	PermLevelWrite   = "write"
 )

--- a/pkg/handlers/git_integration_handler.go
+++ b/pkg/handlers/git_integration_handler.go
@@ -164,6 +164,24 @@ func (h *gitIntegrationHandler) GitHubManifestCallback(w http.ResponseWriter, r 
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
+// GitHubAppSetup is unauthenticated: the browser lands here from GitHub after
+// installing the platform app, carrying the new installation id; the
+// single-use state proves the flow was initiated by an org admin.
+func (h *gitIntegrationHandler) GitHubAppSetup(w http.ResponseWriter, r *http.Request) {
+	installationID, err := strconv.ParseInt(r.URL.Query().Get("installation_id"), 10, 64)
+	if err != nil {
+		handleError(r.Context(), w, errors.MalformedRequest("installation_id must be a number"))
+		return
+	}
+
+	redirectURL, serr := h.gitIntegrationService.HandleGitHubAppSetup(r.Context(), installationID, r.URL.Query().Get("state"))
+	if serr != nil {
+		handleError(r.Context(), w, serr)
+		return
+	}
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
 // GitHubWebhook is unauthenticated at the HTTP layer; deliveries are
 // HMAC-verified against the matched integration's webhook secret.
 func (h *gitIntegrationHandler) GitHubWebhook(w http.ResponseWriter, r *http.Request) {

--- a/pkg/mocks/mock_git_integration_service.go
+++ b/pkg/mocks/mock_git_integration_service.go
@@ -117,6 +117,21 @@ func (mr *MockGitIntegrationServiceMockRecorder) GetRepository(ctx, integrationI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepository", reflect.TypeOf((*MockGitIntegrationService)(nil).GetRepository), ctx, integrationID, owner, repo)
 }
 
+// HandleGitHubAppSetup mocks base method.
+func (m *MockGitIntegrationService) HandleGitHubAppSetup(ctx context.Context, installationID int64, state string) (string, *errors.ServiceError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleGitHubAppSetup", ctx, installationID, state)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(*errors.ServiceError)
+	return ret0, ret1
+}
+
+// HandleGitHubAppSetup indicates an expected call of HandleGitHubAppSetup.
+func (mr *MockGitIntegrationServiceMockRecorder) HandleGitHubAppSetup(ctx, installationID, state any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleGitHubAppSetup", reflect.TypeOf((*MockGitIntegrationService)(nil).HandleGitHubAppSetup), ctx, installationID, state)
+}
+
 // HandleGitHubManifestCallback mocks base method.
 func (m *MockGitIntegrationService) HandleGitHubManifestCallback(ctx context.Context, code, state string) (string, *errors.ServiceError) {
 	m.ctrl.T.Helper()

--- a/pkg/mocks/mock_githubapp_client.go
+++ b/pkg/mocks/mock_githubapp_client.go
@@ -56,6 +56,21 @@ func (mr *MockGitHubAppClientMockRecorder) ConvertManifestCode(ctx, code any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertManifestCode", reflect.TypeOf((*MockGitHubAppClient)(nil).ConvertManifestCode), ctx, code)
 }
 
+// GetInstallation mocks base method.
+func (m *MockGitHubAppClient) GetInstallation(ctx context.Context, creds *githubapp.AppCredentials, installationID int64) (*githubapp.Installation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstallation", ctx, creds, installationID)
+	ret0, _ := ret[0].(*githubapp.Installation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInstallation indicates an expected call of GetInstallation.
+func (mr *MockGitHubAppClientMockRecorder) GetInstallation(ctx, creds, installationID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallation", reflect.TypeOf((*MockGitHubAppClient)(nil).GetInstallation), ctx, creds, installationID)
+}
+
 // GetRepo mocks base method.
 func (m *MockGitHubAppClient) GetRepo(ctx context.Context, creds *githubapp.AppCredentials, installationID int64, owner, repo string) (*githubapp.Repo, error) {
 	m.ctrl.T.Helper()

--- a/pkg/models/git_integration.go
+++ b/pkg/models/git_integration.go
@@ -40,6 +40,9 @@ const (
 // OAuthProviderGitHubAppManifest scopes manifest-flow state records.
 const OAuthProviderGitHubAppManifest = "github_app_manifest"
 
+// OAuthProviderGitHubAppInstall scopes platform-app install state records.
+const OAuthProviderGitHubAppInstall = "github_app_install"
+
 // Condition recorded on image builds when a GitHub App token refresh fails.
 const (
 	GitTokenRefreshFailedConditionType   = "GitTokenRefreshFailed"

--- a/pkg/presenters/git_integration.go
+++ b/pkg/presenters/git_integration.go
@@ -78,7 +78,11 @@ func PresentGitIntegrationList(in []*models.GitIntegration) []openapi.GitIntegra
 // until the callback).
 func PresentGitHubAppManifestFlow(in *models.GitHubAppManifestFlow) openapi.GitHubAppManifestFlow {
 	res := openapi.GitHubAppManifestFlow{}
-	res.SetManifest(in.Manifest)
+	// A platform-wide app has nothing to create, so it carries no manifest and
+	// github_url points straight at the install page.
+	if in.Manifest != nil {
+		res.SetManifest(in.Manifest)
+	}
 	res.SetGithubUrl(in.GitHubURL)
 	res.SetState(in.State)
 	return res

--- a/pkg/services/git_integration_github_app.go
+++ b/pkg/services/git_integration_github_app.go
@@ -27,11 +27,20 @@ const (
 	githubAppsBaseURL    = "https://github.com"
 	manifestCallbackPath = "/api/v1/git-integrations/github/manifest/callback"
 	githubWebhookPath    = "/api/v1/webhooks/github"
+	// setupCompleteRedirect is where the browser lands after a platform-app
+	// install. setup_action tells the SPA it is the install popup, so it can
+	// notify its opener and close.
+	setupCompleteRedirect = "/git-integrations?setup_action=install"
 
 	// GitHub webhook event names.
 	GitHubEventInstallation = "installation"
 	GitHubEventPullRequest  = "pull_request"
 	GitHubEventPush         = "push"
+	// GitHubEventIssueComment covers comments on PRs (GitHub delivers PR
+	// comments under this event name). Subscribed now so already-created apps
+	// receive them when the hub starts handling them; unknown events are
+	// dropped by the webhook handler until then.
+	GitHubEventIssueComment = "issue_comment"
 )
 
 // CreateGitHubAppManifest starts the manifest flow: it creates (or reuses) the
@@ -60,7 +69,15 @@ func (s *gitIntegrationService) CreateGitHubAppManifest(ctx context.Context, org
 		if serr != nil {
 			return nil, serr
 		}
-	} else if integration.Status == models.GitIntegrationStatusInstalled {
+	}
+
+	// Platform mode allows re-running the flow on an installed integration:
+	// that is how a second GitHub account (personal + org) gets added, since
+	// the shared-app webhook cannot attribute new installations to an org.
+	if s.platformApp != nil {
+		return s.platformAppInstallFlow(ctx, integration)
+	}
+	if integration.Status == models.GitIntegrationStatusInstalled {
 		return nil, errors.Conflict("a GitHub App is already installed for this organisation")
 	}
 
@@ -90,11 +107,13 @@ func (s *gitIntegrationService) CreateGitHubAppManifest(ctx context.Context, org
 			githubapp.PermContents:     githubapp.PermLevelRead,
 			githubapp.PermMetadata:     githubapp.PermLevelRead,
 			githubapp.PermPullRequests: githubapp.PermLevelWrite,
+			// Issues read is what allows the issue_comment event below.
+			githubapp.PermIssues: githubapp.PermLevelRead,
 		},
 		// GitHub rejects "installation" as a default_event — installation
 		// lifecycle deliveries are sent to every app automatically, so only
 		// subscribable events belong here.
-		DefaultEvents: []string{GitHubEventPush, GitHubEventPullRequest},
+		DefaultEvents: []string{GitHubEventPush, GitHubEventPullRequest, GitHubEventIssueComment},
 	}
 	// The API contract exposes the manifest as a free-form object, so marshal
 	// the typed manifest into the generic map the model carries.
@@ -108,6 +127,86 @@ func (s *gitIntegrationService) CreateGitHubAppManifest(ctx context.Context, org
 		GitHubURL: fmt.Sprintf("%s/settings/apps/new?state=%s", githubAppsBaseURL, state),
 		State:     state,
 	}, nil
+}
+
+// platformAppInstallFlow is the manifest flow's shortcut when the hub runs one
+// platform-wide GitHub App: there is nothing to create on GitHub, so the user
+// goes straight to the app's install page. The state comes back on the setup
+// callback and is what binds the new installation to this org. The row stores
+// no credentials — platform creds resolve from config at read time.
+func (s *gitIntegrationService) platformAppInstallFlow(ctx context.Context, integration *models.GitIntegration) (*models.GitHubAppManifestFlow, *errors.ServiceError) {
+	state := fmt.Sprintf("%s:%s", uuid.NewString(), integration.ID)
+	if serr := s.oauthStates.Create(ctx, &models.OAuthState{
+		State:     state,
+		Provider:  models.OAuthProviderGitHubAppInstall,
+		CreatedAt: time.Now().UTC(),
+	}); serr != nil {
+		return nil, serr
+	}
+
+	return &models.GitHubAppManifestFlow{
+		GitHubURL: fmt.Sprintf("%s?state=%s", githubAppInstallURL(s.platformApp.Slug), state),
+		State:     state,
+	}, nil
+}
+
+// HandleGitHubAppSetup finishes the platform-app install: GitHub redirects the
+// browser to the app's setup URL with the new installation id and the state
+// issued when the flow started. Unauthenticated: the state is the proof of
+// initiation, exactly as in the manifest callback.
+func (s *gitIntegrationService) HandleGitHubAppSetup(ctx context.Context, installationID int64, state string) (string, *errors.ServiceError) {
+	if installationID == 0 || state == "" {
+		return "", errors.BadRequest("installation_id and state are required")
+	}
+
+	record, serr := s.oauthStates.Consume(ctx, state, models.OAuthProviderGitHubAppInstall)
+	if serr != nil {
+		return "", serr
+	}
+	if time.Since(record.CreatedAt) > manifestStateTTL {
+		return "", errors.BadRequest("the GitHub App setup link has expired; restart the flow")
+	}
+
+	_, integrationID, found := strings.Cut(record.State, ":")
+	if !found || integrationID == "" {
+		return "", errors.BadRequest("malformed state parameter")
+	}
+
+	integration, serr := s.store.GetByID(ctx, integrationID)
+	if serr != nil {
+		return "", serr
+	}
+	if integration.Type != models.GitIntegrationTypeGitHubApp {
+		return "", errors.BadRequest("state does not reference a GitHub App integration")
+	}
+
+	creds, serr := s.appCredentials(integration)
+	if serr != nil {
+		return "", serr
+	}
+	// The id from the query string is not trusted on its own: confirm with
+	// GitHub that this installation really belongs to our app.
+	in, err := s.githubApp.GetInstallation(ctx, creds, installationID)
+	if err != nil {
+		return "", errors.NotFound("installation %d was not found on the platform GitHub App: %s", installationID, err.Error())
+	}
+	if in.Suspended {
+		return "", errors.BadRequest("installation %d is suspended on GitHub", installationID)
+	}
+
+	if _, serr := s.installations.Upsert(ctx, &models.GitInstallation{
+		GitIntegrationID:    integration.ID,
+		InstallationID:      in.ID,
+		AccountLogin:        in.AccountLogin,
+		AccountType:         models.GitAccountType(in.AccountType),
+		RepositorySelection: in.RepositorySelection,
+	}); serr != nil {
+		return "", serr
+	}
+	if serr := syncInstallationStatus(ctx, s.store, s.installations, integration); serr != nil {
+		return "", serr
+	}
+	return s.externalURL + setupCompleteRedirect, nil
 }
 
 func manifestToMap(manifest githubapp.AppManifest) (map[string]any, *errors.ServiceError) {
@@ -400,6 +499,9 @@ func (s *gitIntegrationService) installedApp(ctx context.Context, integrationID,
 	if integration.Type != models.GitIntegrationTypeGitHubApp {
 		return nil, nil, errors.BadRequest("integration '%s' is not a GitHub App", integrationID)
 	}
+	if integration.Status != models.GitIntegrationStatusInstalled {
+		return nil, nil, errors.BadRequest("the GitHub App setup has not been completed yet")
+	}
 	creds, serr := s.appCredentials(integration)
 	if serr != nil {
 		return nil, nil, serr
@@ -409,14 +511,19 @@ func (s *gitIntegrationService) installedApp(ctx context.Context, integrationID,
 
 // appCredentials unseals the integration and extracts the app credentials.
 func (s *gitIntegrationService) appCredentials(integration *models.GitIntegration) (*githubapp.AppCredentials, *errors.ServiceError) {
-	return unsealAppCredentials(s.encryptionService, integration)
+	return unsealAppCredentials(s.encryptionService, s.platformApp, integration)
 }
 
-// unsealAppCredentials decrypts the integration's auth blob (when not already
-// unsealed) and returns the GitHub App credentials. Shared by the integration
-// service and the webhook ingress service.
-func unsealAppCredentials(enc EncryptionService, integration *models.GitIntegration) (*githubapp.AppCredentials, *errors.ServiceError) {
+// unsealAppCredentials returns the GitHub App credentials for an integration.
+// Shared by the integration service and the webhook ingress service.
+//   - Sealed auth on the row (BYO app): decrypt and use it.
+//   - No sealed auth + platform app configured: the platform credentials, read
+//     from config every time so a key rotation is just an env change.
+func unsealAppCredentials(enc EncryptionService, platform *githubapp.AppCredentials, integration *models.GitIntegration) (*githubapp.AppCredentials, *errors.ServiceError) {
 	if integration.EncryptedAuth == "" {
+		if platform != nil {
+			return platform, nil
+		}
 		return nil, errors.BadRequest("the GitHub App setup has not been completed yet")
 	}
 	if integration.Auth == nil {
@@ -453,9 +560,28 @@ func (s *gitIntegrationService) reconcileInstallations(ctx context.Context, inte
 		return errors.BadRequest("failed to list installations from GitHub: %s", err.Error())
 	}
 
+	// A platform-backed integration (no sealed auth of its own) shares the app
+	// with every org, so GitHub's list spans all of them. Only installations
+	// the setup callback already bound to this integration are its to
+	// reconcile. BYO apps own their whole list.
+	sharedApp := s.platformApp != nil && integration.EncryptedAuth == ""
+	owned := map[int64]bool{}
+	if sharedApp {
+		local, serr := s.installations.ListByIntegrationID(ctx, integration.ID)
+		if serr != nil {
+			return serr
+		}
+		for _, l := range local {
+			owned[l.InstallationID] = true
+		}
+	}
+
 	return s.atomic.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
 		live := make(map[int64]bool, len(remote))
 		for _, in := range remote {
+			if sharedApp && !owned[in.ID] {
+				continue
+			}
 			if in.Suspended {
 				// Suspended installations can't mint tokens; treat as absent so
 				// they are pruned below, matching the webhook suspend handling.

--- a/pkg/services/git_integration_github_app.go
+++ b/pkg/services/git_integration_github_app.go
@@ -36,11 +36,12 @@ const (
 	GitHubEventInstallation = "installation"
 	GitHubEventPullRequest  = "pull_request"
 	GitHubEventPush         = "push"
-	// GitHubEventIssueComment covers comments on PRs (GitHub delivers PR
-	// comments under this event name). Subscribed now so already-created apps
-	// receive them when the hub starts handling them; unknown events are
-	// dropped by the webhook handler until then.
+	// issue_comment and label are subscribed ahead of use so already-created
+	// apps receive them when the hub starts handling them; unknown events are
+	// dropped by the webhook handler until then. GitHub delivers PR comments
+	// under issue_comment.
 	GitHubEventIssueComment = "issue_comment"
+	GitHubEventLabel        = "label"
 )
 
 // CreateGitHubAppManifest starts the manifest flow: it creates (or reuses) the
@@ -113,7 +114,7 @@ func (s *gitIntegrationService) CreateGitHubAppManifest(ctx context.Context, org
 		// GitHub rejects "installation" as a default_event — installation
 		// lifecycle deliveries are sent to every app automatically, so only
 		// subscribable events belong here.
-		DefaultEvents: []string{GitHubEventPush, GitHubEventPullRequest, GitHubEventIssueComment},
+		DefaultEvents: []string{GitHubEventPush, GitHubEventPullRequest, GitHubEventIssueComment, GitHubEventLabel},
 	}
 	// The API contract exposes the manifest as a free-form object, so marshal
 	// the typed manifest into the generic map the model carries.

--- a/pkg/services/git_integration_github_app_test.go
+++ b/pkg/services/git_integration_github_app_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,8 @@ import (
 	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/mocks"
 	"github.com/Stackdome/stackdome/pkg/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 )
 
@@ -275,6 +278,7 @@ func TestProcessGitHubWebhookInstallationCreated(t *testing.T) {
 	integration.Status = models.GitIntegrationStatusPendingInstall
 	payload := installationWebhookPayload(t, "created")
 
+	deps.installations.EXPECT().GetByInstallationID(gomock.Any(), int64(77)).Return(nil, errors.NotFound("no installation row yet"))
 	deps.store.EXPECT().ListGitHubApps(gomock.Any()).Return([]*models.GitIntegration{integration}, nil)
 	deps.installations.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, installation *models.GitInstallation) (*models.GitInstallation, *errors.ServiceError) {
@@ -303,6 +307,7 @@ func TestProcessGitHubWebhookRejectsBadSignature(t *testing.T) {
 	integration := sealedGitHubApp(t, deps.encryption, models.GitHubAppCredentials{AppID: 4242, WebhookSecret: "hook-secret"})
 	payload := installationWebhookPayload(t, "created")
 
+	deps.installations.EXPECT().GetByInstallationID(gomock.Any(), int64(77)).Return(nil, errors.NotFound("no installation row yet"))
 	deps.store.EXPECT().ListGitHubApps(gomock.Any()).Return([]*models.GitIntegration{integration}, nil)
 
 	serr := svc.ProcessGitHubWebhook(context.Background(), GitHubEventInstallation, payload, signWebhook(payload, "wrong-secret"))
@@ -316,6 +321,7 @@ func TestProcessGitHubWebhookInstallationDeleted(t *testing.T) {
 	integration := sealedGitHubApp(t, deps.encryption, models.GitHubAppCredentials{AppID: 4242, WebhookSecret: "hook-secret"})
 	payload := installationWebhookPayload(t, "deleted")
 
+	deps.installations.EXPECT().GetByInstallationID(gomock.Any(), int64(77)).Return(nil, errors.NotFound("no installation row yet"))
 	deps.store.EXPECT().ListGitHubApps(gomock.Any()).Return([]*models.GitIntegration{integration}, nil)
 	deps.installations.EXPECT().DeleteByInstallationID(gomock.Any(), "gi-app", int64(77)).Return(nil)
 	deps.installations.EXPECT().ListByIntegrationID(gomock.Any(), "gi-app").Return(nil, nil)
@@ -372,3 +378,299 @@ func TestInternalMintForRepoFallsThroughWhenNoInstallationCoversOwner(t *testing
 		t.Fatalf("expected 404 to fall through, got %v", serr)
 	}
 }
+
+var _ = Describe("platform GitHub App", func() {
+	const platformSlug = "stackdome-cloud"
+
+	var (
+		ctrl     *gomock.Controller
+		svc      GitIntegrationService
+		deps     *githubAppServiceMocks
+		platform *githubapp.AppCredentials
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+
+		encryption, err := NewAESEncryptionService(EncryptionServiceSpec{Masterkey: strings.Repeat("k", 64)})
+		Expect(err).NotTo(HaveOccurred())
+
+		permissions := mocks.NewMockPermissionService(ctrl)
+		permissions.EXPECT().Check(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+		deps = &githubAppServiceMocks{
+			store:         mocks.NewMockGitIntegrationStore(ctrl),
+			installations: mocks.NewMockGitInstallationStore(ctrl),
+			oauthStates:   mocks.NewMockOAuthStateStore(ctrl),
+			organisations: mocks.NewMockOrganisationStore(ctrl),
+			atomic:        mocks.NewMockAtomicExecutor(ctrl),
+			appClient:     mocks.NewMockGitHubAppClient(ctrl),
+			encryption:    encryption,
+		}
+		deps.atomic.EXPECT().WithTransaction(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, fn func(context.Context) *errors.ServiceError) *errors.ServiceError {
+				return fn(ctx)
+			}).AnyTimes()
+
+		platform = &githubapp.AppCredentials{
+			AppID:         4242,
+			Slug:          platformSlug,
+			PEM:           "-----BEGIN RSA PRIVATE KEY-----",
+			WebhookSecret: "hook-secret",
+		}
+		svc = NewGitIntegrationService(GitIntegrationServiceSpec{
+			Store:             deps.store,
+			InstallationStore: deps.installations,
+			OAuthStateStore:   deps.oauthStates,
+			OrganisationStore: deps.organisations,
+			AtomicExecutor:    deps.atomic,
+			GitHubAppClient:   deps.appClient,
+			EncryptionService: encryption,
+			Permissions:       permissions,
+			Logger:            logger.NewLogger(),
+			ExternalURL:       "https://hub.example.com",
+			PlatformApp:       platform,
+		})
+	})
+
+	Describe("CreateGitHubAppManifest", func() {
+		It("skips app creation and sends the user to the install page", func() {
+			deps.store.EXPECT().GetGitHubAppForOrg(gomock.Any(), "org-1").Return(nil, errors.NotFound("none"))
+			deps.store.EXPECT().Create(gomock.Any(), gomock.Any()).Return(&models.GitIntegration{
+				ID:             "gi-app",
+				OrganisationID: "org-1",
+				Type:           models.GitIntegrationTypeGitHubApp,
+				Status:         models.GitIntegrationStatusPendingInstall,
+			}, nil)
+
+			var stored *models.OAuthState
+			deps.oauthStates.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, state *models.OAuthState) *errors.ServiceError {
+					stored = state
+					return nil
+				})
+
+			flow, serr := svc.CreateGitHubAppManifest(context.Background(), "org-1")
+			Expect(serr).To(BeNil())
+			Expect(flow.Manifest).To(BeNil())
+			Expect(flow.GitHubURL).To(Equal("https://github.com/apps/" + platformSlug + "/installations/new?state=" + flow.State))
+			Expect(stored.Provider).To(Equal(models.OAuthProviderGitHubAppInstall))
+			Expect(stored.State).To(HaveSuffix(":gi-app"))
+		})
+	})
+
+	Describe("HandleGitHubAppSetup", func() {
+		var integration *models.GitIntegration
+
+		BeforeEach(func() {
+			// Platform-backed rows carry no credentials; they resolve from config.
+			integration = &models.GitIntegration{
+				ID:             "gi-app",
+				OrganisationID: "org-1",
+				Type:           models.GitIntegrationTypeGitHubApp,
+				Status:         models.GitIntegrationStatusPendingInstall,
+				DataHash:       gitIntegrationDataHash(nil),
+			}
+		})
+
+		It("binds the new installation to the org that started the flow", func() {
+			deps.oauthStates.EXPECT().Consume(gomock.Any(), "state-1", models.OAuthProviderGitHubAppInstall).
+				Return(&models.OAuthState{State: "uuid:gi-app", CreatedAt: time.Now().UTC()}, nil)
+			deps.store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(integration, nil)
+			deps.appClient.EXPECT().GetInstallation(gomock.Any(), gomock.Any(), int64(77)).Return(&githubapp.Installation{
+				ID: 77, AccountLogin: "acme", AccountType: string(models.GitAccountTypeOrganization), RepositorySelection: "all",
+			}, nil)
+
+			var upserted *models.GitInstallation
+			deps.installations.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, in *models.GitInstallation) (*models.GitInstallation, *errors.ServiceError) {
+					upserted = in
+					return in, nil
+				})
+			deps.installations.EXPECT().ListByIntegrationID(gomock.Any(), "gi-app").
+				Return([]*models.GitInstallation{{InstallationID: 77}}, nil)
+			deps.store.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, in *models.GitIntegration) (*models.GitIntegration, *errors.ServiceError) {
+					return in, nil
+				})
+
+			redirect, serr := svc.HandleGitHubAppSetup(context.Background(), 77, "state-1")
+			Expect(serr).To(BeNil())
+			Expect(redirect).To(Equal("https://hub.example.com/git-integrations?setup_action=install"))
+			Expect(upserted.GitIntegrationID).To(Equal("gi-app"))
+			Expect(upserted.AccountLogin).To(Equal("acme"))
+			Expect(integration.Status).To(Equal(models.GitIntegrationStatusInstalled))
+		})
+
+		It("rejects an installation the platform app does not have", func() {
+			deps.oauthStates.EXPECT().Consume(gomock.Any(), "state-1", models.OAuthProviderGitHubAppInstall).
+				Return(&models.OAuthState{State: "uuid:gi-app", CreatedAt: time.Now().UTC()}, nil)
+			deps.store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(integration, nil)
+			deps.appClient.EXPECT().GetInstallation(gomock.Any(), gomock.Any(), int64(77)).Return(nil, fmt.Errorf("404 not found"))
+
+			_, serr := svc.HandleGitHubAppSetup(context.Background(), 77, "state-1")
+			Expect(serr).NotTo(BeNil())
+			Expect(serr.Is404()).To(BeTrue())
+		})
+
+		It("leaves another org's installation of the same app alone on refresh", func() {
+			integration.Status = models.GitIntegrationStatusInstalled
+			deps.store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(integration, nil)
+			deps.appClient.EXPECT().ListInstallations(gomock.Any(), gomock.Any()).Return([]githubapp.Installation{
+				{ID: 77, AccountLogin: "acme", AccountType: string(models.GitAccountTypeOrganization), RepositorySelection: "all"},
+				{ID: 99, AccountLogin: "other-org", AccountType: string(models.GitAccountTypeOrganization), RepositorySelection: "all"},
+			}, nil)
+			deps.installations.EXPECT().ListByIntegrationID(gomock.Any(), "gi-app").
+				Return([]*models.GitInstallation{{InstallationID: 77}}, nil).AnyTimes()
+			deps.installations.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, in *models.GitInstallation) (*models.GitInstallation, *errors.ServiceError) {
+					Expect(in.InstallationID).To(Equal(int64(77)))
+					return in, nil
+				})
+
+			_, serr := svc.ListInstallations(context.Background(), "gi-app", true)
+			Expect(serr).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("platform GitHub App webhooks", func() {
+	It("resolves deliveries via the installation row and verifies with the platform secret", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+
+		encryption, err := NewAESEncryptionService(EncryptionServiceSpec{Masterkey: strings.Repeat("k", 64)})
+		Expect(err).NotTo(HaveOccurred())
+
+		platform := &githubapp.AppCredentials{
+			AppID:         4242,
+			Slug:          "stackdome-cloud",
+			PEM:           "-----BEGIN RSA PRIVATE KEY-----",
+			WebhookSecret: "platform-hook-secret",
+		}
+		store := mocks.NewMockGitIntegrationStore(ctrl)
+		installations := mocks.NewMockGitInstallationStore(ctrl)
+		svc := NewGitHubWebhookService(GitHubWebhookServiceSpec{
+			Store:             store,
+			InstallationStore: installations,
+			EncryptionService: encryption,
+			PreviewWebhook:    NewMockPreviewWebhookService(ctrl),
+			Logger:            logger.NewLogger(),
+			PlatformApp:       platform,
+		})
+
+		// Platform-backed row: no sealed auth of its own.
+		integration := &models.GitIntegration{
+			ID:             "gi-app",
+			OrganisationID: "org-1",
+			Type:           models.GitIntegrationTypeGitHubApp,
+			Status:         models.GitIntegrationStatusInstalled,
+		}
+		payload, err := json.Marshal(map[string]any{
+			"action": "deleted",
+			"installation": map[string]any{
+				"id":     77,
+				"app_id": 4242,
+				"account": map[string]any{
+					"login": "acme",
+					"type":  models.GitAccountTypeOrganization,
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		installations.EXPECT().GetByInstallationID(gomock.Any(), int64(77)).
+			Return(&models.GitInstallation{GitIntegrationID: "gi-app", InstallationID: 77}, nil)
+		store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(integration, nil)
+		installations.EXPECT().DeleteByInstallationID(gomock.Any(), "gi-app", int64(77)).Return(nil)
+		installations.EXPECT().ListByIntegrationID(gomock.Any(), "gi-app").Return(nil, nil)
+		store.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, in *models.GitIntegration) (*models.GitIntegration, *errors.ServiceError) {
+				Expect(in.Status).To(Equal(models.GitIntegrationStatusPendingInstall))
+				return in, nil
+			})
+
+		serr := svc.ProcessGitHubWebhook(context.Background(), GitHubEventInstallation, payload, signWebhookGinkgo(payload, platform.WebhookSecret))
+		Expect(serr).To(BeNil())
+	})
+
+	It("acks an installation event with no binding yet instead of erroring", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+
+		encryption, err := NewAESEncryptionService(EncryptionServiceSpec{Masterkey: strings.Repeat("k", 64)})
+		Expect(err).NotTo(HaveOccurred())
+
+		store := mocks.NewMockGitIntegrationStore(ctrl)
+		installations := mocks.NewMockGitInstallationStore(ctrl)
+		svc := NewGitHubWebhookService(GitHubWebhookServiceSpec{
+			Store:             store,
+			InstallationStore: installations,
+			EncryptionService: encryption,
+			PreviewWebhook:    NewMockPreviewWebhookService(ctrl),
+			Logger:            logger.NewLogger(),
+			PlatformApp:       &githubapp.AppCredentials{AppID: 4242, Slug: "stackdome-cloud", PEM: "k", WebhookSecret: "s"},
+		})
+
+		payload, err := json.Marshal(map[string]any{
+			"action":       "created",
+			"installation": map[string]any{"id": 88, "app_id": 4242},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Setup callback hasn't bound installation 88 yet; nothing sealed to
+		// match by app id either. The delivery must be acked, not retried.
+		installations.EXPECT().GetByInstallationID(gomock.Any(), int64(88)).
+			Return(nil, errors.NotFound("not bound yet"))
+		store.EXPECT().ListGitHubApps(gomock.Any()).Return(nil, nil)
+
+		Expect(svc.ProcessGitHubWebhook(context.Background(), GitHubEventInstallation, payload, "sha256=irrelevant")).To(BeNil())
+	})
+})
+
+func signWebhookGinkgo(payload []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+var _ = Describe("platform GitHub App re-run", func() {
+	It("allows starting the flow again when already installed, to add another account", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+
+		encryption, err := NewAESEncryptionService(EncryptionServiceSpec{Masterkey: strings.Repeat("k", 64)})
+		Expect(err).NotTo(HaveOccurred())
+		permissions := mocks.NewMockPermissionService(ctrl)
+		permissions.EXPECT().Check(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+		store := mocks.NewMockGitIntegrationStore(ctrl)
+		oauthStates := mocks.NewMockOAuthStateStore(ctrl)
+		svc := NewGitIntegrationService(GitIntegrationServiceSpec{
+			Store:             store,
+			InstallationStore: mocks.NewMockGitInstallationStore(ctrl),
+			OAuthStateStore:   oauthStates,
+			OrganisationStore: mocks.NewMockOrganisationStore(ctrl),
+			AtomicExecutor:    mocks.NewMockAtomicExecutor(ctrl),
+			GitHubAppClient:   mocks.NewMockGitHubAppClient(ctrl),
+			EncryptionService: encryption,
+			Permissions:       permissions,
+			Logger:            logger.NewLogger(),
+			ExternalURL:       "https://hub.example.com",
+			PlatformApp:       &githubapp.AppCredentials{AppID: 4242, Slug: "stackdome-cloud", PEM: "k", WebhookSecret: "s"},
+		})
+
+		store.EXPECT().GetGitHubAppForOrg(gomock.Any(), "org-1").Return(&models.GitIntegration{
+			ID:             "gi-app",
+			OrganisationID: "org-1",
+			Type:           models.GitIntegrationTypeGitHubApp,
+			Status:         models.GitIntegrationStatusInstalled,
+		}, nil)
+		oauthStates.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+
+		flow, serr := svc.CreateGitHubAppManifest(context.Background(), "org-1")
+		Expect(serr).To(BeNil())
+		Expect(flow.GitHubURL).To(ContainSubstring("/apps/stackdome-cloud/installations/new?state="))
+	})
+})

--- a/pkg/services/git_integration_service.go
+++ b/pkg/services/git_integration_service.go
@@ -46,6 +46,7 @@ type GitIntegrationService interface {
 	// GitHub App manifest flow, installations, and discovery.
 	CreateGitHubAppManifest(ctx context.Context, organisationID string) (*models.GitHubAppManifestFlow, *errors.ServiceError)
 	HandleGitHubManifestCallback(ctx context.Context, code, state string) (string, *errors.ServiceError)
+	HandleGitHubAppSetup(ctx context.Context, installationID int64, state string) (string, *errors.ServiceError)
 	ListInstallations(ctx context.Context, integrationID string, refresh bool) ([]*models.GitInstallation, *errors.ServiceError)
 	ListRepositories(ctx context.Context, integrationID string, page int, installationUUID string) (*githubapp.RepoPage, *errors.ServiceError)
 	GetRepository(ctx context.Context, integrationID, owner, repo string) (*githubapp.Repo, *errors.ServiceError)
@@ -72,6 +73,9 @@ type GitIntegrationServiceSpec struct {
 	// ExternalURL is the hub's externally reachable base URL, required for
 	// the GitHub App manifest flow.
 	ExternalURL string
+	// PlatformApp is the platform-wide GitHub App every org installs. Nil
+	// keeps each org creating its own app through the manifest flow.
+	PlatformApp *githubapp.AppCredentials
 	// GitClients is optional; it defaults to real git clients.
 	GitClients verifyGitClientProvider
 }
@@ -87,6 +91,7 @@ type gitIntegrationService struct {
 	permissions       auth.PermissionService
 	logger            logger.Logger
 	externalURL       string
+	platformApp       *githubapp.AppCredentials
 	gitClients        verifyGitClientProvider
 }
 
@@ -106,6 +111,7 @@ func NewGitIntegrationService(spec GitIntegrationServiceSpec) GitIntegrationServ
 		permissions:       spec.Permissions,
 		logger:            spec.Logger,
 		externalURL:       strings.TrimSuffix(spec.ExternalURL, "/"),
+		platformApp:       spec.PlatformApp,
 		gitClients:        gitClients,
 	}
 }

--- a/pkg/services/github_webhook_service.go
+++ b/pkg/services/github_webhook_service.go
@@ -35,6 +35,17 @@ func truncateForLog(s string) string {
 // GitHubWebhookService is the ingress for GitHub webhook deliveries. It is
 // deliberately separate from GitIntegrationService so webhook dispatch can
 // depend on the preview webhook router without a construction cycle.
+//
+// How we find out which org a delivery belongs to:
+//   - First, look up the git_installations row by installation id. This works
+//     for both app modes. For the shared platform app it is the ONLY safe
+//     way: all orgs share one app id, so the app id cannot tell orgs apart.
+//   - If there is no row, match by app id across BYO integrations. Each BYO
+//     app has its own unique app id, so a match names exactly one org. This
+//     only happens on a BYO app's very first delivery, before its row exists.
+//   - If neither works for an installation event, we ack it and do nothing.
+//     For the platform app, the setup callback links the install to its org —
+//     the webhook never does. Erroring would just make GitHub retry forever.
 type GitHubWebhookService interface {
 	// ProcessGitHubWebhook resolves the integration a delivery belongs to,
 	// HMAC-verifies the payload against that integration's webhook secret,
@@ -48,6 +59,9 @@ type GitHubWebhookServiceSpec struct {
 	EncryptionService EncryptionService
 	PreviewWebhook    PreviewWebhookService
 	Logger            logger.Logger
+	// PlatformApp mirrors GitIntegrationServiceSpec.PlatformApp; nil means
+	// per-org apps.
+	PlatformApp *githubapp.AppCredentials
 }
 
 type gitHubWebhookService struct {
@@ -56,6 +70,7 @@ type gitHubWebhookService struct {
 	encryption     EncryptionService
 	previewWebhook PreviewWebhookService
 	logger         logger.Logger
+	platformApp    *githubapp.AppCredentials
 }
 
 func NewGitHubWebhookService(spec GitHubWebhookServiceSpec) GitHubWebhookService {
@@ -65,6 +80,7 @@ func NewGitHubWebhookService(spec GitHubWebhookServiceSpec) GitHubWebhookService
 		encryption:     spec.EncryptionService,
 		previewWebhook: spec.PreviewWebhook,
 		logger:         spec.Logger,
+		platformApp:    spec.PlatformApp,
 	}
 }
 
@@ -91,6 +107,12 @@ func (s *gitHubWebhookService) ProcessGitHubWebhook(ctx context.Context, event s
 	integration, creds, serr := s.webhookIntegration(ctx, parsed)
 	if serr != nil {
 		s.logger.Warn(ctx, "github webhook: cannot resolve integration for '%s' event: %s", event, serr.Reason)
+		if event == GitHubEventInstallation && serr.Is404() {
+			// A new platform-app install has no org link until the setup
+			// callback runs. Ack it so GitHub does not keep retrying a
+			// delivery we can never match.
+			return nil
+		}
 		return serr
 	}
 	if err := github.ValidateSignature(signature, payload, []byte(creds.WebhookSecret)); err != nil {
@@ -109,18 +131,27 @@ func (s *gitHubWebhookService) ProcessGitHubWebhook(ctx context.Context, event s
 	}
 }
 
-// webhookIntegration resolves the integration a delivery belongs to. Only
-// installation events carry the full installation object with app_id;
-// repository events (pull_request) carry the slim {id, node_id} reference, so
-// they resolve through the stored installation row instead.
+// webhookIntegration finds the integration a delivery belongs to. The lookup
+// order is explained on GitHubWebhookService. pull_request payloads only
+// carry {id, node_id} for the installation — no app id — so there is no
+// fallback for them: unknown installation means no org has that repo
+// connection.
 func (s *gitHubWebhookService) webhookIntegration(ctx context.Context, parsed any) (*models.GitIntegration, *githubapp.AppCredentials, *errors.ServiceError) {
 	switch e := parsed.(type) {
 	case *github.InstallationEvent:
+		// Try the installation row first.
+		if installationID := e.GetInstallation().GetID(); installationID != 0 {
+			integration, creds, serr := s.findAppByInstallation(ctx, installationID)
+			if serr == nil {
+				return integration, creds, nil
+			}
+		}
+		// No row yet: a BYO app's first delivery. Match by app id.
 		appID := e.GetInstallation().GetAppID()
 		if appID == 0 {
 			return nil, nil, errors.BadRequest("installation payload has no app id")
 		}
-		return s.findAppByID(ctx, appID)
+		return s.findBYOAppByAppID(ctx, appID)
 	case *github.PullRequestEvent:
 		installationID := e.GetInstallation().GetID()
 		if installationID == 0 {
@@ -132,17 +163,24 @@ func (s *gitHubWebhookService) webhookIntegration(ctx context.Context, parsed an
 	}
 }
 
-// findAppByID locates a github_app integration by GitHub app ID.
-func (s *gitHubWebhookService) findAppByID(ctx context.Context, appID int64) (*models.GitIntegration, *githubapp.AppCredentials, *errors.ServiceError) {
+// findBYOAppByAppID finds the BYO integration that owns a GitHub app id.
+//   - Each BYO app has its own unique app id, so a match names exactly one
+//     org.
+//   - Rows using the platform app store no credentials and MUST be skipped:
+//     they would all report the same platform app id, and picking the first
+//     match would hand the delivery — and later its repo tokens — to the
+//     wrong org. Those rows are only ever found via the installation row.
+func (s *gitHubWebhookService) findBYOAppByAppID(ctx context.Context, appID int64) (*models.GitIntegration, *githubapp.AppCredentials, *errors.ServiceError) {
 	integrations, serr := s.store.ListGitHubApps(ctx)
 	if serr != nil {
 		return nil, nil, serr
 	}
 	for _, integration := range integrations {
+		// No stored credentials = platform-app row. Skip (see doc above).
 		if integration.EncryptedAuth == "" {
 			continue
 		}
-		creds, serr := unsealAppCredentials(s.encryption, integration)
+		creds, serr := unsealAppCredentials(s.encryption, s.platformApp, integration)
 		if serr != nil {
 			continue
 		}
@@ -164,7 +202,7 @@ func (s *gitHubWebhookService) findAppByInstallation(ctx context.Context, instal
 	if serr != nil {
 		return nil, nil, serr
 	}
-	creds, serr := unsealAppCredentials(s.encryption, integration)
+	creds, serr := unsealAppCredentials(s.encryption, s.platformApp, integration)
 	if serr != nil {
 		return nil, nil, serr
 	}

--- a/pkg/services/user_service.go
+++ b/pkg/services/user_service.go
@@ -149,10 +149,8 @@ func (u usersService) InternalCreateOAuthUser(ctx context.Context, email, name, 
 		return nil, fmt.Errorf("failed to create organisation for oauth user: %w", serr)
 	}
 
-	if u.projectService != nil {
-		if _, projectErr := u.projectService.InternalCreateDefaultProject(ctx, createdOrg.ID); projectErr != nil {
-			return nil, fmt.Errorf("failed to create default project for oauth user: %w", projectErr)
-		}
+	if _, projectErr := u.projectService.InternalCreateDefaultProject(ctx, createdOrg.ID); projectErr != nil {
+		return nil, fmt.Errorf("failed to create default project for oauth user: %w", projectErr)
 	}
 
 	user := &models.User{

--- a/test/int/bootstrap/server.go
+++ b/test/int/bootstrap/server.go
@@ -36,6 +36,7 @@ func NewServerManager(sessionFactory db.SessionFactory, dbConfig *config.Databas
 			},
 			Database:        dbConfig,
 			GitHubOAuth:     &config.GitHubOAuthConfig{},
+			GitHubApp:       &config.GitHubAppConfig{},
 			PlatformCluster: &config.ClusterConfig{},
 		},
 		port:           ServerPort,


### PR DESCRIPTION
## 📝 What this does
Lets cloud users sign in with GitHub and connect repos by installing one platform-wide GitHub App, instead of every org creating its own app through the manifest flow. GitHub credentials now live in the installer's bootstrap secret, so upgrades stop wiping them.

## 🏗️ Architecture
One GitHub App per environment serves both jobs: its client id/secret drive OAuth login, and the app itself is what users install. The per-org manifest flow stays as the fallback for self-hosted installs without `GITHUB_APP_*` config.

### Platform install flow
```mermaid
sequenceDiagram
    participant B as Browser (popup)
    participant H as Hub
    participant G as GitHub
    B->>H: POST …/github/manifest
    H-->>B: install URL + single-use state (no manifest)
    B->>G: /apps/slug/installations/new?state=…
    G--)H: webhook installation.created (no org link yet → acked)
    G->>H: GET …/github/setup?installation_id&state
    H->>G: GET /app/installations/{id} (verify)
    H->>H: bind installation to org, status installed
    H-->>B: 302 back to the git integrations page
```

Key decisions:
- Platform credentials are never stored per org — they resolve from config at read time, so key rotation is an env change with no stale copies.
- The setup callback is what links an installation to an org (via the single-use state). Webhooks cannot do it: every org shares one app id.
- Rows using the platform app store no credentials, and the webhook app-id scan skips them — a match there would hand a delivery, and later repo tokens, to the wrong org.

## 🔌 API Reference
| Method | Route | Auth | Request | Response |
|--------|-------|------|---------|----------|
| **GET** | `/api/v1/git-integrations/github/setup` | state-validated | `?installation_id&state` | `302` to git integrations page |

`POST …/github/manifest` now returns no `manifest` field in platform mode; `github_url` points at the app's install page.

## 🔀 Changes
- Added platform GitHub App mode behind `GITHUB_APP_ID/SLUG/PRIVATE_KEY/WEBHOOK_SECRET`, with a setup callback that binds installations to orgs
- Webhook resolution now tries the stored installation row before the app-id scan; unresolvable installation events are acked instead of retried
- Installer accepts and persists GitHub credentials in the bootstrap secret (`--github-client-id/-secret`, `--github-app-*`) and renders them into the api-server CR; partial app flag sets are rejected
- Fixed the derived OAuth redirect to point at the SPA callback page instead of the JSON API route, and always render `SERVER_EXTERNAL_URL` from the domain
- Manifest apps additionally request issues:read and subscribe to issue_comment for upcoming PR-comment features

## 🧪 How to test
- [ ] Run `stackdome-install upgrade` with the six GitHub flags; check the bootstrap secret and api-server CR carry them
- [ ] Run a flagless upgrade after that; check credentials survive
- [ ] Sign in with GitHub from the login page
- [ ] Connect GitHub from git integrations with `GITHUB_APP_*` set; popup goes straight to the install page and lands back installed
- [ ] Connect a second GitHub account by re-running the flow; repos from both accounts appear
- [ ] With `GITHUB_APP_*` unset, the per-org manifest flow behaves as before