### PR TITLE
Fix: allow the GitHub App setup callback through auth middleware

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -158,18 +158,25 @@ func injectLoggerMiddleware(next http.Handler, baseLogger applogger.Logger) http
 	})
 }
 
+// publicAPIPaths are the routes that skip authentication: signup/login,
+// browser redirects arriving from GitHub (state-validated), and the
+// HMAC-verified webhook receiver. A GitHub redirect route missing from this
+// list dies in the JWT middleware with "Authorization header missing".
+var publicAPIPaths = []string{
+	"^/api/v1/user-signup",
+	"^/api/v1/auth",
+	"^/api/v1/config$",
+	"^/api/v1/invites/[^/]+/info$",
+	"^/api/v1/git-integrations/github/manifest/callback$",
+	"^/api/v1/git-integrations/github/setup$",
+	"^/api/v1/webhooks/github$",
+	"^/health",
+}
+
 func setupAuthenticationMiddleWare(mainHandler http.Handler, env environment.EnvImpl) http.Handler {
 	authenticationHandler := NewAuthSelectHandler(AuthSelectorHandlerSpec{
 		MainHandler: mainHandler,
-		PublicPaths: []string{
-			"^/api/v1/user-signup",
-			"^/api/v1/auth",
-			"^/api/v1/config$",
-			"^/api/v1/invites/[^/]+/info$",
-			"^/api/v1/git-integrations/github/manifest/callback$",
-			"^/api/v1/webhooks/github$",
-			"^/health",
-		},
+		PublicPaths: publicAPIPaths,
 		// Set JWT authentication as the default handler.
 		DefaultAuthHandler: auth.NewJwtAuthnHandler(mainHandler, auth.JWTAuthnHandlerSpec{
 			JWTSecret:  []byte(env.Environment().Config.JwtSecret),

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"regexp"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Server Suite")
+}
+
+var _ = Describe("publicAPIPaths", func() {
+	matches := func(path string) bool {
+		for _, expr := range publicAPIPaths {
+			if regexp.MustCompile(expr).MatchString(path) {
+				return true
+			}
+		}
+		return false
+	}
+
+	It("lets the unauthenticated GitHub routes through", func() {
+		// Browser redirects from GitHub and the webhook receiver carry no JWT;
+		// each is protected by its own mechanism (state / HMAC).
+		Expect(matches("/api/v1/git-integrations/github/manifest/callback")).To(BeTrue())
+		Expect(matches("/api/v1/git-integrations/github/setup")).To(BeTrue())
+		Expect(matches("/api/v1/webhooks/github")).To(BeTrue())
+	})
+
+	It("keeps the git-integrations API authenticated", func() {
+		Expect(matches("/api/v1/organizations/org-1/git-integrations")).To(BeFalse())
+		Expect(matches("/api/v1/git-integrations/github/manifest")).To(BeFalse())
+		Expect(matches("/api/v1/stacks")).To(BeFalse())
+	})
+})


### PR DESCRIPTION
## 📝 What this does
Unblocks the platform GitHub App install flow on stackdome.io: GitHub's post-install redirect to the setup callback was rejected by the JWT middleware with "Authorization header missing", so installations never got bound to an org.

## 🔀 Changes
- Added `/api/v1/git-integrations/github/setup` to the public paths list — the route is state-validated, like the manifest callback next to it
- Extracted the list to a named var and added a test pinning the three unauthenticated GitHub routes, so the next GitHub redirect route can't silently miss the list

## 🧪 How to test
- [ ] Connect GitHub on stackdome.io, install the app; the popup lands back on git integrations with the account installed