### PR TITLE
Fix: keep preview PR comment updating until ingress URLs are present

### DIFF
--- a/pkg/models/preview_stack.go
+++ b/pkg/models/preview_stack.go
@@ -90,6 +90,10 @@ func (s *PreviewStackStatus) Scan(value any) error {
 type PreviewStackOutputs struct {
 	CommitSHA string       `json:"commit_sha,omitempty"`
 	URLs      []PreviewURL `json:"urls,omitempty"`
+	// True while a publicly exposed resource still has no ingress URL. The
+	// agent publishes URLs only after TLS is issued (or after its ~2min
+	// fallback to http), which lands after the release goes live.
+	URLsPending bool `json:"urls_pending,omitempty"`
 }
 
 // PreviewURL maps a resource name to its public URL.

--- a/pkg/services/preview_comment_service.go
+++ b/pkg/services/preview_comment_service.go
@@ -15,7 +15,10 @@ import (
 	"github.com/Stackdome/stackdome/pkg/stores"
 )
 
-const previewCommentMarker = "<!-- stackdome-preview -->"
+const (
+	previewCommentMarker = "<!-- stackdome-preview -->"
+	urlsPendingNote      = "_⏳ Public URLs are still being provisioned — this comment updates when they are ready._"
+)
 
 // PreviewCommentService maintains the sticky PR comment for a preview stack.
 // Perm-less: reached only from the preview worker, never from user requests.
@@ -130,11 +133,13 @@ func writeOutputs(b *strings.Builder, preview *models.PreviewStack) {
 	if outputs.CommitSHA != "" {
 		fmt.Fprintf(b, "\nDeployed commit: `%s`\n", outputs.CommitSHA)
 	}
-	if len(outputs.URLs) == 0 {
-		return
+	if len(outputs.URLs) > 0 {
+		b.WriteString("\n| Resource | URL |\n| --- | --- |\n")
+		for _, u := range outputs.URLs {
+			fmt.Fprintf(b, "| %s | %s |\n", u.Resource, u.URL)
+		}
 	}
-	b.WriteString("\n| Resource | URL |\n| --- | --- |\n")
-	for _, u := range outputs.URLs {
-		fmt.Fprintf(b, "| %s | %s |\n", u.Resource, u.URL)
+	if outputs.URLsPending {
+		b.WriteString("\n" + urlsPendingNote + "\n")
 	}
 }

--- a/pkg/services/preview_comment_service_test.go
+++ b/pkg/services/preview_comment_service_test.go
@@ -151,5 +151,20 @@ var _ = Describe("PreviewCommentService", func() {
 			Expect(body).To(ContainSubstring("Preview environment is live"))
 			Expect(body).ToNot(ContainSubstring("Deployed commit"))
 		})
+
+		It("notes that URLs are still being provisioned when none have landed", func() {
+			preview.Status.Outputs.URLs = nil
+			preview.Status.Outputs.URLsPending = true
+			body := renderPreviewComment(preview)
+			Expect(body).To(ContainSubstring("Preview environment is live"))
+			Expect(body).To(ContainSubstring("`abc123`"))
+			Expect(body).To(ContainSubstring(urlsPendingNote))
+		})
+
+		It("drops the pending note once the URLs land", func() {
+			body := renderPreviewComment(preview)
+			Expect(body).To(ContainSubstring("https://pr-7-web.example.dev"))
+			Expect(body).ToNot(ContainSubstring(urlsPendingNote))
+		})
 	})
 })

--- a/pkg/worker/preview/converge_reconciler.go
+++ b/pkg/worker/preview/converge_reconciler.go
@@ -40,8 +40,8 @@ func (r *convergeReconciler) Reconcile(ctx context.Context, preview *models.Prev
 
 	switch release.State {
 	case models.ReleaseStateReleased:
-		if preview.Status.Phase == models.PreviewStackPhaseReady {
-			return r.retryPendingComment(ctx, preview)
+		if preview.Status.Phase == models.PreviewStackPhaseReady && !preview.GitHubCommentPending {
+			return resultNil, nil
 		}
 		stack, sErr := r.stackService.InternalGetStack(ctx, *preview.StackID)
 		if sErr != nil {
@@ -54,11 +54,19 @@ func (r *convergeReconciler) Reconcile(ctx context.Context, preview *models.Prev
 			Reason:  "ReleaseConverged",
 			Outputs: &outputs,
 		}
-		preview.GitHubCommentPending = !r.upsertComment(ctx, preview)
+		// The comment is only final once the URLs are in it. While they are
+		// missing, keep it pending so later passes re-read the stack and edit
+		// the URLs into the sticky comment.
+		posted := r.upsertComment(ctx, preview)
+		preview.GitHubCommentPending = !posted || outputs.URLsPending
 		if _, sErr := r.previewStackStore.Update(ctx, preview); sErr != nil {
 			return resultNil, fmt.Errorf("failed to update preview status: %w", sErr)
 		}
 
+		if outputs.URLsPending {
+			r.logger.Info(ctx, "preview %s is ready, waiting for public URLs", preview.ID)
+			return resultRequeueAfter(convergePollInterval), nil
+		}
 		r.logger.Info(ctx, "preview %s is ready", preview.ID)
 		return resultStop, nil
 
@@ -68,6 +76,9 @@ func (r *convergeReconciler) Reconcile(ctx context.Context, preview *models.Prev
 		return resultRequeueAfter(convergePollInterval), nil
 
 	case models.ReleaseStateFailed:
+		if preview.Status.Outputs != nil {
+			preview.Status.Outputs.URLsPending = false // no more URLs are coming
+		}
 		preview.Status = models.PreviewStackStatus{
 			Phase:   models.PreviewStackPhaseFailed,
 			Reason:  "ReleaseFailed",
@@ -108,36 +119,36 @@ func (r *convergeReconciler) upsertComment(ctx context.Context, preview *models.
 	return true
 }
 
-// retryPendingComment re-attempts a PR comment that failed after the preview
-// already went Ready. Status is already persisted; only the flag changes.
-func (r *convergeReconciler) retryPendingComment(ctx context.Context, preview *models.PreviewStack) (subReconcilerResult, error) {
-	if !preview.GitHubCommentPending {
-		return resultNil, nil
-	}
-	if !r.upsertComment(ctx, preview) {
-		return resultStop, nil // still failing; the periodic scan retries
-	}
-	preview.GitHubCommentPending = false
-	if _, sErr := r.previewStackStore.Update(ctx, preview); sErr != nil {
-		return resultNil, fmt.Errorf("failed to update preview status: %w", sErr)
-	}
-	return resultStop, nil
-}
-
 func buildOutputs(stack *models.Stack, commitSHA string) models.PreviewStackOutputs {
 	outputs := models.PreviewStackOutputs{
 		CommitSHA: commitSHA,
 	}
 	for _, res := range stack.StackResources {
-		if res.Status == nil {
-			continue
+		var gotURL bool
+		if res.Status != nil {
+			for _, ingress := range res.Status.PublicIngresses {
+				if ingress.URL == "" {
+					continue
+				}
+				outputs.URLs = append(outputs.URLs, models.PreviewURL{
+					Resource: res.Name,
+					URL:      ingress.URL,
+				})
+				gotURL = true
+			}
 		}
-		for _, ingress := range res.Status.PublicIngresses {
-			outputs.URLs = append(outputs.URLs, models.PreviewURL{
-				Resource: res.Name,
-				URL:      ingress.URL,
-			})
+		if !gotURL && exposesPublicPort(res) {
+			outputs.URLsPending = true
 		}
 	}
 	return outputs
+}
+
+func exposesPublicPort(res *models.StackResource) bool {
+	for _, port := range res.Ports {
+		if port.ExposedToPublic {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/worker/preview/converge_reconciler_test.go
+++ b/pkg/worker/preview/converge_reconciler_test.go
@@ -87,6 +87,8 @@ var _ = Describe("ConvergeReconciler", func() {
 
 			releaseSvc.EXPECT().InternalGet(gomock.Any(), releaseID).
 				Return(&models.StackRelease{ID: releaseID, State: models.ReleaseStateReleased}, nil)
+			stackSvc.EXPECT().InternalGetStack(gomock.Any(), "stack-1").
+				Return(&models.Stack{ID: "stack-1"}, nil)
 			commentService.EXPECT().InternalUpsertComment(gomock.Any(), preview).Return(nil)
 			previewStore.EXPECT().Update(gomock.Any(), preview).
 				DoAndReturn(func(ctx context.Context, p *models.PreviewStack) (*models.PreviewStack, *errors.ServiceError) {
@@ -111,13 +113,157 @@ var _ = Describe("ConvergeReconciler", func() {
 
 			releaseSvc.EXPECT().InternalGet(gomock.Any(), releaseID).
 				Return(&models.StackRelease{ID: releaseID, State: models.ReleaseStateReleased}, nil)
+			stackSvc.EXPECT().InternalGetStack(gomock.Any(), "stack-1").
+				Return(&models.Stack{ID: "stack-1"}, nil)
 			commentService.EXPECT().InternalUpsertComment(gomock.Any(), preview).
 				Return(stderrors.New("github down"))
+			previewStore.EXPECT().Update(gomock.Any(), preview).
+				DoAndReturn(func(ctx context.Context, p *models.PreviewStack) (*models.PreviewStack, *errors.ServiceError) {
+					Expect(p.GitHubCommentPending).To(BeTrue())
+					return p, nil
+				})
 
 			result, err := reconciler.Reconcile(ctx, preview)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(resultStop))
 			Expect(preview.GitHubCommentPending).To(BeTrue())
+		})
+	})
+
+	Context("pending public URLs", func() {
+		var (
+			preview   *models.PreviewStack
+			stackID   string
+			releaseID string
+			release   *models.StackRelease
+		)
+
+		exposedResource := func(status *models.StackResourceStatus) *models.StackResource {
+			return &models.StackResource{
+				Name:   "web",
+				Ports:  models.Ports{{Name: "http", Number: 8080, ExposedToPublic: true}},
+				Status: status,
+			}
+		}
+
+		BeforeEach(func() {
+			stackID = "stack-1"
+			releaseID = "rel-1"
+			release = &models.StackRelease{ID: releaseID, State: models.ReleaseStateReleased}
+			preview = &models.PreviewStack{
+				ID:              "p-urls",
+				StackID:         &stackID,
+				ActiveReleaseID: &releaseID,
+				CommitSHA:       "abc1234",
+				Status:          models.PreviewStackStatus{Phase: models.PreviewStackPhaseDeploying},
+			}
+		})
+
+		It("requeues and keeps the comment pending while an exposed resource has no URL", func() {
+			stack := &models.Stack{
+				ID:             stackID,
+				StackResources: []*models.StackResource{exposedResource(&models.StackResourceStatus{})},
+			}
+
+			releaseSvc.EXPECT().InternalGet(gomock.Any(), releaseID).Return(release, nil)
+			stackSvc.EXPECT().InternalGetStack(gomock.Any(), stackID).Return(stack, nil)
+			commentService.EXPECT().InternalUpsertComment(gomock.Any(), gomock.Any()).Return(nil)
+			previewStore.EXPECT().Update(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, p *models.PreviewStack) (*models.PreviewStack, *errors.ServiceError) {
+					Expect(p.Status.Phase).To(Equal(models.PreviewStackPhaseReady))
+					Expect(p.Status.Outputs.URLs).To(BeEmpty())
+					Expect(p.Status.Outputs.URLsPending).To(BeTrue())
+					Expect(p.GitHubCommentPending).To(BeTrue())
+					return p, nil
+				})
+
+			result, err := reconciler.Reconcile(ctx, preview)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(resultRequeueAfter(convergePollInterval)))
+		})
+
+		It("treats an ingress with an empty URL as still pending", func() {
+			stack := &models.Stack{
+				ID: stackID,
+				StackResources: []*models.StackResource{
+					exposedResource(&models.StackResourceStatus{PublicIngresses: []models.Ingress{{TargetPort: 8080}}}),
+				},
+			}
+
+			releaseSvc.EXPECT().InternalGet(gomock.Any(), releaseID).Return(release, nil)
+			stackSvc.EXPECT().InternalGetStack(gomock.Any(), stackID).Return(stack, nil)
+			commentService.EXPECT().InternalUpsertComment(gomock.Any(), gomock.Any()).Return(nil)
+			previewStore.EXPECT().Update(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, p *models.PreviewStack) (*models.PreviewStack, *errors.ServiceError) {
+					Expect(p.Status.Outputs.URLs).To(BeEmpty())
+					Expect(p.Status.Outputs.URLsPending).To(BeTrue())
+					return p, nil
+				})
+
+			result, err := reconciler.Reconcile(ctx, preview)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(resultRequeueAfter(convergePollInterval)))
+		})
+
+		It("finalises the comment on a later pass once the http fallback URL lands", func() {
+			preview.Status = models.PreviewStackStatus{
+				Phase:   models.PreviewStackPhaseReady,
+				Reason:  "ReleaseConverged",
+				Outputs: &models.PreviewStackOutputs{CommitSHA: "abc1234", URLsPending: true},
+			}
+			preview.GitHubCommentPending = true
+			preview.GitHubCommentID = 4242
+
+			stack := &models.Stack{
+				ID: stackID,
+				StackResources: []*models.StackResource{
+					exposedResource(&models.StackResourceStatus{
+						PublicIngresses: []models.Ingress{{URL: "http://pr-1-web.example.com", TargetPort: 8080}},
+					}),
+				},
+			}
+
+			releaseSvc.EXPECT().InternalGet(gomock.Any(), releaseID).Return(release, nil)
+			stackSvc.EXPECT().InternalGetStack(gomock.Any(), stackID).Return(stack, nil)
+			commentService.EXPECT().InternalUpsertComment(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, p *models.PreviewStack) error {
+					Expect(p.Status.Outputs.URLs).To(HaveLen(1))
+					Expect(p.Status.Outputs.URLs[0].URL).To(Equal("http://pr-1-web.example.com"))
+					return nil
+				})
+			previewStore.EXPECT().Update(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, p *models.PreviewStack) (*models.PreviewStack, *errors.ServiceError) {
+					Expect(p.Status.Outputs.URLsPending).To(BeFalse())
+					Expect(p.GitHubCommentPending).To(BeFalse())
+					return p, nil
+				})
+
+			result, err := reconciler.Reconcile(ctx, preview)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(resultStop))
+		})
+
+		It("does not wait on resources with no publicly exposed port", func() {
+			stack := &models.Stack{
+				ID: stackID,
+				StackResources: []*models.StackResource{
+					{Name: "worker", Ports: models.Ports{{Name: "metrics", Number: 9090}}, Status: &models.StackResourceStatus{}},
+				},
+			}
+
+			releaseSvc.EXPECT().InternalGet(gomock.Any(), releaseID).Return(release, nil)
+			stackSvc.EXPECT().InternalGetStack(gomock.Any(), stackID).Return(stack, nil)
+			commentService.EXPECT().InternalUpsertComment(gomock.Any(), gomock.Any()).Return(nil)
+			previewStore.EXPECT().Update(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, p *models.PreviewStack) (*models.PreviewStack, *errors.ServiceError) {
+					Expect(p.Status.Outputs.URLsPending).To(BeFalse())
+					Expect(p.GitHubCommentPending).To(BeFalse())
+					return p, nil
+				})
+
+			result, err := reconciler.Reconcile(ctx, preview)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(resultStop))
 		})
 	})
 


### PR DESCRIPTION
## Symptom

The preview-environment sticky PR comment goes up with **no public URLs** — just "Preview environment is live" and the commit SHA. The URLs show up in the UI minutes later, but the comment is never corrected.

## Root cause

The cluster agent writes ingress public URLs into `StackResource.Status.PublicIngresses` only **after** the TLS cert is issued — or, if issuance fails / a ~2 min grace window passes, after it falls back to `http://` URLs. Both happen *after* the release flips to `Released`.

`convergeReconciler` snapshots the stack the moment the release goes `Released`, builds `Outputs` from whatever `PublicIngresses` holds at that instant (usually nothing), posts the comment, and returns `resultStop`. Once the preview is `Ready` with `GitHubCommentPending` false it is excluded from `ListNeedingReconciliation`, so nothing ever revisits it.

## Fix

The comment is not final until the URLs are in it.

- `buildOutputs` now also reports `URLsPending`: true when a resource has a port with `ExposedToPublic` but no non-empty ingress URL yet. Ingress entries with an empty `URL` count as absent.
- The `Released` branch keeps `GitHubCommentPending = true` while `URLsPending` and returns `resultRequeueAfter(convergePollInterval)` (15s, the existing preview poll interval). The existing store query (`... OR github_comment_pending`) already keeps such previews in the reconcile list, so a process restart resumes it too — no schema change, no new loop.
- `retryPendingComment` is deleted. The pending path now falls through the normal Released path, so every retry re-reads the stack and re-renders — which is exactly what picks up late URLs (TLS or the `http://` fallback, either one). The comment machinery is edit-in-place, so repeated upserts are safe.
- The failure path clears `URLsPending` — no more URLs are coming for a failed release.

No hard cap: if URLs take longer than the grace window, the worker just keeps editing the same comment. Resources with no publicly exposed port never mark the comment pending, so a worker-only preview finalises immediately.

## Interim comment behaviour: (a) post now, edit later

The comment already carries state earlier in the flow (failed / deleted / live + commit SHA) and it is the only signal the PR author gets that the preview exists. Withholding it until URLs land would delay that by up to ~2 min and complicate the failure-comment path. So the comment posts immediately and shows

> _⏳ Public URLs are still being provisioned — this comment updates when they are ready._

in place of the URL table; the note is replaced by the table on a later pass.

## Tests

`pkg/worker/preview/converge_reconciler_test.go`:
- requeues and keeps the comment pending while an exposed resource has no URL
- an ingress entry with an empty URL counts as still pending
- a later pass with an `http://` fallback URL renders it into the comment, clears `URLsPending` and `GitHubCommentPending`, returns `resultStop`
- a resource with no publicly exposed port never marks the comment pending
- the two existing pending-comment retry specs updated: they now go through the full stack-refetch path

`pkg/services/preview_comment_service_test.go`: renders the pending note when no URLs have landed; drops it once they have.

## Verification

- `go build ./...` — pass
- `go vet ./pkg/...` — pass
- `go test ./pkg/worker/... ./pkg/services/` — all green
- `golangci-lint run ./pkg/worker/... ./pkg/services/...` — 0 issues
