### PR TITLE
Fix: two authorization bugs — scoped-token project resolution and stale casbin cache

### DIFF
--- a/pkg/handlers/handler_helper.go
+++ b/pkg/handlers/handler_helper.go
@@ -277,7 +277,7 @@ func resolveProjectID(r *http.Request, projectService services.ProjectService) (
 	if projectName == "" {
 		return "", errors.BadRequest("project_name is required")
 	}
-	project, serr := projectService.GetProjectByOrgAndName(r.Context(), orgID, projectName)
+	project, serr := projectService.InternalGetProjectByOrgAndName(r.Context(), orgID, projectName)
 	if serr != nil {
 		return "", serr
 	}

--- a/pkg/mocks/mock_project_service.go
+++ b/pkg/mocks/mock_project_service.go
@@ -146,6 +146,21 @@ func (mr *MockProjectServiceMockRecorder) InternalCreateDefaultProject(ctx, orgI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalCreateDefaultProject", reflect.TypeOf((*MockProjectService)(nil).InternalCreateDefaultProject), ctx, orgID)
 }
 
+// InternalGetProjectByOrgAndName mocks base method.
+func (m *MockProjectService) InternalGetProjectByOrgAndName(ctx context.Context, orgID, name string) (*models.Project, *errors.ServiceError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InternalGetProjectByOrgAndName", ctx, orgID, name)
+	ret0, _ := ret[0].(*models.Project)
+	ret1, _ := ret[1].(*errors.ServiceError)
+	return ret0, ret1
+}
+
+// InternalGetProjectByOrgAndName indicates an expected call of InternalGetProjectByOrgAndName.
+func (mr *MockProjectServiceMockRecorder) InternalGetProjectByOrgAndName(ctx, orgID, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalGetProjectByOrgAndName", reflect.TypeOf((*MockProjectService)(nil).InternalGetProjectByOrgAndName), ctx, orgID, name)
+}
+
 // InternalListUserProjects mocks base method.
 func (m *MockProjectService) InternalListUserProjects(ctx context.Context, userID, orgID string) ([]*models.ProjectMembership, *errors.ServiceError) {
 	m.ctrl.T.Helper()

--- a/pkg/resourceaccess/resource_access_mgr.go
+++ b/pkg/resourceaccess/resource_access_mgr.go
@@ -57,9 +57,6 @@ func NewResourceAccessPolicyManager(cfg CasbinResourceAccessPolicyManagerConfig)
 		return nil, fmt.Errorf("failed to create casbin enforcer: %w", err)
 	}
 
-	// Reload the policies from the DB every cfg.PolicyAutoLoadInterval.
-	enforcer.StartAutoLoadPolicy(cfg.PolicyAutoLoadInterval)
-
 	// Load policies from database
 	if err := enforcer.LoadPolicy(); err != nil {
 		return nil, fmt.Errorf("failed to load casbin policies: %w", err)
@@ -69,11 +66,25 @@ func NewResourceAccessPolicyManager(cfg CasbinResourceAccessPolicyManagerConfig)
 	enforcer.SetLogger(casbinLogger)
 
 	logger := logger.NewLoggerWithPrefix(context.Background(), "casbin")
-	return &casbinResourceAccessPolicyManager{
+	mgr := &casbinResourceAccessPolicyManager{
 		enforcer: enforcer,
 		logger:   logger,
 		debug:    cfg.EnableDebugLog,
-	}, nil
+	}
+
+	// Reload the policies from the DB every cfg.PolicyAutoLoadInterval.
+	// StartAutoLoadPolicy is off-limits: it reloads via the embedded SyncedEnforcer,
+	// which skips the cache purge, so stale decisions would survive the reload.
+	ticker := time.NewTicker(cfg.PolicyAutoLoadInterval)
+	go func() {
+		for range ticker.C {
+			if err := mgr.RefreshPolicies(); err != nil {
+				logger.Errorf("casbin policy auto-reload failed: %s", err.Error())
+			}
+		}
+	}()
+
+	return mgr, nil
 }
 
 func (r *casbinResourceAccessPolicyManager) AddPolicy(subject, domain, resource, action string) error {
@@ -87,8 +98,10 @@ func (r *casbinResourceAccessPolicyManager) RemovePolicy(subject, domain, resour
 }
 
 func (r *casbinResourceAccessPolicyManager) RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) error {
-	_, err := r.enforcer.RemoveFilteredPolicy(fieldIndex, fieldValues...)
-	return err
+	if _, err := r.enforcer.RemoveFilteredPolicy(fieldIndex, fieldValues...); err != nil {
+		return err
+	}
+	return r.enforcer.InvalidateCache()
 }
 
 func (r *casbinResourceAccessPolicyManager) CheckPermission(subject, domain, resource, action string) (bool, error) {
@@ -118,14 +131,21 @@ func (r *casbinResourceAccessPolicyManager) RefreshPolicies() error {
 	return nil
 }
 
+// SyncedCachedEnforcer only purges its decision cache on AddPolicy/RemovePolicy.
+// Grouping changes go straight to the embedded SyncedEnforcer, so a cached deny
+// from before the role was granted would stick around: invalidate it by hand.
 func (r *casbinResourceAccessPolicyManager) AddGroupingPolicy(subject, role, domain string) error {
-	_, err := r.enforcer.AddGroupingPolicy(subject, role, domain)
-	return err
+	if _, err := r.enforcer.AddGroupingPolicy(subject, role, domain); err != nil {
+		return err
+	}
+	return r.enforcer.InvalidateCache()
 }
 
 func (r *casbinResourceAccessPolicyManager) RemoveGroupingPolicy(subject, role, domain string) error {
-	_, err := r.enforcer.RemoveGroupingPolicy(subject, role, domain)
-	return err
+	if _, err := r.enforcer.RemoveGroupingPolicy(subject, role, domain); err != nil {
+		return err
+	}
+	return r.enforcer.InvalidateCache()
 }
 
 func (r *casbinResourceAccessPolicyManager) HasGroupingPolicy(subject, role, domain string) (bool, error) {

--- a/pkg/resourceaccess/resource_access_mgr_test.go
+++ b/pkg/resourceaccess/resource_access_mgr_test.go
@@ -1,0 +1,57 @@
+package resourceaccess
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestResourceAccess(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ResourceAccess Suite")
+}
+
+var _ = Describe("casbinResourceAccessPolicyManager grouping changes", func() {
+	const (
+		subject  = "user-1"
+		role     = "TestRole"
+		domain   = "project-1"
+		resource = "stacks"
+		action   = "read"
+	)
+
+	var mgr ResourceAccessPolicyManager
+
+	BeforeEach(func() {
+		var err error
+		mgr, err = NewInMemoryPolicyManager()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.AddPolicy(role, domain, resource, action)).To(Succeed())
+	})
+
+	It("clears a cached deny once the grouping is added", func() {
+		allowed, err := mgr.CheckPermission(subject, domain, resource, action)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allowed).To(BeFalse())
+
+		Expect(mgr.AddGroupingPolicy(subject, role, domain)).To(Succeed())
+
+		allowed, err = mgr.CheckPermission(subject, domain, resource, action)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allowed).To(BeTrue())
+	})
+
+	It("clears a cached allow once the grouping is removed", func() {
+		Expect(mgr.AddGroupingPolicy(subject, role, domain)).To(Succeed())
+		allowed, err := mgr.CheckPermission(subject, domain, resource, action)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allowed).To(BeTrue())
+
+		Expect(mgr.RemoveGroupingPolicy(subject, role, domain)).To(Succeed())
+
+		allowed, err = mgr.CheckPermission(subject, domain, resource, action)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(allowed).To(BeFalse())
+	})
+})

--- a/pkg/services/project_service.go
+++ b/pkg/services/project_service.go
@@ -26,6 +26,7 @@ type ProjectService interface {
 	UpdateProject(ctx context.Context, id string, project *models.Project) (*models.Project, *errors.ServiceError)
 	DeleteProject(ctx context.Context, id string) *errors.ServiceError
 	InternalCreateDefaultProject(ctx context.Context, orgID string) (*models.Project, *errors.ServiceError)
+	InternalGetProjectByOrgAndName(ctx context.Context, orgID, name string) (*models.Project, *errors.ServiceError)
 	InternalAddMember(ctx context.Context, projectID, userID string, role models.ProjectRole) (*models.ProjectMembership, *errors.ServiceError)
 
 	AddMember(ctx context.Context, projectID, userID string, role models.ProjectRole) (*models.ProjectMembership, *errors.ServiceError)
@@ -136,6 +137,13 @@ func (s *projectService) GetProjectByOrgAndName(ctx context.Context, orgID, name
 		return nil, permErr
 	}
 	return res, nil
+}
+
+// Name -> ID lookup with no permission check. Callers use it to resolve a URL
+// path segment before authorizing the resource actually being requested; an
+// API token scoped to that resource must not need projects:read to get there.
+func (s *projectService) InternalGetProjectByOrgAndName(ctx context.Context, orgID, name string) (*models.Project, *errors.ServiceError) {
+	return s.projectStore.GetByOrgAndName(ctx, orgID, name)
 }
 
 func (s *projectService) ListProjects(ctx context.Context, orgID string) ([]*models.Project, *errors.ServiceError) {

--- a/pkg/services/project_service_test.go
+++ b/pkg/services/project_service_test.go
@@ -1,0 +1,92 @@
+package services
+
+import (
+	"context"
+
+	"github.com/Stackdome/stackdome/pkg/auth"
+	"github.com/Stackdome/stackdome/pkg/errors"
+	"github.com/Stackdome/stackdome/pkg/mocks"
+	"github.com/Stackdome/stackdome/pkg/models"
+	"github.com/Stackdome/stackdome/pkg/resourceaccess"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+// Suite bootstrapped by TestAESEncryptionService in encryption_service_test.go.
+
+var _ = Describe("ProjectService name resolution", func() {
+	const (
+		orgID       = "org-1"
+		projectID   = "proj-1"
+		projectName = "my-project"
+		userID      = "user-1"
+	)
+
+	var (
+		svc         *projectService
+		tokenCtx    context.Context
+		testProject *models.Project
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		testProject = &models.Project{ID: projectID, OrganisationID: orgID, Name: projectName}
+
+		projectStore := mocks.NewMockProjectStore(ctrl)
+		projectStore.EXPECT().GetByOrgAndName(gomock.Any(), orgID, projectName).Return(testProject, nil).AnyTimes()
+		projectStore.EXPECT().GetByID(gomock.Any(), projectID).Return(testProject, nil).AnyTimes()
+
+		logMock := mocks.NewMockLogger(ctrl)
+		logMock.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+		logMock.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+
+		policyMgr, err := resourceaccess.NewInMemoryPolicyManager()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(auth.LoadDefaultPolicies(policyMgr.AddPolicy)).To(Succeed())
+		Expect(policyMgr.AddGroupingPolicy(userID, string(models.DeveloperRole), projectID)).To(Succeed())
+		Expect(policyMgr.AddGroupingPolicy(userID, string(models.OrgMemberRole), orgID)).To(Succeed())
+
+		svc = &projectService{
+			projectStore: projectStore,
+			policyMgr:    policyMgr,
+			permissions: auth.NewPermissionService(auth.PermissionServiceSpec{
+				PolicyManager: policyMgr,
+				ProjectStore:  projectStore,
+				Logger:        logMock,
+			}),
+			logger: logMock,
+		}
+
+		tokenCtx = auth.SetIdentityInContext(context.Background(), &auth.Identity{
+			UserID:      userID,
+			OrgID:       orgID,
+			AuthMethod:  auth.AuthMethodAPIToken,
+			TokenScopes: []string{"stacks:*"},
+		})
+	})
+
+	It("resolves the project name for a stacks-scoped token", func() {
+		project, serr := svc.InternalGetProjectByOrgAndName(tokenCtx, orgID, projectName)
+		Expect(serr).To(BeNil())
+		Expect(project.ID).To(Equal(projectID))
+	})
+
+	It("still denies the project resource itself to a stacks-scoped token", func() {
+		_, serr := svc.GetProjectByOrgAndName(tokenCtx, orgID, projectName)
+		Expect(serr).ToNot(BeNil())
+		Expect(serr.Code).To(Equal(errors.ErrorForbidden))
+	})
+
+	It("allows the project resource for a projects-scoped token", func() {
+		ctx := auth.SetIdentityInContext(context.Background(), &auth.Identity{
+			UserID:      userID,
+			OrgID:       orgID,
+			AuthMethod:  auth.AuthMethodAPIToken,
+			TokenScopes: []string{"projects:*"},
+		})
+		project, serr := svc.GetProjectByOrgAndName(ctx, orgID, projectName)
+		Expect(serr).To(BeNil())
+		Expect(project.ID).To(Equal(projectID))
+	})
+})


### PR DESCRIPTION
Two authorization bugs, both verified in code.

## Bug A — `stacks:*` API token gets 403 on `GET .../projects/{name}/stacks`

**Repro:** create an API token scoped `stacks:*`, call `GET /organizations/{org}/projects/{project}/stacks`. 403. The same call with a `*:*` token works.

**Root cause:** the handler resolves the project name to an ID first (`stack_handler.go` → `resolveProjectID` in `handler_helper.go`), which called the permission-checked `projectService.GetProjectByOrgAndName`. That runs `permissions.Check(..., ResourceProjects, ..., ActionRead)`, and the token-scope gate in `permission_service.go` correctly refuses `projects:read` for a `stacks:*` scope. The request died on the name-resolution side-check, before the real stacks authorization (`stack_service.go`) was ever reached.

**Fix:** name→ID resolution is plumbing, not the protected action — the real authorization is the resource check that follows. Added `InternalGetProjectByOrgAndName` (no permission check, following the existing `Internal*` convention in the same file) and switched `resolveProjectID` to it. The public `GetProjectByOrgAndName` keeps its check and is still used by every route where the project itself is the requested resource: `project_handler.go` (GET/PUT/DELETE by name, members), `organisation_handler.go`, `org_invite_service.go`. Mock regenerated via `go generate`.

## Bug B — fresh signup's OrgAdmin gets a persistent 403 on `POST /organizations/{org}/projects`

**Repro:** sign up, immediately create a project. If any permission check for that (user, org, resource, action) happened before the OrgAdmin grouping row was visible, the 403 never goes away — not after a retry, not after the 1-minute policy reload.

**Root cause:** two compounding defects in `pkg/resourceaccess/resource_access_mgr.go` with `casbin/v2` `SyncedCachedEnforcer`:

1. `SyncedCachedEnforcer` overrides only `AddPolicy`/`RemovePolicy` to purge its decision cache. `AddGroupingPolicy` promotes to the embedded `SyncedEnforcer`, so granting a role left the stale cached deny in place.
2. Nothing flushed it afterwards. Cache entries never expire (`SetExpireTime` is never called → ttl 0 → `Get` treats entries as non-expiring), and `StartAutoLoadPolicy` reloads via the embedded `SyncedEnforcer`, bypassing `SyncedCachedEnforcer.LoadPolicy`'s cache clear. Net: one cached deny persists for the life of the process.

**Fix (minimal):**
- `InvalidateCache()` after `AddGroupingPolicy`, `RemoveGroupingPolicy`, and `RemoveFilteredPolicy` (the last one is the same class of bug in the revoke direction: a cached *allow* surviving a policy removal).
- Replaced `StartAutoLoadPolicy` with a ticker goroutine calling the pre-existing (previously caller-less) `RefreshPolicies`, which goes through `SyncedCachedEnforcer.LoadPolicy` and therefore clears the cache. Interval config unchanged (`time.Minute` from `cmd/environment/env.go`). Lifecycle matches what it replaces — `StartAutoLoadPolicy` was never stopped either.

No check was weakened: the scope gate, the resource-ID gate, and every `permissions.Check` call site are untouched.

## Tests

- `pkg/services/project_service_test.go` (new, added to the existing suite): a `stacks:*` token identity completes `InternalGetProjectByOrgAndName`; the same identity is still Forbidden on `GetProjectByOrgAndName`; a `projects:*` token still passes it. Real in-memory Casbin enforcer + default policies, mocked store.
- `pkg/resourceaccess/resource_access_mgr_test.go` (new, bootstraps the package suite): cached deny is cleared by `AddGroupingPolicy`, cached allow is cleared by `RemoveGroupingPolicy`. Verified this test **fails on the unpatched manager** (stashed the fix, spec failed at the post-grouping assertion) and passes with it.

## Verification

| Gate | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./pkg/auth/ ./pkg/resourceaccess/ ./pkg/services/ ./pkg/handlers/` | pass |
| `golangci-lint run ./pkg/auth/... ./pkg/resourceaccess/... ./pkg/services/... ./pkg/handlers/...` | 0 issues |
