### PR TITLE
Fix: repair corrupted mocks target prerequisites in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ frontend:
 .PHONY: frontend
 
 MOCKGEN := $(shell go env GOPATH)/bin/mockgen
-mocks: 20 20 12 61 79 80 81 98 33 100 204 250 395 398 399 400 701MOCKGEN)
+mocks: $(MOCKGEN)
 	go generate ./pkg/controllers ./pkg/stores/... ./pkg/logger/... ./pkg/validator/... ./pkg/services/... ./pkg/auth/... ./pkg/worker/stack/... ./pkg/worker/release/... ./pkg/clients/... ./pkg/credentials/... ./pkg/clustermanager/... ./pkg/handlers/... ./pkg/resourceaccess/...
 .PHONY: mocks
 


### PR DESCRIPTION
## Symptom

`make mocks` fails immediately:

```
make: *** No rule to make target '20', needed by 'mocks'.  Stop.
```

## Cause

Line 27 of the Makefile had a mangled prerequisite list:

```make
mocks: 20 20 12 61 79 80 81 98 33 100 204 250 395 398 399 400 701MOCKGEN)
```

The `$(MOCKGEN)` variable reference was overwritten with a run of literal numbers, leaving a trailing `MOCKGEN)` fragment. Make then treated each number as a real prerequisite target and bailed on the first one. Introduced in fac71f91; `git log -S MOCKGEN -- Makefile` shows the line was `mocks: $(MOCKGEN)` before that.

## Fix

Restore the original prerequisite:

```make
mocks: $(MOCKGEN)
```

One line, no other changes.

## Verification

- `make -n mocks` prints the expected single `go generate ./pkg/...` command.
- `make mocks` runs clean (exit 0).
- `git status` after regeneration shows only the Makefile modified — regenerated mocks are byte-identical to what is committed, so no mock drift. This PR is a pure Makefile fix.

Found while working PR #226.