### PR TITLE
Feature: warn on unknown stackfile keys

### DIFF
--- a/pkg/services/preview_stack_service.go
+++ b/pkg/services/preview_stack_service.go
@@ -405,9 +405,12 @@ func (s *previewStackService) InternalBuildStackFromContent(
 	preview *models.PreviewStack,
 	stackFileBytes []byte,
 ) (*models.Stack, *errors.OperationError) {
-	sf, err := stackfile.Load(stackFileBytes)
+	sf, warnings, err := stackfile.LoadWithWarnings(stackFileBytes)
 	if err != nil {
 		return nil, errors.Permanent("InvalidStackfile", fmt.Sprintf("failed to parse stackfile: %v", err))
+	}
+	for _, w := range warnings {
+		s.logger.Warn(ctx, "stackfile: %s", w)
 	}
 
 	// Merge env overrides into the stackfile before ToStack so that override

--- a/pkg/stackfile/parse.go
+++ b/pkg/stackfile/parse.go
@@ -14,19 +14,27 @@ const MaxStackfileSize = 1 << 20 // 1MB
 
 // Load parses raw YAML bytes into a Stackfile and validates it.
 func Load(content []byte) (*Stackfile, error) {
+	sf, _, err := LoadWithWarnings(content)
+	return sf, err
+}
+
+// LoadWithWarnings is Load plus warnings about keys the decoder ignored.
+// Unknown keys never fail the load: old files carrying dropped fields such as
+// `stateful:` must keep working.
+func LoadWithWarnings(content []byte) (*Stackfile, []string, error) {
 	if len(content) > MaxStackfileSize {
-		return nil, fmt.Errorf("stackfile too large (%d bytes, max %d)", len(content), MaxStackfileSize)
+		return nil, nil, fmt.Errorf("stackfile too large (%d bytes, max %d)", len(content), MaxStackfileSize)
 	}
 	var sf Stackfile
 	if err := yaml.Unmarshal(content, &sf); err != nil {
-		return nil, fmt.Errorf("failed to parse stackfile: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse stackfile: %w", err)
 	}
 
 	if err := Validate(&sf); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &sf, nil
+	return &sf, collectUnknownKeys(content), nil
 }
 
 func Validate(sf *Stackfile) error {

--- a/pkg/stackfile/unknown_keys.go
+++ b/pkg/stackfile/unknown_keys.go
@@ -1,0 +1,169 @@
+package stackfile
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	addonTypeKey = "type"
+	yamlTagName  = "yaml"
+	yamlTagSkip  = "-"
+	topLevelPath = "top level"
+)
+
+// collectUnknownKeys walks the YAML against the Stackfile struct tags and reports
+// keys the decoder silently drops: typos ("imagee") and removed fields ("stateful").
+// Not checked: free-form maps (env, secrets) and the user-chosen names under
+// resources:/volumes:/addons:.
+func collectUnknownKeys(content []byte) []string {
+	var root yaml.Node
+	if err := yaml.Unmarshal(content, &root); err != nil {
+		return nil
+	}
+	node := &root
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+
+	var warnings []string
+	walkUnknownKeys(node, reflect.TypeOf(Stackfile{}), "", &warnings)
+	return warnings
+}
+
+var addonConfigType = reflect.TypeOf(AddonConnectionConfig{})
+
+func walkUnknownKeys(node *yaml.Node, t reflect.Type, path string, out *[]string) {
+	if node == nil {
+		return
+	}
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	switch t.Kind() {
+	case reflect.Struct:
+		if node.Kind != yaml.MappingNode {
+			return
+		}
+		if t == addonConfigType {
+			walkAddon(node, path, out)
+			return
+		}
+		fields := yamlFields(t)
+		eachMapEntry(node, func(key string, val *yaml.Node) {
+			ft, ok := fields[key]
+			if !ok {
+				*out = append(*out, unknownKeyWarning(key, path))
+				return
+			}
+			walkUnknownKeys(val, ft, childPath(path, key), out)
+		})
+
+	case reflect.Map:
+		// Keys are user-chosen names, so only the values are checked. Maps of
+		// scalars (env, secrets) have nothing to check.
+		if node.Kind != yaml.MappingNode || !isCheckable(t.Elem()) {
+			return
+		}
+		eachMapEntry(node, func(key string, val *yaml.Node) {
+			walkUnknownKeys(val, t.Elem(), childPath(path, key), out)
+		})
+
+	case reflect.Slice:
+		if node.Kind != yaml.SequenceNode || !isCheckable(t.Elem()) {
+			return
+		}
+		for i, item := range node.Content {
+			walkUnknownKeys(item, t.Elem(), fmt.Sprintf("%s[%d]", path, i), out)
+		}
+	}
+}
+
+// Addon blocks decode through a custom unmarshaller: a common base plus
+// type-specific fields. Extra keys on an unrecognised type are left alone.
+func walkAddon(node *yaml.Node, path string, out *[]string) {
+	allowed := yamlFields(addonConfigType)
+	switch addonTypeOf(node) {
+	case PostgresAddonType:
+		for k, v := range yamlFields(reflect.TypeOf(PostgresAddonConfig{})) {
+			allowed[k] = v
+		}
+	default:
+		return
+	}
+
+	eachMapEntry(node, func(key string, _ *yaml.Node) {
+		if _, ok := allowed[key]; !ok {
+			*out = append(*out, unknownKeyWarning(key, path))
+		}
+	})
+}
+
+func addonTypeOf(node *yaml.Node) string {
+	var addonType string
+	eachMapEntry(node, func(key string, val *yaml.Node) {
+		if key == addonTypeKey {
+			addonType = val.Value
+		}
+	})
+	return addonType
+}
+
+func eachMapEntry(node *yaml.Node, fn func(key string, val *yaml.Node)) {
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		fn(node.Content[i].Value, node.Content[i+1])
+	}
+}
+
+// yamlFields maps a struct's yaml key names to their field types.
+func yamlFields(t reflect.Type) map[string]reflect.Type {
+	fields := make(map[string]reflect.Type, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" {
+			continue
+		}
+		name, _, _ := strings.Cut(f.Tag.Get(yamlTagName), ",")
+		if name == yamlTagSkip {
+			continue
+		}
+		if name == "" {
+			name = strings.ToLower(f.Name)
+		}
+		fields[name] = f.Type
+	}
+	return fields
+}
+
+// Only containers of structs carry keys worth checking.
+func isCheckable(t reflect.Type) bool {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	switch t.Kind() {
+	case reflect.Struct:
+		return true
+	case reflect.Map, reflect.Slice:
+		return isCheckable(t.Elem())
+	default:
+		return false
+	}
+}
+
+func childPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}
+
+func unknownKeyWarning(key, path string) string {
+	if path == "" {
+		path = topLevelPath
+	}
+	return fmt.Sprintf("unknown key %q in %s", key, path)
+}

--- a/pkg/stackfile/unknown_keys_test.go
+++ b/pkg/stackfile/unknown_keys_test.go
@@ -1,0 +1,145 @@
+package stackfile
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LoadWithWarnings", func() {
+	loadYAML := func(content string) []string {
+		sf, warnings, err := LoadWithWarnings([]byte(content))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sf).NotTo(BeNil())
+		return warnings
+	}
+
+	const cleanFile = `
+name: demo
+resources:
+  web:
+    image: nginx:latest
+    ports:
+      - name: http
+        port: 80
+`
+
+	It("returns no warnings for a clean file", func() {
+		Expect(loadYAML(cleanFile)).To(BeEmpty())
+	})
+
+	It("warns about an unknown top-level key", func() {
+		warnings := loadYAML(cleanFile + "bogus_key_xyz: true\n")
+		Expect(warnings).To(ConsistOf(`unknown key "bogus_key_xyz" in top level`))
+	})
+
+	It("warns about a legacy stateful flag on a resource", func() {
+		warnings := loadYAML(cleanFile + "    stateful: true\n")
+		Expect(warnings).To(ConsistOf(`unknown key "stateful" in resources.web`))
+	})
+
+	It("warns about a misspelled resource key", func() {
+		warnings := loadYAML(`
+name: demo
+resources:
+  web:
+    image: nginx:latest
+    imagee: nginx:latest
+`)
+		Expect(warnings).To(ConsistOf(`unknown key "imagee" in resources.web`))
+	})
+
+	It("warns about an unknown key in a build block", func() {
+		warnings := loadYAML(`
+name: demo
+resources:
+  api:
+    build:
+      repo: https://github.com/acme/app.git
+      branchh: main
+`)
+		Expect(warnings).To(ConsistOf(`unknown key "branchh" in resources.api.build`))
+	})
+
+	It("warns about an unknown key in a port entry", func() {
+		warnings := loadYAML(`
+name: demo
+resources:
+  web:
+    image: nginx:latest
+    ports:
+      - name: http
+        port: 80
+        publicc: true
+`)
+		Expect(warnings).To(ConsistOf(`unknown key "publicc" in resources.web.ports[0]`))
+	})
+
+	It("warns about an unknown key in a volume definition", func() {
+		warnings := loadYAML(`
+name: demo
+volumes:
+  data:
+    size: 1Gi
+    sizee: 2Gi
+resources:
+  web:
+    image: nginx:latest
+`)
+		Expect(warnings).To(ConsistOf(`unknown key "sizee" in volumes.data`))
+	})
+
+	It("warns about an unknown key in a postgres addon block", func() {
+		warnings := loadYAML(`
+name: demo
+resources:
+  web:
+    image: nginx:latest
+    addons:
+      pg:
+        type: postgres
+        database: appdb
+        superuser: true
+        databse: typo
+        env:
+          DB_HOST: "{{ host }}"
+`)
+		Expect(warnings).To(ConsistOf(`unknown key "databse" in resources.web.addons.pg`))
+	})
+
+	It("does not flag env or secret keys", func() {
+		warnings := loadYAML(`
+name: demo
+resources:
+  web:
+    image: nginx:latest
+    env:
+      IMAGEE: anything
+      stateful: "true"
+    secrets:
+      api-keys:
+        STRIPE_KEY: stripe
+`)
+		Expect(warnings).To(BeEmpty())
+	})
+
+	DescribeTable("legacy testdata fixtures load with only the stateful warning",
+		func(fixture string) {
+			content, err := os.ReadFile(testdataPath(fixture))
+			Expect(err).NotTo(HaveOccurred())
+
+			sf, warnings, err := LoadWithWarnings(content)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sf).NotTo(BeNil())
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring(`unknown key "stateful" in resources.`))
+
+			viaLoad, err := Load(content)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(viaLoad).To(Equal(sf))
+		},
+		Entry("infisical", "infisical.yaml"),
+		Entry("kitchen sink", "kitchen_sink.yaml"),
+	)
+})


### PR DESCRIPTION
## Problem

`pkg/stackfile` decodes with plain `yaml.Unmarshal`, so any key the structs do not know is silently dropped. A typo (`imagee:` instead of `image:`) or a field that no longer exists (`stateful: true`, still present in `testdata/infisical.yaml` and `testdata/kitchen_sink.yaml`) parses as a no-op and the user gets no signal at all.

## Design

- Decoding stays **non-strict**. Strict decoding would break every existing user file that still carries `stateful:`, so unknown keys are warnings, never errors.
- New `pkg/stackfile/unknown_keys.go` walks the `yaml.Node` tree against the struct `yaml` tags via reflection, so new fields need no walker edits. Warnings are path-qualified: `unknown key "stateful" in resources.web`, `unknown key "publicc" in resources.web.ports[0]`.
- New exported `LoadWithWarnings(content []byte) (*Stackfile, []string, error)`. `Load` is now a thin wrapper that discards the warnings — **signature unchanged**, so the external CLI keeps compiling and can move to `LoadWithWarnings` to print them.
- Addon blocks decode through a custom unmarshaller (common base + type-specific fields), so their allowed set is `{type, env}` plus `{database, superuser}` for `type: postgres`. Extra keys on an unrecognised addon type are left alone — `Validate` already errors on the type itself.
- Hub surfacing: `previewStackService.InternalBuildStackFromContent` calls `LoadWithWarnings` and logs each warning via the service's existing logger (`s.logger.Warn`). `InternalBuildStackFromContent`'s signature is unchanged.

## Not checked

Free-form maps: `env`, `secrets`, and the user-chosen names under `resources:`, `volumes:`, and `addons:`. Those keys are data, not schema.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./pkg/stackfile/ ./pkg/services/ ./pkg/worker/preview/` — all pass
- `golangci-lint run ./pkg/stackfile/... ./pkg/services/...` — 0 issues
- New Ginkgo specs in `pkg/stackfile/unknown_keys_test.go`: top-level unknown key, `stateful:` on a resource, `imagee:` typo, unknown keys nested in a build block / port entry / volume def / postgres addon block, `env` and `secrets` keys not flagged, clean file yields zero warnings, and both legacy testdata fixtures load with exactly the one `stateful` warning while `Load` returns an identical stackfile.