### PR TITLE
Fix: self-heal GitHub App setup state and platform-mode account adds

### DIFF
--- a/frontend/src/hooks/tests/use-github-setup-landing.test.ts
+++ b/frontend/src/hooks/tests/use-github-setup-landing.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
-import { useGithubSetupLanding, GITHUB_APP_INSTALLED_MESSAGE } from "../use-github-setup-landing";
+import {
+  useGithubSetupLanding,
+  GITHUB_APP_INSTALLED_MESSAGE,
+  GITHUB_APP_SETUP_ERROR_MESSAGE,
+} from "../use-github-setup-landing";
 
 describe("useGithubSetupLanding", () => {
   const originalOpener = window.opener;
@@ -26,6 +30,20 @@ describe("useGithubSetupLanding", () => {
 
     expect(postMessage).toHaveBeenCalledWith(
       { type: GITHUB_APP_INSTALLED_MESSAGE },
+      window.location.origin,
+    );
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("relays a setup_error to the opener and closes", () => {
+    const postMessage = vi.fn();
+    Object.defineProperty(window, "opener", { value: { postMessage }, writable: true });
+    window.history.replaceState({}, "", "/?setup_error=the%20link%20expired");
+
+    renderHook(() => useGithubSetupLanding());
+
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: GITHUB_APP_SETUP_ERROR_MESSAGE, reason: "the link expired" },
       window.location.origin,
     );
     expect(closeSpy).toHaveBeenCalled();

--- a/frontend/src/hooks/use-github-connect.ts
+++ b/frontend/src/hooks/use-github-connect.ts
@@ -6,7 +6,10 @@ import {
 } from "@/api/git-integrations";
 import { getErrorMessage } from "@/api/client";
 import { getCurrentOrganizationId } from "@/lib/common";
-import { GITHUB_APP_INSTALLED_MESSAGE } from "@/hooks/use-github-setup-landing";
+import {
+  GITHUB_APP_INSTALLED_MESSAGE,
+  GITHUB_APP_SETUP_ERROR_MESSAGE,
+} from "@/hooks/use-github-setup-landing";
 import {
   GIT_INTEGRATION_TYPE_GITHUB_APP,
   STATUS_INSTALLED,
@@ -134,8 +137,12 @@ export function useGithubConnect(): GithubConnect {
     if (state !== "waiting") return;
     const onMessage = (ev: MessageEvent) => {
       if (ev.origin !== window.location.origin) return;
-      if ((ev.data as { type?: string })?.type === GITHUB_APP_INSTALLED_MESSAGE) {
+      const data = ev.data as { type?: string; reason?: string };
+      if (data?.type === GITHUB_APP_INSTALLED_MESSAGE) {
         setState("connected");
+      } else if (data?.type === GITHUB_APP_SETUP_ERROR_MESSAGE) {
+        setError(data.reason ?? "The GitHub App install failed.");
+        setState("error");
       }
     };
     window.addEventListener("message", onMessage);

--- a/frontend/src/hooks/use-github-setup-landing.ts
+++ b/frontend/src/hooks/use-github-setup-landing.ts
@@ -2,20 +2,25 @@ import { useEffect } from "react";
 
 /** Message a GitHub-App-install popup posts to its opener before closing. */
 export const GITHUB_APP_INSTALLED_MESSAGE = "stackdome:github-app-installed";
+export const GITHUB_APP_SETUP_ERROR_MESSAGE = "stackdome:github-app-setup-error";
 
 /**
  * GitHub's App setup URL is the hub root, so after an install the popup lands
- * on the SPA with ?setup_action=install. When that happens inside a popup
- * (window.opener set), notify the opener and close; the opener's connect flow
- * (use-github-connect) is listening.
+ * on the SPA with ?setup_action=install (or ?setup_error=<reason> when the
+ * callback failed). When that happens inside a popup (window.opener set),
+ * notify the opener and close; the opener's connect flow (use-github-connect)
+ * is listening. Outside a popup the page's own setup_error handling toasts.
  */
 export function useGithubSetupLanding(): void {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    if (!params.get("setup_action")) return;
+    const setupError = params.get("setup_error");
+    if (!params.get("setup_action") && !setupError) return;
     if (!window.opener) return;
     (window.opener as Window).postMessage(
-      { type: GITHUB_APP_INSTALLED_MESSAGE },
+      setupError
+        ? { type: GITHUB_APP_SETUP_ERROR_MESSAGE, reason: setupError }
+        : { type: GITHUB_APP_INSTALLED_MESSAGE },
       window.location.origin,
     );
     window.close();

--- a/frontend/src/pages/git-integrations/components/integration-row.tsx
+++ b/frontend/src/pages/git-integrations/components/integration-row.tsx
@@ -85,12 +85,15 @@ export function IntegrationRow({
   onVerify,
   onRemove,
   onUpdateCredentials,
+  onAddAccount,
 }: {
   integration: GitIntegration;
   onVerify: (integration: GitIntegration) => void;
   onRemove: (integration: GitIntegration) => void;
   /** Opens the update-credentials dialog for this row (credentials-type only). */
   onUpdateCredentials?: (integration: GitIntegration) => void;
+  /** Starts the install flow for another GitHub account (github_app only). */
+  onAddAccount?: (integration: GitIntegration) => void;
 }) {
   const [installations, setInstallations] = useState<GitInstallation[]>([]);
   const requestSeq = useRef(0);
@@ -167,6 +170,13 @@ export function IntegrationRow({
           onVerify={isGithubApp ? undefined : () => onVerify(integration)}
           onUpdateCredentials={
             isGithubApp || !onUpdateCredentials ? undefined : () => onUpdateCredentials(integration)
+          }
+          onAddAccount={
+            // BYO rows already have the direct manageUrl link; only platform
+            // rows (no install_url) need the state-minting flow.
+            isGithubApp && !integration.install_url && onAddAccount
+              ? () => onAddAccount(integration)
+              : undefined
           }
           manageUrl={isGithubApp ? integration.install_url : undefined}
           onRemove={() => onRemove(integration)}

--- a/frontend/src/pages/git-integrations/components/row-menu.tsx
+++ b/frontend/src/pages/git-integrations/components/row-menu.tsx
@@ -11,9 +11,15 @@ import {
 export function RowMenu({
   onVerify,
   onUpdateCredentials,
+  onAddAccount,
   manageUrl,
   onRemove,
 }: {
+  /** Platform-app rows: starts the install flow for another account. Same
+      "Manage on GitHub" label as BYO's manageUrl link, but it must mint a
+      fresh single-use state per click — a bare install link can't bind an
+      installation to the org on the shared platform app. */
+  onAddAccount?: () => void;
   /** Direct verification only works for credentials-type integrations
       (backend rejects github_app: access there flows through per-installation
       tokens, not stored credentials). Omit to hide the item. */
@@ -25,7 +31,7 @@ export function RowMenu({
   manageUrl?: string;
   onRemove: () => void;
 }) {
-  const hasPrimaryItems = !!(onVerify || onUpdateCredentials || manageUrl);
+  const hasPrimaryItems = !!(onVerify || onUpdateCredentials || onAddAccount || manageUrl);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -55,6 +61,12 @@ export function RowMenu({
           <DropdownMenuItem onSelect={() => setTimeout(() => onUpdateCredentials(), 0)}>
             <KeyRound className="h-4 w-4" />
             Update credentials
+          </DropdownMenuItem>
+        )}
+        {onAddAccount && (
+          <DropdownMenuItem onSelect={() => setTimeout(() => onAddAccount(), 0)}>
+            <ExternalLink className="h-4 w-4" />
+            Manage on GitHub
           </DropdownMenuItem>
         )}
         {manageUrl && (

--- a/frontend/src/pages/git-integrations/index.tsx
+++ b/frontend/src/pages/git-integrations/index.tsx
@@ -12,6 +12,7 @@ import {
 import { getErrorMessage } from "@/api/client";
 import { getCurrentOrganizationId } from "@/lib/common";
 import { useBreadcrumb } from "@/hooks/use-breadcrumb";
+import { useGithubConnect } from "@/hooks/use-github-connect";
 import { GIT_INTEGRATION_TYPE_GITHUB_APP } from "@/lib/git-integrations";
 import { IntegrationsErrorState, IntegrationsEmptyState } from "./components/page-states";
 import { IntegrationRow } from "./components/integration-row";
@@ -28,10 +29,38 @@ export default function GitIntegrationsPage() {
   const confirm = useConfirm();
   const [wizardOpen, setWizardOpen] = useState(false);
   const { setCustomLabel } = useBreadcrumb();
+  const github = useGithubConnect();
 
   useEffect(() => {
     setCustomLabel("/git-integrations", "Git providers");
   }, [setCustomLabel]);
+
+  // A failed install callback lands back here with the reason in the URL
+  // (the popup itself relays it to its opener and closes).
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const setupError = params.get("setup_error");
+    if (!setupError) return;
+    toast({ title: "GitHub App install failed", description: setupError, variant: "destructive" });
+    params.delete("setup_error");
+    const query = params.toString();
+    window.history.replaceState(null, "", window.location.pathname + (query ? `?${query}` : ""));
+  }, [toast]);
+
+  // "Add GitHub account" runs the same connect flow as the wizard; the hook
+  // polls until the new installation is bound.
+  useEffect(() => {
+    if (github.state === "connected") void refresh();
+    if (github.state === "error" && github.error) {
+      toast({ title: "GitHub App install failed", description: github.error, variant: "destructive" });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [github.state, github.error]);
+
+  const addAccount = () => {
+    void github.connect();
+    toast({ title: "Finish the install in the GitHub popup", description: "Pick the account or organization to add." });
+  };
 
   const refresh = useCallback(async () => {
     const orgId = getCurrentOrganizationId();
@@ -129,6 +158,7 @@ export default function GitIntegrationsPage() {
                   onVerify={setVerifying}
                   onRemove={(i) => void remove(i)}
                   onUpdateCredentials={setEditing}
+                  onAddAccount={addAccount}
                 />
               ))}
             </div>

--- a/pkg/handlers/git_integration_handler.go
+++ b/pkg/handlers/git_integration_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/Stackdome/stackdome/pkg/api/openapi"
@@ -158,10 +159,17 @@ func (h *gitIntegrationHandler) GitHubManifestCallback(w http.ResponseWriter, r 
 
 	redirectURL, serr := h.gitIntegrationService.HandleGitHubManifestCallback(r.Context(), code, state)
 	if serr != nil {
-		handleError(r.Context(), w, serr)
+		redirectSetupError(w, r, serr)
 		return
 	}
 	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// redirectSetupError sends the browser back to the SPA with the failure
+// reason instead of a raw JSON body — these callbacks render in a popup a
+// person is looking at.
+func redirectSetupError(w http.ResponseWriter, r *http.Request, serr *errors.ServiceError) {
+	http.Redirect(w, r, "/git-integrations?setup_error="+url.QueryEscape(serr.Reason), http.StatusFound)
 }
 
 // GitHubAppSetup is unauthenticated: the browser lands here from GitHub after
@@ -170,13 +178,13 @@ func (h *gitIntegrationHandler) GitHubManifestCallback(w http.ResponseWriter, r 
 func (h *gitIntegrationHandler) GitHubAppSetup(w http.ResponseWriter, r *http.Request) {
 	installationID, err := strconv.ParseInt(r.URL.Query().Get("installation_id"), 10, 64)
 	if err != nil {
-		handleError(r.Context(), w, errors.MalformedRequest("installation_id must be a number"))
+		redirectSetupError(w, r, errors.MalformedRequest("installation_id must be a number"))
 		return
 	}
 
 	redirectURL, serr := h.gitIntegrationService.HandleGitHubAppSetup(r.Context(), installationID, r.URL.Query().Get("state"))
 	if serr != nil {
-		handleError(r.Context(), w, serr)
+		redirectSetupError(w, r, serr)
 		return
 	}
 	http.Redirect(w, r, redirectURL, http.StatusFound)

--- a/pkg/services/git_integration_github_app.go
+++ b/pkg/services/git_integration_github_app.go
@@ -87,7 +87,7 @@ func (s *gitIntegrationService) CreateGitHubAppManifest(ctx context.Context, org
 		return nil, serr
 	}
 
-	state := fmt.Sprintf("%s:%s", uuid.NewString(), integration.ID)
+	state := appFlowState(integration)
 	if serr := s.oauthStates.Create(ctx, &models.OAuthState{
 		State:     state,
 		Provider:  models.OAuthProviderGitHubAppManifest,
@@ -136,7 +136,7 @@ func (s *gitIntegrationService) CreateGitHubAppManifest(ctx context.Context, org
 // callback and is what binds the new installation to this org. The row stores
 // no credentials — platform creds resolve from config at read time.
 func (s *gitIntegrationService) platformAppInstallFlow(ctx context.Context, integration *models.GitIntegration) (*models.GitHubAppManifestFlow, *errors.ServiceError) {
-	state := fmt.Sprintf("%s:%s", uuid.NewString(), integration.ID)
+	state := appFlowState(integration)
 	if serr := s.oauthStates.Create(ctx, &models.OAuthState{
 		State:     state,
 		Provider:  models.OAuthProviderGitHubAppInstall,
@@ -168,17 +168,9 @@ func (s *gitIntegrationService) HandleGitHubAppSetup(ctx context.Context, instal
 		return "", errors.BadRequest("the GitHub App setup link has expired; restart the flow")
 	}
 
-	_, integrationID, found := strings.Cut(record.State, ":")
-	if !found || integrationID == "" {
-		return "", errors.BadRequest("malformed state parameter")
-	}
-
-	integration, serr := s.store.GetByID(ctx, integrationID)
+	integration, serr := s.stateIntegration(ctx, record.State)
 	if serr != nil {
 		return "", serr
-	}
-	if integration.Type != models.GitIntegrationTypeGitHubApp {
-		return "", errors.BadRequest("state does not reference a GitHub App integration")
 	}
 
 	creds, serr := s.appCredentials(integration)
@@ -260,17 +252,9 @@ func (s *gitIntegrationService) HandleGitHubManifestCallback(ctx context.Context
 		return "", errors.BadRequest("the GitHub App setup link has expired; restart the flow")
 	}
 
-	_, integrationID, found := strings.Cut(record.State, ":")
-	if !found || integrationID == "" {
-		return "", errors.BadRequest("malformed state parameter")
-	}
-
-	integration, serr := s.store.GetByID(ctx, integrationID)
+	integration, serr := s.stateIntegration(ctx, record.State)
 	if serr != nil {
 		return "", serr
-	}
-	if integration.Type != models.GitIntegrationTypeGitHubApp {
-		return "", errors.BadRequest("state does not reference a GitHub App integration")
 	}
 
 	creds, err := s.githubApp.ConvertManifestCode(ctx, code)
@@ -299,6 +283,35 @@ func (s *gitIntegrationService) HandleGitHubManifestCallback(ctx context.Context
 	}
 
 	return githubAppInstallURL(creds.Slug), nil
+}
+
+// appFlowState is the single-use state minted when a GitHub App flow starts:
+// "nonce:orgID:integrationID". It comes back on the unauthenticated callback
+// and is what binds the result to the org.
+func appFlowState(integration *models.GitIntegration) string {
+	return fmt.Sprintf("%s:%s:%s", uuid.NewString(), integration.OrganisationID, integration.ID)
+}
+
+// stateIntegration resolves the integration a flow state points at. If the
+// row was deleted mid-flow (user removed the pending card, then reconnected)
+// the org's current GitHub App row takes its place, so the callback still
+// binds instead of dead-ending on a not-found.
+func (s *gitIntegrationService) stateIntegration(ctx context.Context, state string) (*models.GitIntegration, *errors.ServiceError) {
+	parts := strings.SplitN(state, ":", 3)
+	if len(parts) != 3 || parts[1] == "" || parts[2] == "" {
+		return nil, errors.BadRequest("malformed state parameter")
+	}
+	integration, serr := s.store.GetByID(ctx, parts[2])
+	if serr != nil && serr.Is404() {
+		integration, serr = s.store.GetGitHubAppForOrg(ctx, parts[1])
+	}
+	if serr != nil {
+		return nil, serr
+	}
+	if integration.Type != models.GitIntegrationTypeGitHubApp {
+		return nil, errors.BadRequest("state does not reference a GitHub App integration")
+	}
+	return integration, nil
 }
 
 func githubAppInstallURL(slug string) string {

--- a/pkg/services/git_integration_github_app_test.go
+++ b/pkg/services/git_integration_github_app_test.go
@@ -168,7 +168,7 @@ func TestHandleGitHubManifestCallbackSealsCredentials(t *testing.T) {
 		Status:         models.GitIntegrationStatusPendingInstall,
 	}
 	deps.oauthStates.EXPECT().Consume(gomock.Any(), "state-1:gi-app", models.OAuthProviderGitHubAppManifest).
-		Return(&models.OAuthState{State: "state-1:gi-app", CreatedAt: time.Now().UTC()}, nil)
+		Return(&models.OAuthState{State: "state-1:org-1:gi-app", CreatedAt: time.Now().UTC()}, nil)
 	deps.store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(integration, nil)
 	deps.appClient.EXPECT().ConvertManifestCode(gomock.Any(), "tmp-code").Return(&githubapp.AppCredentials{
 		AppID:         4242,
@@ -476,7 +476,7 @@ var _ = Describe("platform GitHub App", func() {
 
 		It("binds the new installation to the org that started the flow", func() {
 			deps.oauthStates.EXPECT().Consume(gomock.Any(), "state-1", models.OAuthProviderGitHubAppInstall).
-				Return(&models.OAuthState{State: "uuid:gi-app", CreatedAt: time.Now().UTC()}, nil)
+				Return(&models.OAuthState{State: "uuid:org-1:gi-app", CreatedAt: time.Now().UTC()}, nil)
 			deps.store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(integration, nil)
 			deps.appClient.EXPECT().GetInstallation(gomock.Any(), gomock.Any(), int64(77)).Return(&githubapp.Installation{
 				ID: 77, AccountLogin: "acme", AccountType: string(models.GitAccountTypeOrganization), RepositorySelection: "all",
@@ -503,9 +503,43 @@ var _ = Describe("platform GitHub App", func() {
 			Expect(integration.Status).To(Equal(models.GitIntegrationStatusInstalled))
 		})
 
+		It("falls back to the org's current row when the state's row was deleted mid-flow", func() {
+			recreated := &models.GitIntegration{
+				ID:             "gi-new",
+				OrganisationID: "org-1",
+				Type:           models.GitIntegrationTypeGitHubApp,
+				Status:         models.GitIntegrationStatusPendingInstall,
+				DataHash:       gitIntegrationDataHash(nil),
+			}
+			deps.oauthStates.EXPECT().Consume(gomock.Any(), "state-1", models.OAuthProviderGitHubAppInstall).
+				Return(&models.OAuthState{State: "uuid:org-1:gi-app", CreatedAt: time.Now().UTC()}, nil)
+			deps.store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(nil, errors.NotFound("gone"))
+			deps.store.EXPECT().GetGitHubAppForOrg(gomock.Any(), "org-1").Return(recreated, nil)
+			deps.appClient.EXPECT().GetInstallation(gomock.Any(), gomock.Any(), int64(77)).Return(&githubapp.Installation{
+				ID: 77, AccountLogin: "acme", AccountType: string(models.GitAccountTypeOrganization), RepositorySelection: "all",
+			}, nil)
+
+			var upserted *models.GitInstallation
+			deps.installations.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, in *models.GitInstallation) (*models.GitInstallation, *errors.ServiceError) {
+					upserted = in
+					return in, nil
+				})
+			deps.installations.EXPECT().ListByIntegrationID(gomock.Any(), "gi-new").
+				Return([]*models.GitInstallation{{InstallationID: 77}}, nil)
+			deps.store.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, in *models.GitIntegration) (*models.GitIntegration, *errors.ServiceError) {
+					return in, nil
+				})
+
+			_, serr := svc.HandleGitHubAppSetup(context.Background(), 77, "state-1")
+			Expect(serr).To(BeNil())
+			Expect(upserted.GitIntegrationID).To(Equal("gi-new"))
+		})
+
 		It("rejects an installation the platform app does not have", func() {
 			deps.oauthStates.EXPECT().Consume(gomock.Any(), "state-1", models.OAuthProviderGitHubAppInstall).
-				Return(&models.OAuthState{State: "uuid:gi-app", CreatedAt: time.Now().UTC()}, nil)
+				Return(&models.OAuthState{State: "uuid:org-1:gi-app", CreatedAt: time.Now().UTC()}, nil)
 			deps.store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(integration, nil)
 			deps.appClient.EXPECT().GetInstallation(gomock.Any(), gomock.Any(), int64(77)).Return(nil, fmt.Errorf("404 not found"))
 


### PR DESCRIPTION
## 📝 What this does
Makes the platform GitHub App install flow survive a mid-flow retry: a stale setup state no longer strands the GitHub installation, callback failures land on a readable error page instead of raw JSON, and platform-mode integrations finally get a menu action to add more GitHub accounts.

## 🔀 Changes
- Flow state now carries the org id; when the integration row it references was deleted and recreated mid-flow, the setup and manifest callbacks bind to the org's current row instead of failing with not-found
- Setup callback errors redirect to the git-providers page with the reason, and the install popup relays it to its opener before closing
- Platform-mode rows get a "Manage on GitHub" menu item that mints a fresh single-use state per click; a bare install link can't bind an installation on the shared app, so BYO rows keep their direct link and platform rows run the connect flow
- Landing page toasts the failure reason when the callback lands outside a popup

## 🧪 How to test
- [ ] Connect GitHub, remove the pending integration, reconnect, finish the install in the popup — installation binds instead of erroring
- [ ] Break the state (expired or malformed) and finish an install — popup closes and the wizard shows the failure reason
- [ ] On a connected platform-mode row, open the row menu → Manage on GitHub → install to a second account — both installations listed