### PR TITLE
Fix: correct README log-streaming and RBAC role claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ The system follows a **hub-and-spoke model**:
 - **Stack deployments** -- Deploy multi-service applications from container images or git repositories
 - **Managed PostgreSQL** -- Provision PostgreSQL clusters with automated backups, restore, and HA (via CloudNativePG)
 - **Environment interpolation** -- Template-based cross-service references (`{{ STACKDOME_POSTGRES_INTERNAL }}`)
-- **RBAC** -- Role-based access control with Casbin (viewer, editor, admin roles with org-scoped isolation)
+- **RBAC** -- Role-based access control with Casbin (OrgAdmin and OrgMember org roles, Developer and Viewer project roles, with org-scoped isolation)
 - **Secrets management** -- Encrypted key-value storage for sensitive configuration
 - **Container builds** -- Build container images from git repos using Kaniko
 - **In-cluster registry** -- Managed container registry (Zot) per cluster
 - **Volume management** -- Persistent storage with git, remote dir, and build artifact sources
-- **WebSocket log streaming** -- Real-time log access for deployed services
+- **Live log streaming** -- Real-time log access for deployed services over Server-Sent Events (SSE)
 
 ## Prerequisites
 


### PR DESCRIPTION
Two verified README inaccuracies.

1. **Log streaming is SSE, not WebSockets.** There are no WebSockets in the codebase; every streaming endpoint sets `Content-Type: text/event-stream` (`pkg/handlers/handler_helper.go:236`). Line 47 now reads "Live log streaming ... over Server-Sent Events (SSE)".

2. **RBAC roles were wrong.** README claimed "viewer, editor, admin"; no `editor` role exists. Actual roles per `pkg/auth/default_policies.go` (+ `pkg/models/user.go`, `pkg/models/project.go`) are org roles OrgAdmin / OrgMember and project roles Developer / Viewer. Line 42 updated to match.

Docs-only, no code change.