### PR TITLE
Fix: exclude revoked API tokens from list endpoint

### DIFF
--- a/pkg/stores/pgstore/api_token_store.go
+++ b/pkg/stores/pgstore/api_token_store.go
@@ -59,7 +59,7 @@ func (s *apiTokenStore) GetByTokenHash(ctx context.Context, hash string) (*model
 func (s *apiTokenStore) ListByUserID(ctx context.Context, userID string) ([]*models.APIToken, *errors.ServiceError) {
 	session := s.sessionFactory.New(ctx)
 	var tokens []*models.APIToken
-	if err := session.Where("user_id = ?", userID).Order("created_at DESC").Find(&tokens).Error; err != nil {
+	if err := session.Where("user_id = ? AND revoked_at IS NULL", userID).Order("created_at DESC").Find(&tokens).Error; err != nil {
 		return nil, errors.GeneralError("failed to list api tokens: %s", err.Error())
 	}
 	return tokens, nil

--- a/pkg/stores/pgstore/api_token_store_test.go
+++ b/pkg/stores/pgstore/api_token_store_test.go
@@ -1,0 +1,69 @@
+package pgstore_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/Stackdome/stackdome/pkg/models"
+	"github.com/Stackdome/stackdome/pkg/stores"
+	"github.com/Stackdome/stackdome/pkg/stores/pgstore"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("APITokenStore", func() {
+	var (
+		store stores.APITokenStore
+		ctx   context.Context
+	)
+
+	const userID = "user-1"
+
+	newToken := func(id, name string) *models.APIToken {
+		return &models.APIToken{
+			ID:          id,
+			Name:        name,
+			UserID:      userID,
+			TokenHash:   "hash-" + id,
+			TokenPrefix: "sd_" + id,
+			Scopes:      models.StringSlice{"read"},
+			OrgID:       "org-1",
+			CreatedAt:   time.Now().UTC(),
+		}
+	}
+
+	BeforeEach(func() {
+		sf := newSQLiteSessionFactory(`
+			CREATE TABLE IF NOT EXISTS api_tokens (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				user_id TEXT NOT NULL,
+				token_hash TEXT NOT NULL,
+				token_prefix TEXT NOT NULL,
+				scopes JSONB NOT NULL,
+				resource_ids JSONB,
+				org_id TEXT NOT NULL,
+				expires_at DATETIME,
+				last_used_at DATETIME,
+				created_at DATETIME NOT NULL,
+				revoked_at DATETIME
+			)
+		`)
+		store = pgstore.NewAPITokenStore(pgstore.APITokenStoreSpec{SessionFactory: sf})
+		ctx = context.Background()
+	})
+
+	It("omits revoked tokens from the list", func() {
+		_, err := store.Create(ctx, newToken("token-live", "live"))
+		Expect(err).To(BeNil())
+		_, err = store.Create(ctx, newToken("token-revoked", "revoked"))
+		Expect(err).To(BeNil())
+
+		Expect(store.Revoke(ctx, "token-revoked")).To(BeNil())
+
+		tokens, err := store.ListByUserID(ctx, userID)
+		Expect(err).To(BeNil())
+		Expect(tokens).To(HaveLen(1))
+		Expect(tokens[0].ID).To(Equal("token-live"))
+	})
+})


### PR DESCRIPTION
## Problem

`DELETE /api/v1/api-tokens/{id}` returns 204, but `GET /api/v1/api-tokens` still lists the token. The delete is a soft revoke (`revoked_at` is stamped, no `gorm.DeletedAt`), and `ListByUserID` filtered on `user_id` only — so revoked tokens never left the list.

## Fix

One-line filter change in `pkg/stores/pgstore/api_token_store.go`:

```go
session.Where("user_id = ? AND revoked_at IS NULL", userID)
```

Same predicate `GetByTokenHash` already uses. No API schema change — `revoked_at` was already exposed. `ListByUserID` has a single production caller (`pkg/services/api_token_service.go:110`), so the store-level filter covers every path.

## Test

Added `pkg/stores/pgstore/api_token_store_test.go` (Ginkgo v2 + Gomega, `var _ = Describe(...)` on the existing pgstore suite): create two tokens, revoke one, assert the list returns only the live one. Uses the package's in-memory SQLite session factory — no live Postgres needed.

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./pkg/stores/pgstore/` — pass
- `golangci-lint run ./pkg/stores/...` — 0 issues