### PR TITLE
Fix: reject GitHub installations already bound to another organisation

### DIFF
--- a/pkg/services/git_integration_github_app.go
+++ b/pkg/services/git_integration_github_app.go
@@ -187,6 +187,17 @@ func (s *gitIntegrationService) HandleGitHubAppSetup(ctx context.Context, instal
 		return "", errors.BadRequest("installation %d is suspended on GitHub", installationID)
 	}
 
+	// One GitHub account, one Stackdome organisation. A GitHub account can
+	// hold only one installation of the shared app, so re-binding it here
+	// would silently move repos between orgs and break webhook attribution.
+	existing, serr := s.installations.GetByInstallationID(ctx, in.ID)
+	if serr != nil && !serr.Is404() {
+		return "", serr
+	}
+	if serr == nil && existing.GitIntegrationID != integration.ID {
+		return "", errors.Conflict("the GitHub account '%s' is already connected to another organisation; disconnect it there first", in.AccountLogin)
+	}
+
 	if _, serr := s.installations.Upsert(ctx, &models.GitInstallation{
 		GitIntegrationID:    integration.ID,
 		InstallationID:      in.ID,

--- a/pkg/services/git_integration_github_app_test.go
+++ b/pkg/services/git_integration_github_app_test.go
@@ -481,6 +481,7 @@ var _ = Describe("platform GitHub App", func() {
 			deps.appClient.EXPECT().GetInstallation(gomock.Any(), gomock.Any(), int64(77)).Return(&githubapp.Installation{
 				ID: 77, AccountLogin: "acme", AccountType: string(models.GitAccountTypeOrganization), RepositorySelection: "all",
 			}, nil)
+			deps.installations.EXPECT().GetByInstallationID(gomock.Any(), int64(77)).Return(nil, errors.NotFound("none"))
 
 			var upserted *models.GitInstallation
 			deps.installations.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -518,6 +519,7 @@ var _ = Describe("platform GitHub App", func() {
 			deps.appClient.EXPECT().GetInstallation(gomock.Any(), gomock.Any(), int64(77)).Return(&githubapp.Installation{
 				ID: 77, AccountLogin: "acme", AccountType: string(models.GitAccountTypeOrganization), RepositorySelection: "all",
 			}, nil)
+			deps.installations.EXPECT().GetByInstallationID(gomock.Any(), int64(77)).Return(nil, errors.NotFound("none"))
 
 			var upserted *models.GitInstallation
 			deps.installations.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -535,6 +537,21 @@ var _ = Describe("platform GitHub App", func() {
 			_, serr := svc.HandleGitHubAppSetup(context.Background(), 77, "state-1")
 			Expect(serr).To(BeNil())
 			Expect(upserted.GitIntegrationID).To(Equal("gi-new"))
+		})
+
+		It("rejects an installation already bound to another organisation", func() {
+			deps.oauthStates.EXPECT().Consume(gomock.Any(), "state-1", models.OAuthProviderGitHubAppInstall).
+				Return(&models.OAuthState{State: "uuid:org-1:gi-app", CreatedAt: time.Now().UTC()}, nil)
+			deps.store.EXPECT().GetByID(gomock.Any(), "gi-app").Return(integration, nil)
+			deps.appClient.EXPECT().GetInstallation(gomock.Any(), gomock.Any(), int64(77)).Return(&githubapp.Installation{
+				ID: 77, AccountLogin: "acme", AccountType: string(models.GitAccountTypeOrganization), RepositorySelection: "all",
+			}, nil)
+			deps.installations.EXPECT().GetByInstallationID(gomock.Any(), int64(77)).
+				Return(&models.GitInstallation{GitIntegrationID: "gi-other-org", InstallationID: 77}, nil)
+
+			_, serr := svc.HandleGitHubAppSetup(context.Background(), 77, "state-1")
+			Expect(serr).NotTo(BeNil())
+			Expect(serr.Reason).To(ContainSubstring("already connected to another organisation"))
 		})
 
 		It("rejects an installation the platform app does not have", func() {


### PR DESCRIPTION
## 📝 What this does
Enforces one GitHub account per organisation on the shared platform app, the same rule Vercel and Railway apply. A second organisation connecting an already-connected GitHub account now gets a clear error in the wizard instead of polling forever with no feedback.

## 🔀 Changes
- Setup callback rejects binding an installation that a different organisation's integration already owns, with a conflict error telling the user to disconnect it there first
- The owning organisation's own re-runs (repo-access changes, reconnects) still pass through the idempotent upsert

## 🧪 How to test
Requires "Redirect on update" enabled on the GitHub App so Configure → Save reaches the setup callback.
- [ ] Connect a GitHub account from org A — works
- [ ] Connect the same GitHub account from org B, finish on GitHub — popup closes and the wizard shows "already connected to another organisation"
- [ ] From org A, re-run the flow for the same account — still binds fine