### PR TITLE
Fix: preview stacks show a permanent phantom diff, plus canvas and timeline fixes

### DIFF
--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -11,7 +11,9 @@ import {
   BreadcrumbSeparator
 } from "@/components/ui/breadcrumb";
 import { BreadcrumbProvider } from "@/contexts/breadcrumb-context";
+import { PreviewLineageProvider } from "@/contexts/preview-lineage-context";
 import { useBreadcrumb } from "@/hooks/use-breadcrumb";
+import { usePreviewLineage } from "@/hooks/use-preview-lineage";
 import { useGithubSetupLanding } from "@/hooks/use-github-setup-landing";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Separator } from "@/components/ui/separator";
@@ -30,9 +32,23 @@ function AppLayoutContent({
   useGithubSetupLanding();
   const location = useLocation();
   const { customLabels, loadingLabels, nonClickablePaths } = useBreadcrumb();
+  const { lineage } = usePreviewLineage();
 
   // Parse the current path for breadcrumbs
   const pathSegments = location.pathname.split('/').filter(Boolean);
+
+  // A preview stack sits at /stacks/<id>, but it belongs to its preview config —
+  // swap the "Stacks" ancestor for the config that owns it.
+  const previewAncestors: BreadcrumbItemType[] | null = lineage
+    ? [
+        { name: 'Previews', path: '/previews', clickable: true },
+        {
+          name: lineage.configName ?? '...',
+          path: `/previews/${lineage.configId}`,
+          clickable: !!lineage.configName,
+        },
+      ]
+    : null;
 
   // Full-bleed layout for the canvas stack editor: /stacks/new (draft) and
   // /stacks/<id> (existing). A single trailing segment only — not /stacks.
@@ -41,6 +57,7 @@ function AppLayoutContent({
   // Create breadcrumb items based on the current path
   const breadcrumbItems: BreadcrumbItemType[] = [
     { name: 'Home', path: '/', clickable: true },
+    ...(previewAncestors ?? []),
     ...pathSegments.map((segment, index): BreadcrumbItemType => {
       const path = '/' + pathSegments.slice(0, index + 1).join('/');
       const clickable = !nonClickablePaths[path];
@@ -55,7 +72,9 @@ function AppLayoutContent({
       // Otherwise, capitalize the segment
       const name = segment.charAt(0).toUpperCase() + segment.slice(1);
       return { name, path, clickable };
-    }),
+    })
+    // The preview ancestors stand in for "Stacks", so drop that leading crumb.
+    .filter((_, index) => !previewAncestors || index > 0),
   ];
 
   return (
@@ -135,8 +154,10 @@ export function AppLayout({
   children?: React.ReactNode;
 }) {
   return (
-    <BreadcrumbProvider>
-      <AppLayoutContent children={children} />
-    </BreadcrumbProvider>
+    <PreviewLineageProvider>
+      <BreadcrumbProvider>
+        <AppLayoutContent children={children} />
+      </BreadcrumbProvider>
+    </PreviewLineageProvider>
   );
 }

--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -41,13 +41,13 @@ function AppLayoutContent({
   // swap the "Stacks" ancestor for the config that owns it.
   const previewAncestors: BreadcrumbItemType[] | null = lineage
     ? [
-        { name: 'Previews', path: '/previews', clickable: true },
-        {
-          name: lineage.configName ?? '...',
-          path: `/previews/${lineage.configId}`,
-          clickable: !!lineage.configName,
-        },
-      ]
+      { name: 'Previews', path: '/previews', clickable: true },
+      {
+        name: lineage.configName ?? '...',
+        path: `/previews/${lineage.configId}`,
+        clickable: !!lineage.configName,
+      },
+    ]
     : null;
 
   // Full-bleed layout for the canvas stack editor: /stacks/new (draft) and
@@ -74,7 +74,7 @@ function AppLayoutContent({
       return { name, path, clickable };
     })
     // The preview ancestors stand in for "Stacks", so drop that leading crumb.
-    .filter((_, index) => !previewAncestors || index > 0),
+      .filter((_, index) => !previewAncestors || index > 0),
   ];
 
   return (

--- a/frontend/src/components/nav-previews.tsx
+++ b/frontend/src/components/nav-previews.tsx
@@ -6,10 +6,13 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import { usePreviewLineage } from "@/hooks/use-preview-lineage"
 
 export function NavPreviews() {
   const location = useLocation();
-  const isActive = location.pathname.startsWith("/previews");
+  const { lineage } = usePreviewLineage();
+  // A preview stack renders under /stacks, but it belongs to Previews.
+  const isActive = location.pathname.startsWith("/previews") || !!lineage;
 
   return (
     <SidebarMenu>

--- a/frontend/src/components/nav-stacks.tsx
+++ b/frontend/src/components/nav-stacks.tsx
@@ -8,10 +8,13 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import { usePreviewLineage } from "@/hooks/use-preview-lineage"
 
 export function NavStacks() {
   const location = useLocation();
-  const isStacksActive = location.pathname.startsWith('/stacks');
+  const { lineage } = usePreviewLineage();
+  // A preview stack hands its highlight to Previews.
+  const isStacksActive = location.pathname.startsWith('/stacks') && !lineage;
 
   return (
     <SidebarMenu>

--- a/frontend/src/contexts/preview-lineage-context.tsx
+++ b/frontend/src/contexts/preview-lineage-context.tsx
@@ -1,0 +1,46 @@
+import { createContext, useCallback, useState } from "react";
+import type { ReactNode } from "react";
+
+/** Preview-stack labels the API server writes (pkg/models/preview_stack.go). */
+export const PREVIEW_STACK_LABEL = "preview.stackdome.io/preview-stack";
+export const PREVIEW_CONFIG_ID_LABEL = "preview.stackdome.io/config-id";
+
+export interface PreviewLineage {
+  configId: string;
+  /** Config name, or undefined until the config request resolves. */
+  configName?: string;
+}
+
+export type PreviewLineageContextType = {
+  /** Set while the open stack is a preview environment; null otherwise. */
+  lineage: PreviewLineage | null;
+  setLineage: (lineage: PreviewLineage | null) => void;
+};
+
+export const PreviewLineageContext = createContext<PreviewLineageContextType>({
+  lineage: null,
+  setLineage: () => {},
+});
+
+/**
+ * A preview stack lives at /stacks/<id> like any other, so its owning config is
+ * invisible to the chrome. The stack page reads it off the stack's labels and
+ * publishes it here; the breadcrumb and sidebar read it back.
+ */
+export function PreviewLineageProvider({ children }: { children: ReactNode }) {
+  const [lineage, setLineageState] = useState<PreviewLineage | null>(null);
+
+  const setLineage = useCallback((next: PreviewLineage | null) => {
+    setLineageState((prev) => {
+      if (prev === next) return prev;
+      if (prev && next && prev.configId === next.configId && prev.configName === next.configName) return prev;
+      return next;
+    });
+  }, []);
+
+  return (
+    <PreviewLineageContext.Provider value={{ lineage, setLineage }}>
+      {children}
+    </PreviewLineageContext.Provider>
+  );
+}

--- a/frontend/src/hooks/use-preview-lineage.tsx
+++ b/frontend/src/hooks/use-preview-lineage.tsx
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { PreviewLineageContext } from "@/contexts/preview-lineage-context";
+
+export function usePreviewLineage() {
+  return useContext(PreviewLineageContext);
+}

--- a/frontend/src/pages/stacks/components/editor/canvas-editor-shell.tsx
+++ b/frontend/src/pages/stacks/components/editor/canvas-editor-shell.tsx
@@ -432,7 +432,9 @@ export function CanvasEditorShell({
               </>
             )}
           </div>
-          {opsBody && <div className="absolute inset-0 overflow-auto bg-background">{opsBody}</div>}
+          {/* z-20 clears the canvas layer's own z-10 children (the live-view
+              toggle), which stay mounted underneath. */}
+          {opsBody && <div className="absolute inset-0 z-20 overflow-auto bg-background">{opsBody}</div>}
         </div>
       </div>
     </HeaderCollapseContext.Provider>

--- a/frontend/src/pages/stacks/components/editor/index.tsx
+++ b/frontend/src/pages/stacks/components/editor/index.tsx
@@ -707,10 +707,6 @@ export default function CanvasEditorPage() {
     (releaseId: string) => runDeploy(() => rollbackRelease(deployIds.orgId, deployIds.projectName, deployIds.stackId, releaseId), "Rollback started"),
     [runDeploy, deployIds],
   );
-  const onCopyId = useCallback((releaseId: string) => {
-    void navigator.clipboard?.writeText(releaseId);
-    toast({ title: "Release ID copied", variant: "success" });
-  }, [toast]);
 
   // Draft deploy: validates name, creates the stack, starts the first release,
   // and navigates to the new page. There is no separate "create" step — the
@@ -969,7 +965,6 @@ export default function CanvasEditorPage() {
       lifecycle={lifecycle}
       onRollback={onRollback}
       onCancel={onCancelDeploy}
-      onCopyId={onCopyId}
     />
   ) : (
     <div className="text-center text-muted-foreground py-12">Stack ID not available</div>

--- a/frontend/src/pages/stacks/components/editor/index.tsx
+++ b/frontend/src/pages/stacks/components/editor/index.tsx
@@ -103,6 +103,11 @@ export default function CanvasEditorPage() {
   const stackProjectId = fetchedStack?.project_id ?? currentStack?.project_id;
   const canWriteStack = canWrite(stackProjectId ?? "");
 
+  // Navigating straight from one stack to another keeps the previous fetch's
+  // payload until the new one lands — every consumer of savedStack would read
+  // the old stack, and a failed fetch would leave it there for good.
+  useEffect(() => { setFetchedStack(null); }, [id]);
+
   useEffect(() => {
     if (isNewStack) return;
     const path = `/stacks/${id}`;
@@ -188,10 +193,12 @@ export default function CanvasEditorPage() {
     let cancelled = false;
     void getPreviewConfig(deployIds.orgId, deployIds.projectName, previewConfigId)
       .then((config) => {
-        // Name only sharpens the crumb — a failed lookup leaves it loading, not broken.
         if (!cancelled) setLineage({ configId: previewConfigId, configName: config.name });
       })
-      .catch(() => {});
+      .catch(() => {
+        // The crumb only needs a label to be usable; its link works off the id.
+        if (!cancelled) setLineage({ configId: previewConfigId, configName: "Preview" });
+      });
     return () => { cancelled = true; };
   }, [previewConfigId, deployIds.orgId, deployIds.projectName, setLineage]);
 

--- a/frontend/src/pages/stacks/components/editor/index.tsx
+++ b/frontend/src/pages/stacks/components/editor/index.tsx
@@ -45,6 +45,9 @@ import { useReleaseAnchors } from "@/pages/stacks/components/editor/hooks/use-re
 import { mapVolumeToFormData, formResourcesFromSpec } from "@/pages/stacks/lib/spec-to-form";
 import { addonIdsFromConnections } from "@/pages/stacks/lib/connection-mapping";
 import { useBreadcrumb } from "@/hooks/use-breadcrumb";
+import { usePreviewLineage } from "@/hooks/use-preview-lineage";
+import { PREVIEW_CONFIG_ID_LABEL, PREVIEW_STACK_LABEL } from "@/contexts/preview-lineage-context";
+import { getPreviewConfig } from "@/api/preview-configs";
 import { getCurrentOrganizationId } from "@/lib/common";
 import { useResourceProjects } from "@/hooks/use-resource-projects";
 import { useCurrentUser } from "@/hooks/use-current-user";
@@ -89,6 +92,7 @@ export default function CanvasEditorPage() {
   const [nameError, setNameError] = useState<string | undefined>();
 
   const { setCustomLabel, setPathLoading } = useBreadcrumb();
+  const { setLineage } = usePreviewLineage();
   const { toast } = useToast();
   const { projects, projectNameById, defaultProjectName } = useResourceProjects();
   const { canWrite } = useCurrentUser();
@@ -165,6 +169,35 @@ export default function CanvasEditorPage() {
     stackId: savedStack?.id || "",
   }), [savedStack, projectNameById, defaultProjectName]);
   const idsReady = !!deployIds.stackId && !!deployIds.projectName;
+
+  // Preview stacks live at /stacks/<id> but belong to a preview config; publish
+  // that so the breadcrumb and sidebar can place the page under Previews.
+  const previewConfigId = useMemo(() => {
+    const labels = savedStack?.labels ?? [];
+    if (!labels.some((l) => l.key === PREVIEW_STACK_LABEL && l.value === "true")) return undefined;
+    return labels.find((l) => l.key === PREVIEW_CONFIG_ID_LABEL)?.value;
+  }, [savedStack?.labels]);
+
+  useEffect(() => {
+    if (!previewConfigId) {
+      setLineage(null);
+      return;
+    }
+    setLineage({ configId: previewConfigId });
+    if (!deployIds.orgId || !deployIds.projectName) return;
+    let cancelled = false;
+    void getPreviewConfig(deployIds.orgId, deployIds.projectName, previewConfigId)
+      .then((config) => {
+        // Name only sharpens the crumb — a failed lookup leaves it loading, not broken.
+        if (!cancelled) setLineage({ configId: previewConfigId, configName: config.name });
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [previewConfigId, deployIds.orgId, deployIds.projectName, setLineage]);
+
+  // Leaving the stack page hands the highlight back to Stacks.
+  useEffect(() => () => setLineage(null), [setLineage]);
+
   const releasesResult = useReleases({ ...deployIds, enabled: idsReady });
   const releaseDetail = useReleaseDetail(deployIds.orgId, deployIds.projectName, deployIds.stackId);
 

--- a/frontend/src/pages/stacks/components/editor/public-endpoint-row.tsx
+++ b/frontend/src/pages/stacks/components/editor/public-endpoint-row.tsx
@@ -235,9 +235,13 @@ function EndpointChip({ endpoint: { service, url, port, variant, urls }, reveal,
           aria-hidden
           className="flex items-center text-foreground/90 hover:text-foreground"
         >
-          <span className="flex max-w-0 items-center overflow-hidden whitespace-nowrap opacity-0 transition-[max-width,opacity] duration-200 group-focus-within:max-w-[360px] group-focus-within:opacity-100 group-hover:max-w-[360px] group-hover:opacity-100">
-            <span className="px-1 text-border">|</span>
-            <span className="pr-1 hover:underline">{hostOf(url)}</span>
+          {/* 0fr→1fr animates to the hostname's own width; a max-width would
+              need a fixed ceiling and clip the long ones. */}
+          <span className="grid grid-cols-[0fr] overflow-hidden opacity-0 transition-[grid-template-columns,opacity] duration-200 group-focus-within:grid-cols-[1fr] group-focus-within:opacity-100 group-hover:grid-cols-[1fr] group-hover:opacity-100">
+            <span className="flex min-w-0 items-center overflow-hidden whitespace-nowrap">
+              <span className="px-1 text-border">|</span>
+              <span className="pr-1 hover:underline">{hostOf(url)}</span>
+            </span>
           </span>
         </a>
       )}

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/canvas-controls.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/canvas-controls.tsx
@@ -34,12 +34,13 @@ export function CanvasControls({ showConnections, onToggleConnections, onAutoLay
     const next = !zenActive;
     setHeaderCollapsed(next);
     setSidebarOpen(!next);
-    // Entering zen reclaims the header + sidebar space — re-layout once the
-    // collapse has settled so the fit measures the final pane size.
+    // Entering zen reclaims the header + sidebar space — refit once the collapse
+    // has settled so the fit measures the final pane size. Fit, not auto layout:
+    // zen reveals the graph, it doesn't rearrange what the user placed.
     // ponytail: 250ms outlasts the sidebar's 200ms transition; switch to a
     // transitionend listener if the timing ever drifts.
-    if (next) window.setTimeout(onAutoLayout, 250);
-  }, [zenActive, setHeaderCollapsed, setSidebarOpen, onAutoLayout]);
+    if (next) window.setTimeout(() => fitView(FIT_OPTIONS), 250);
+  }, [zenActive, setHeaderCollapsed, setSidebarOpen, fitView]);
 
   // ⌘. toggles zen. Lives here (not the shell) because zen also needs the
   // sidebar; the canvas stays mounted across tabs, so the shortcut is global.
@@ -72,7 +73,7 @@ export function CanvasControls({ showConnections, onToggleConnections, onAutoLay
         </button>
         <span className="h-px w-full bg-border" aria-hidden />
         <button type="button" aria-label="Fit to view" title="Fit to view" className={cell} onClick={() => fitView(FIT_OPTIONS)}>
-          <Maximize2 className="size-3.5" />
+          <Focus className="size-3.5" />
         </button>
       </div>
       <div className="flex flex-col overflow-hidden rounded-md border border-border bg-popover shadow-lg">
@@ -94,7 +95,7 @@ export function CanvasControls({ showConnections, onToggleConnections, onAutoLay
           onClick={toggleZen}
           className={cn(cell, zenActive && "text-brand")}
         >
-          <Focus className="size-4" />
+          <Maximize2 className="size-4" />
         </button>
       </div>
       <button

--- a/frontend/src/pages/stacks/components/editor/tabs/architecture/tests/canvas-controls.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/architecture/tests/canvas-controls.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
 import { useState } from "react";
 import { ReactFlowProvider } from "@xyflow/react";
 import { SidebarProvider } from "@/components/ui/sidebar";
@@ -81,5 +81,15 @@ describe("CanvasControls", () => {
     render(<Harness onAutoLayout={onAutoLayout} />);
     fireEvent.click(screen.getByRole("button", { name: "Auto layout" }));
     expect(onAutoLayout).toHaveBeenCalled();
+  });
+
+  it("entering zen refits the view instead of rearranging the graph", () => {
+    vi.useFakeTimers();
+    const onAutoLayout = vi.fn();
+    render(<Harness onAutoLayout={onAutoLayout} />);
+    fireEvent.click(screen.getByRole("button", { name: "Zen mode" }));
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(onAutoLayout).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/deployments-tab.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/deployments-tab.tsx
@@ -25,10 +25,9 @@ export interface DeploymentsTabProps {
   lifecycle: DeployLifecycle;
   onRollback: (id: string) => void;
   onCancel: (id: string) => void;
-  onCopyId: (id: string) => void;
 }
 
-export function DeploymentsTab({ orgId, projectName, stackId, stack, onJumpToResource, refetchReleases, releases, activeRelease, loading, error, lifecycle, onRollback, onCancel, onCopyId }: DeploymentsTabProps) {
+export function DeploymentsTab({ orgId, projectName, stackId, stack, onJumpToResource, refetchReleases, releases, activeRelease, loading, error, lifecycle, onRollback, onCancel }: DeploymentsTabProps) {
   if (error) return <EmptyState title="Could not load deployments" description={error} />;
 
   const logContext = { orgId, projectName, stackId };
@@ -72,7 +71,6 @@ export function DeploymentsTab({ orgId, projectName, stackId, stack, onJumpToRes
             draftNode={draftNode}
             onRollback={onRollback}
             onCancel={onCancel}
-            onCopyId={onCopyId}
           />
         )}
       </div>

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/deployments-tab.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/deployments-tab.test.tsx
@@ -34,7 +34,7 @@ beforeAll(() => {
 
 const stack = { spec: { stack_resources: [] } } as unknown as Stack;
 const releases: StackRelease[] = [{ id: "r1", sequence: 14, state: "Released", cause: { kind: "manual" } } as StackRelease];
-const handlers = { onRollback: vi.fn(), onCancel: vi.fn(), onCopyId: vi.fn() };
+const handlers = { onRollback: vi.fn(), onCancel: vi.fn() };
 const base = { orgId: "o", projectName: "t", stackId: "s", stack, loading: false, error: null, ...handlers };
 
 const stubDetail: ReleaseDetail = { ensure: vi.fn(), peek: () => ({ loading: false }), refresh: vi.fn() };

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/release-menu.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/release-menu.tsx
@@ -6,14 +6,15 @@ import { ReleaseState } from "../release-states";
 
 export interface ReleaseMenuProps {
   release: StackRelease;
-  onRollback: (id: string) => void;
   onCancel: (id: string) => void;
-  onCopyId: (id: string) => void;
 }
 
-export function ReleaseMenu({ release, onRollback, onCancel, onCopyId }: ReleaseMenuProps) {
-  const id = release.id ?? "";
-  const state = release.state ?? "";
+export function ReleaseMenu({ release, onCancel }: ReleaseMenuProps) {
+  // Only a Pending release can be cancelled — once InProgress the backend
+  // rejects it (the rollout is already applied to the cluster). Cancel is the
+  // menu's only item, so there is nothing to open otherwise.
+  if (release.state !== ReleaseState.Pending || !release.id) return null;
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -22,13 +23,7 @@ export function ReleaseMenu({ release, onRollback, onCancel, onCopyId }: Release
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-[180px]">
-        {state === ReleaseState.Released && release.id && <DropdownMenuItem onClick={() => onRollback(release.id!)}>Rollback to this</DropdownMenuItem>}
-        {/* Only a Pending release can be cancelled — once InProgress the backend
-            rejects it (the rollout is already applied to the cluster). */}
-        {state === ReleaseState.Pending && release.id && (
-          <DropdownMenuItem variant="destructive" onClick={() => onCancel(release.id!)}>Cancel release</DropdownMenuItem>
-        )}
-        <DropdownMenuItem onClick={() => onCopyId(id)}>Copy release ID</DropdownMenuItem>
+        <DropdownMenuItem variant="destructive" onClick={() => onCancel(release.id!)}>Cancel release</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/tests/release-menu.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/tests/release-menu.test.tsx
@@ -17,26 +17,21 @@ beforeAll(() => {
 const rel = (over: Partial<StackRelease>) => ({ id: "r1", sequence: 5, state: "Released", ...over } as StackRelease);
 
 describe("ReleaseMenu", () => {
-  it("shows Rollback for Released and Copy id; hides Cancel", async () => {
-    const onRollback = vi.fn();
-    render(<ReleaseMenu release={rel({ state: "Released" })} onRollback={onRollback} onCancel={vi.fn()} onCopyId={vi.fn()} />);
-    await userEvent.click(screen.getByRole("button", { name: /release actions/i }));
-    expect(screen.getByText("Rollback to this")).toBeInTheDocument();
-    expect(screen.queryByText("Cancel release")).not.toBeInTheDocument();
-    await userEvent.click(screen.getByText("Rollback to this"));
-    expect(onRollback).toHaveBeenCalledWith("r1");
-  });
-
   it("shows Cancel for Pending", async () => {
-    render(<ReleaseMenu release={rel({ state: "Pending" })} onRollback={vi.fn()} onCancel={vi.fn()} onCopyId={vi.fn()} />);
+    const onCancel = vi.fn();
+    render(<ReleaseMenu release={rel({ state: "Pending" })} onCancel={onCancel} />);
     await userEvent.click(screen.getByRole("button", { name: /release actions/i }));
-    expect(screen.getByText("Cancel release")).toBeInTheDocument();
-    expect(screen.queryByText("Rollback to this")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByText("Cancel release"));
+    expect(onCancel).toHaveBeenCalledWith("r1");
   });
 
-  it("hides Cancel once InProgress (the backend rejects cancelling a rollout)", async () => {
-    render(<ReleaseMenu release={rel({ state: "InProgress" })} onRollback={vi.fn()} onCancel={vi.fn()} onCopyId={vi.fn()} />);
-    await userEvent.click(screen.getByRole("button", { name: /release actions/i }));
-    expect(screen.queryByText("Cancel release")).not.toBeInTheDocument();
+  it("renders nothing for Released — rollback is a button on the detail card", () => {
+    render(<ReleaseMenu release={rel({ state: "Released" })} onCancel={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /release actions/i })).not.toBeInTheDocument();
+  });
+
+  it("renders nothing once InProgress (the backend rejects cancelling a rollout)", () => {
+    render(<ReleaseMenu release={rel({ state: "InProgress" })} onCancel={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /release actions/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/tests/timeline-node.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/tests/timeline-node.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/api/releases", () => ({
   ReleaseEventType: { ResourceWaiting: "resource_waiting", ResourceDeploying: "resource_deploying", ResourceReady: "resource_ready", ResourceFailed: "resource_failed" },
 }));
 import { useReleaseDetail } from "../../use-release-detail";
+import { ConfirmProvider } from "@/components/branded/confirm";
 import { TimelineNode } from "../timeline-node";
 import { getRelease, listReleaseEvents, ReleaseEventScope } from "@/api/releases";
 import type { StackRelease } from "@/api/releases";
@@ -50,7 +51,6 @@ function Wrap(over: Partial<React.ComponentProps<typeof TimelineNode>> & { relea
       onToggle={vi.fn()}
       onRollback={vi.fn()}
       onCancel={vi.fn()}
-      onCopyId={vi.fn()}
       isActive={false}
       isLive={false}
       stack={stack}
@@ -83,6 +83,24 @@ describe("TimelineNode", () => {
     render(<Wrap release={{ id: "r1", sequence: 7, state: "Released" } as StackRelease} isActive isOpen />);
     expect(screen.getByText("Build")).toBeInTheDocument();
     expect(screen.getByText("Deploy")).toBeInTheDocument();
+  });
+
+  it("offers rollback on an earlier release, and only after confirmation", async () => {
+    const onRollback = vi.fn();
+    render(
+      <ConfirmProvider>
+        <Wrap release={{ id: "r1", sequence: 12, state: "Released" } as StackRelease} isOpen onRollback={onRollback} />
+      </ConfirmProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Rollback to this/ }));
+    expect(onRollback).not.toHaveBeenCalled();
+    await userEvent.click(await screen.findByRole("button", { name: /^Roll back$/ }));
+    await waitFor(() => expect(onRollback).toHaveBeenCalledWith("r1"));
+  });
+
+  it("offers no rollback on the live release — it is already serving traffic", () => {
+    render(<Wrap release={{ id: "r1", sequence: 13, state: "Released" } as StackRelease} isOpen isLive />);
+    expect(screen.queryByRole("button", { name: /Rollback to this/ })).not.toBeInTheDocument();
   });
 
   it("renders the historical post-mortem for a non-active node when open", async () => {

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/tests/timeline-rail.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/tests/timeline-rail.test.tsx
@@ -26,7 +26,7 @@ beforeAll(() => {
 const stack = { spec: { stack_resources: [] } } as unknown as Stack;
 const rels = (n: number): StackRelease[] => Array.from({ length: n }, (_, i) => ({ id: `r${n - i}`, sequence: n - i, state: "Released", cause: { kind: "manual" } } as StackRelease));
 
-const base = { stack, onRollback: vi.fn(), onCancel: vi.fn(), onCopyId: vi.fn() };
+const base = { stack, onRollback: vi.fn(), onCancel: vi.fn() };
 
 const stubDetail: ReleaseDetail = { ensure: vi.fn(), peek: () => ({ loading: false }), refresh: vi.fn() };
 function renderRail(ui: React.ReactElement) {

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/timeline-node.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/timeline-node.tsx
@@ -1,5 +1,7 @@
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Undo2 } from "lucide-react";
 import { StatusPill } from "@/components/branded";
+import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/branded/confirm";
 import type { StackRelease } from "@/api/releases";
 import type { Stack } from "@/api/stacks";
 import type { EditSessionTab } from "@/pages/stacks/hooks/use-stack-edit-session";
@@ -20,7 +22,6 @@ export interface TimelineNodeProps {
   onToggle: (id: string) => void;
   onRollback: (id: string) => void;
   onCancel: (id: string) => void;
-  onCopyId: (id: string) => void;
   /** releases[0] — render LIVE progress from the stack rather than the stored outcome. */
   isActive: boolean;
   /** This release currently serves traffic (stack.converged_release). */
@@ -37,10 +38,22 @@ export interface TimelineNodeProps {
  * release; only the body differs (live progress for the latest, stored post-mortem for earlier).
  */
 export function TimelineNode(props: TimelineNodeProps) {
-  const { release, prevReleaseId, prevSeq, detail, isOpen, onToggle, onRollback, onCancel, onCopyId, isActive, isLive, stack, logContext, onJumpToResource, refetchReleases } = props;
+  const { release, prevReleaseId, prevSeq, detail, isOpen, onToggle, onRollback, onCancel, isActive, isLive, stack, logContext, onJumpToResource, refetchReleases } = props;
   const id = release.id ?? "";
   const state = release.state ?? "";
   const deploying = isDeploying(state);
+  // Rolling back to the release already serving traffic would be a no-op.
+  const canRollback = state === ReleaseState.Released && !!release.id && !isLive;
+
+  const confirm = useConfirm();
+  const requestRollback = async () => {
+    const ok = await confirm({
+      title: `Roll back to release #${release.sequence}?`,
+      description: "The stack is redeployed from this release's snapshot, replacing what is currently live.",
+      confirmLabel: "Roll back",
+    });
+    if (ok) onRollback(id);
+  };
 
   const sha = releaseGitSha(release);
   const dur = formatDuration(release.rendered_at, release.completed_at);
@@ -76,12 +89,23 @@ export function TimelineNode(props: TimelineNodeProps) {
         {ts && <span className="flex-none font-mono text-[11px] text-fg-muted">{ts}</span>}
         <ChevronDown className={`h-3.5 w-3.5 flex-none text-fg-muted transition-transform ${isOpen ? "rotate-180" : ""}`} />
         <span onClick={(e) => e.stopPropagation()}>
-          <ReleaseMenu release={release} onRollback={onRollback} onCancel={onCancel} onCopyId={onCopyId} />
+          <ReleaseMenu release={release} onCancel={onCancel} />
         </span>
       </div>
 
       {isOpen && (
-        <div className={`mb-1 mt-1.5 rounded-md border ${cardBorder} bg-card p-4`}>
+        <div className={`relative mb-1 mt-1.5 rounded-md border ${cardBorder} bg-card p-4`}>
+          {canRollback && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="absolute right-4 top-4 z-10 h-7 text-[12px]"
+              onClick={(e) => { e.stopPropagation(); void requestRollback(); }}
+            >
+              <Undo2 className="mr-1 h-3.5 w-3.5" />
+              Rollback to this
+            </Button>
+          )}
           {isActive ? (
             <LiveReleaseBody
               release={release}

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/timeline-node.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/timeline-node.tsx
@@ -49,7 +49,7 @@ export function TimelineNode(props: TimelineNodeProps) {
   const requestRollback = async () => {
     const ok = await confirm({
       title: `Roll back to release #${release.sequence}?`,
-      description: "The stack is redeployed from this release's snapshot, replacing what is currently live.",
+      description: "The stack redeploys this release's snapshot, replacing what is currently live.",
       confirmLabel: "Roll back",
     });
     if (ok) onRollback(id);

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/timeline-rail.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/timeline-rail.tsx
@@ -22,7 +22,6 @@ export interface TimelineRailProps {
   draftNode?: React.ReactNode;
   onRollback: (id: string) => void;
   onCancel: (id: string) => void;
-  onCopyId: (id: string) => void;
   initialWindow?: number;
 }
 
@@ -39,7 +38,7 @@ function dotShape(state: string, isLive: boolean): RailDotShape {
  * opens by default, earlier nodes start closed. An optional draft node leads the rail.
  */
 export function TimelineRail(props: TimelineRailProps) {
-  const { releases, activeRelease, stack, logContext, onJumpToResource, refetchReleases, banner, draftNode, onRollback, onCancel, onCopyId, initialWindow = 15 } = props;
+  const { releases, activeRelease, stack, logContext, onJumpToResource, refetchReleases, banner, draftNode, onRollback, onCancel, initialWindow = 15 } = props;
   const detail = useReleaseDetailContext();
   const liveReleaseId = stack.converged_release?.id;
   const [openIds, setOpenIds] = useState<Set<string>>(
@@ -96,7 +95,6 @@ export function TimelineRail(props: TimelineRailProps) {
                 onToggle={toggle}
                 onRollback={onRollback}
                 onCancel={onCancel}
-                onCopyId={onCopyId}
                 // Live body only while the newest release is deploying or is the
                 // released/live one. A newest FAILED/CANCELLED release never
                 // converged — it has no live_status, so the live body would show

--- a/frontend/src/pages/stacks/components/wizard/wizard-chooser.tsx
+++ b/frontend/src/pages/stacks/components/wizard/wizard-chooser.tsx
@@ -37,7 +37,7 @@ interface AltStart {
   desc: string;
   onClick?: () => void;
   disabled?: boolean;
-  soon?: boolean;
+  tag?: string;
 }
 
 export function WizardChooser({
@@ -71,6 +71,7 @@ export function WizardChooser({
       label: "Docker compose",
       desc: "Import a compose.yml.",
       onClick: onPickCompose,
+      tag: "experimental",
     },
     {
       icon: Code,
@@ -118,9 +119,9 @@ export function WizardChooser({
                   <span className="text-sm font-medium text-foreground">
                     {a.label}
                   </span>
-                  {a.soon && (
+                  {a.tag && (
                     <span className="rounded-full border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider text-muted-foreground">
-                      soon
+                      {a.tag}
                     </span>
                   )}
                 </span>

--- a/pkg/services/defaulting_service.go
+++ b/pkg/services/defaulting_service.go
@@ -16,6 +16,7 @@ func NewStackDefaultingService() DefaultingService[*models.Stack] {
 
 func (s *stackDefaultingService) PopulateDefaultValues(resource *models.Stack) (*models.Stack, error) {
 	for i := range resource.StackResources {
+		applyStackResourceWorkloadTypeDefault(resource.StackResources[i])
 		applyStackResourcePortDefaults(resource.StackResources[i])
 		normalizeStackResourceReplicas(resource.StackResources[i])
 	}
@@ -44,6 +45,18 @@ func applyStackResourcePortDefaults(resource *models.StackResource) {
 			resource.Ports[i].Protocol = models.PortProtocolHTTP
 		}
 	}
+}
+
+// applyStackResourceWorkloadTypeDefault fills in the OpenAPI default for
+// workload_type. Stackfile-built stacks (PR previews, compose import) omit it,
+// and the enum has no value for "" — an empty one fails client-side validation
+// and reads as a deleted resource. Runs before the replica normalization below
+// so both see the same workload type.
+func applyStackResourceWorkloadTypeDefault(resource *models.StackResource) {
+	if resource == nil || resource.WorkloadType != "" {
+		return
+	}
+	resource.WorkloadType = models.WorkloadTypeService
 }
 
 // singleInstanceReplicas is the replica count hard-coded for workloads that

--- a/pkg/services/defaulting_service_workload_type_test.go
+++ b/pkg/services/defaulting_service_workload_type_test.go
@@ -1,0 +1,43 @@
+package services
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Stackdome/stackdome/pkg/models"
+)
+
+var _ = Describe("workload type defaulting", func() {
+	// Stackfile-created stacks (PR previews, compose import) omit workload_type,
+	// which the OpenAPI enum has no value for. Persisting "" holds the resource
+	// out of the editor's draft, so the stack reads as "resource removed".
+	It("defaults an empty workload type to Service", func() {
+		stack := &models.Stack{
+			StackResources: []*models.StackResource{
+				{Name: "app"},
+				{Name: "mysql"},
+			},
+		}
+
+		result, err := NewStackDefaultingService().PopulateDefaultValues(stack)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.StackResources[0].WorkloadType).To(Equal(models.WorkloadTypeService))
+		Expect(result.StackResources[1].WorkloadType).To(Equal(models.WorkloadTypeService))
+	})
+
+	It("leaves an explicit workload type untouched", func() {
+		stack := &models.Stack{
+			StackResources: []*models.StackResource{
+				{Name: "cron", WorkloadType: models.WorkloadTypeCronJob},
+				{Name: "queue", WorkloadType: models.WorkloadTypeWorker},
+			},
+		}
+
+		result, err := NewStackDefaultingService().PopulateDefaultValues(stack)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.StackResources[0].WorkloadType).To(Equal(models.WorkloadTypeCronJob))
+		Expect(result.StackResources[1].WorkloadType).To(Equal(models.WorkloadTypeWorker))
+	})
+})


### PR DESCRIPTION
## 📝 What this does

A preview environment always showed undeployed changes it could never clear, claiming every resource had been removed. The cause was one empty field the API emits against its own contract. This fixes that and clears up a handful of rough edges in the stack editor found alongside it.

## 🔀 Changes

- Defaulted an empty `workload_type` to `Service` on every stack write, so stackfile-built stacks stop failing client-side validation
- Placed preview stacks under Previews in the breadcrumb and sidebar instead of Stacks, derived from the stack's own labels so it survives a refresh
- Stopped the canvas live-view toggle painting through the deployments, logs and metrics tabs
- Made zen mode fit the view rather than re-running auto layout, and swapped the fit/zen icons
- Promoted rollback to a button on the release card behind a confirmation, dropped the unused Copy release ID action, and let a public endpoint's hostname expand fully

## 🧪 How to test

- [x] Open a PR preview environment and confirm no undeployed changes are reported
- [x] Refresh on that page — the breadcrumb should still read Previews / repo / stack, with Previews highlighted
- [x] Switch to Deployments and confirm the Draft/Live toggle is gone
- [x] Enter zen mode and confirm nodes keep their positions while the view refits
- [x] Expand an earlier release and roll back — a confirmation should appear first
- [x] Confirm the live release offers no rollback button
- [x] Hover a public endpoint chip and confirm the full hostname is visible