### PR TITLE
Fix: uninstall GitHub App installations when integration is deleted

### DIFF
--- a/pkg/clients/githubapp/client.go
+++ b/pkg/clients/githubapp/client.go
@@ -84,6 +84,8 @@ type Client interface {
 	ListInstallations(ctx context.Context, creds *AppCredentials) ([]Installation, error)
 	// GetInstallation fetches one installation of the app by its GitHub id.
 	GetInstallation(ctx context.Context, creds *AppCredentials, installationID int64) (*Installation, error)
+	// DeleteInstallation uninstalls the app from the installation's account.
+	DeleteInstallation(ctx context.Context, creds *AppCredentials, installationID int64) error
 	// MintInstallationToken creates a short-lived installation access token.
 	MintInstallationToken(ctx context.Context, creds *AppCredentials, installationID int64) (*Token, error)
 	// ListInstallationRepos lists one page of repositories the installation
@@ -240,6 +242,17 @@ func (c *client) GetInstallation(ctx context.Context, creds *AppCredentials, ins
 		RepositorySelection: in.GetRepositorySelection(),
 		Suspended:           !in.GetSuspendedAt().IsZero(),
 	}, nil
+}
+
+func (c *client) DeleteInstallation(ctx context.Context, creds *AppCredentials, installationID int64) error {
+	gh, err := c.appClient(creds)
+	if err != nil {
+		return err
+	}
+	if _, err := gh.Apps.DeleteInstallation(ctx, installationID); err != nil {
+		return fmt.Errorf("failed to delete installation %d: %w", installationID, err)
+	}
+	return nil
 }
 
 func (c *client) MintInstallationToken(ctx context.Context, creds *AppCredentials, installationID int64) (*Token, error) {

--- a/pkg/mocks/mock_githubapp_client.go
+++ b/pkg/mocks/mock_githubapp_client.go
@@ -56,6 +56,20 @@ func (mr *MockGitHubAppClientMockRecorder) ConvertManifestCode(ctx, code any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertManifestCode", reflect.TypeOf((*MockGitHubAppClient)(nil).ConvertManifestCode), ctx, code)
 }
 
+// DeleteInstallation mocks base method.
+func (m *MockGitHubAppClient) DeleteInstallation(ctx context.Context, creds *githubapp.AppCredentials, installationID int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteInstallation", ctx, creds, installationID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteInstallation indicates an expected call of DeleteInstallation.
+func (mr *MockGitHubAppClientMockRecorder) DeleteInstallation(ctx, creds, installationID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstallation", reflect.TypeOf((*MockGitHubAppClient)(nil).DeleteInstallation), ctx, creds, installationID)
+}
+
 // GetInstallation mocks base method.
 func (m *MockGitHubAppClient) GetInstallation(ctx context.Context, creds *githubapp.AppCredentials, installationID int64) (*githubapp.Installation, error) {
 	m.ctrl.T.Helper()

--- a/pkg/services/git_integration_github_app_test.go
+++ b/pkg/services/git_integration_github_app_test.go
@@ -460,6 +460,25 @@ var _ = Describe("platform GitHub App", func() {
 		})
 	})
 
+	Describe("Delete", func() {
+		It("uninstalls every bound installation from GitHub before deleting the row", func() {
+			integration := &models.GitIntegration{
+				ID:             "gi-app",
+				OrganisationID: "org-1",
+				Type:           models.GitIntegrationTypeGitHubApp,
+				Status:         models.GitIntegrationStatusInstalled,
+			}
+			deps.store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(integration, nil)
+			deps.installations.EXPECT().ListByIntegrationID(gomock.Any(), "gi-app").
+				Return([]*models.GitInstallation{{InstallationID: 77}, {InstallationID: 88}}, nil)
+			deps.appClient.EXPECT().DeleteInstallation(gomock.Any(), gomock.Any(), int64(77)).Return(nil)
+			deps.appClient.EXPECT().DeleteInstallation(gomock.Any(), gomock.Any(), int64(88)).Return(fmt.Errorf("github down"))
+			deps.store.EXPECT().Delete(gomock.Any(), "gi-app").Return(nil)
+
+			Expect(svc.Delete(context.Background(), "gi-app")).To(BeNil())
+		})
+	})
+
 	Describe("HandleGitHubAppSetup", func() {
 		var integration *models.GitIntegration
 

--- a/pkg/services/git_integration_service.go
+++ b/pkg/services/git_integration_service.go
@@ -225,7 +225,34 @@ func (s *gitIntegrationService) Delete(ctx context.Context, ID string) *errors.S
 	if permErr := s.permissions.Check(ctx, integration.OrganisationID, auth.ResourceGitIntegrations, ID, auth.ActionDelete); permErr != nil {
 		return permErr
 	}
+	s.uninstallFromGitHub(ctx, integration)
 	return s.store.Delete(ctx, ID)
+}
+
+// uninstallFromGitHub removes the app from every account this integration
+// bound. Without it a deleted-then-reconnected org dead-ends: GitHub shows
+// "Configure" for a still-installed account, never fires the setup callback,
+// and the new pending row can never bind. Best-effort — a GitHub outage must
+// not block the local delete; a leftover installation is recoverable by hand.
+func (s *gitIntegrationService) uninstallFromGitHub(ctx context.Context, integration *models.GitIntegration) {
+	if integration.Type != models.GitIntegrationTypeGitHubApp {
+		return
+	}
+	creds, serr := s.appCredentials(integration)
+	if serr != nil {
+		s.logger.Warn(ctx, "skipping GitHub uninstall for integration '%s': %s", integration.ID, serr.Reason)
+		return
+	}
+	installations, serr := s.installations.ListByIntegrationID(ctx, integration.ID)
+	if serr != nil {
+		s.logger.Warn(ctx, "skipping GitHub uninstall for integration '%s': %s", integration.ID, serr.Reason)
+		return
+	}
+	for _, in := range installations {
+		if err := s.githubApp.DeleteInstallation(ctx, creds, in.InstallationID); err != nil {
+			s.logger.Warn(ctx, "failed to uninstall GitHub installation %d: %s", in.InstallationID, err.Error())
+		}
+	}
 }
 
 func (s *gitIntegrationService) Verify(ctx context.Context, ID, repoURL string) *errors.ServiceError {


### PR DESCRIPTION
## 📝 What this does
Removing a GitHub integration now also uninstalls the app from the GitHub accounts it was bound to. Without this, reconnecting after a delete dead-ends: GitHub shows "Configure" for the still-installed account, never fires the setup callback, and the new pending integration can never bind an installation.

## 🔀 Changes
- Deleting a GitHub App integration calls the app API to remove each bound installation before deleting the row
- Uninstall is best-effort: a GitHub failure logs a warning and never blocks the local delete (a leftover installation is recoverable by hand)
- Added the delete-installation call to the GitHub App client and regenerated its mock

## 🧪 How to test
- [ ] Connect GitHub and finish an install
- [ ] Remove the integration — the app disappears from the account's installed apps on GitHub
- [ ] Reconnect — GitHub shows the fresh install page (not Configure) and the installation binds