### PR TITLE
Feature: API tokens settings page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import CanvasEditorPage from "@/pages/stacks/components/editor"
 import ClustersPage from "@/pages/clusters"
 import ClusterDetailPage from "@/pages/clusters/components/detail"
 import SecretsPage from "@/pages/secrets"
+import ApiTokensPage from "@/pages/api-tokens"
 import DomainsPage from "@/pages/domains"
 import AddonsPage from "@/pages/addons"
 import PostgresFormPage from "@/pages/addons/components/postgres-create-page"
@@ -68,6 +69,7 @@ const router = createBrowserRouter(
         <Route path="/previews/:configId" element={<PreviewConfigDetailPage />} />
         <Route path="/git-integrations" element={<GitIntegrationsPage />} />
         <Route path="/image-registries" element={<ImageRegistriesPage />} />
+        <Route path="/settings/api-tokens" element={<ApiTokensPage />} />
         {/* Workspace collaboration (Users + Projects) shelved — redirect home. */}
         <Route path="/settings/*" element={<Navigate to="/" replace />} />
       </Route>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import CanvasEditorPage from "@/pages/stacks/components/editor"
 import ClustersPage from "@/pages/clusters"
 import ClusterDetailPage from "@/pages/clusters/components/detail"
 import SecretsPage from "@/pages/secrets"
-import ApiTokensPage from "@/pages/api-tokens"
+import ApiTokensPage, { API_TOKENS_PATH } from "@/pages/api-tokens"
 import DomainsPage from "@/pages/domains"
 import AddonsPage from "@/pages/addons"
 import PostgresFormPage from "@/pages/addons/components/postgres-create-page"
@@ -69,7 +69,7 @@ const router = createBrowserRouter(
         <Route path="/previews/:configId" element={<PreviewConfigDetailPage />} />
         <Route path="/git-integrations" element={<GitIntegrationsPage />} />
         <Route path="/image-registries" element={<ImageRegistriesPage />} />
-        <Route path="/settings/api-tokens" element={<ApiTokensPage />} />
+        <Route path={API_TOKENS_PATH} element={<ApiTokensPage />} />
         {/* Workspace collaboration (Users + Projects) shelved — redirect home. */}
         <Route path="/settings/*" element={<Navigate to="/" replace />} />
       </Route>

--- a/frontend/src/api/api-tokens.ts
+++ b/frontend/src/api/api-tokens.ts
@@ -7,21 +7,23 @@ export type APITokenCreateRequest = components["schemas"]["APITokenCreateRequest
 export type APITokenCreateResponse = components["schemas"]["APITokenCreateResponse"];
 export type ScopeList = components["schemas"]["ScopeList"];
 
+const BASE = "/api-tokens";
+
 export async function listApiTokens(): Promise<APITokenList> {
-  const res = await api.get(`/api-tokens`);
+  const res = await api.get(BASE);
   return res.data as APITokenList;
 }
 
 export async function createApiToken(req: APITokenCreateRequest): Promise<APITokenCreateResponse> {
-  const res = await api.post(`/api-tokens`, req);
+  const res = await api.post(BASE, req);
   return res.data as APITokenCreateResponse;
 }
 
 export async function revokeApiToken(id: string): Promise<void> {
-  await api.delete(`/api-tokens/${id}`);
+  await api.delete(`${BASE}/${id}`);
 }
 
 export async function getApiTokenScopes(): Promise<ScopeList> {
-  const res = await api.get(`/api-tokens/scopes`);
+  const res = await api.get(`${BASE}/scopes`);
   return res.data as ScopeList;
 }

--- a/frontend/src/api/api-tokens.ts
+++ b/frontend/src/api/api-tokens.ts
@@ -1,0 +1,27 @@
+import api from "./client";
+import type { components } from "./types/openapi";
+
+export type APIToken = components["schemas"]["APIToken"];
+export type APITokenList = components["schemas"]["APITokenList"];
+export type APITokenCreateRequest = components["schemas"]["APITokenCreateRequest"];
+export type APITokenCreateResponse = components["schemas"]["APITokenCreateResponse"];
+export type ScopeList = components["schemas"]["ScopeList"];
+
+export async function listApiTokens(): Promise<APITokenList> {
+  const res = await api.get(`/api-tokens`);
+  return res.data as APITokenList;
+}
+
+export async function createApiToken(req: APITokenCreateRequest): Promise<APITokenCreateResponse> {
+  const res = await api.post(`/api-tokens`, req);
+  return res.data as APITokenCreateResponse;
+}
+
+export async function revokeApiToken(id: string): Promise<void> {
+  await api.delete(`/api-tokens/${id}`);
+}
+
+export async function getApiTokenScopes(): Promise<ScopeList> {
+  const res = await api.get(`/api-tokens/scopes`);
+  return res.data as ScopeList;
+}

--- a/frontend/src/api/tests/api-tokens.test.ts
+++ b/frontend/src/api/tests/api-tokens.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import api from "../client";
+import { createApiToken, listApiTokens, revokeApiToken, getApiTokenScopes } from "../api-tokens";
+
+vi.mock("../client", () => ({
+  default: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}));
+
+describe("api-tokens api", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("lists tokens", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { items: [] } });
+    await expect(listApiTokens()).resolves.toEqual({ items: [] });
+    expect(api.get).toHaveBeenCalledWith("/api-tokens");
+  });
+
+  it("creates a token and returns the one-time secret", async () => {
+    vi.mocked(api.post).mockResolvedValue({ data: { id: "t1", token: "sd_secret" } });
+    const res = await createApiToken({ name: "agent", scopes: ["*"] });
+    expect(res.token).toBe("sd_secret");
+    expect(api.post).toHaveBeenCalledWith("/api-tokens", { name: "agent", scopes: ["*"] });
+  });
+
+  it("revokes a token", async () => {
+    vi.mocked(api.delete).mockResolvedValue({});
+    await revokeApiToken("t1");
+    expect(api.delete).toHaveBeenCalledWith("/api-tokens/t1");
+  });
+
+  it("fetches scopes", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { full_access_scope: "*", items: [] } });
+    await expect(getApiTokenScopes()).resolves.toMatchObject({ full_access_scope: "*" });
+    expect(api.get).toHaveBeenCalledWith("/api-tokens/scopes");
+  });
+});

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -11,6 +11,7 @@ import { NavDomains } from "@/components/nav-domains"
 import { NavGitIntegrations } from "@/components/nav-git-integrations"
 import { NavImageRegistries } from "@/components/nav-image-registries"
 import { NavAddons } from "@/components/nav-addons"
+import { NavApiTokens } from "@/components/nav-api-tokens"
 import { NavUser } from "@/components/nav-user"
 import { getCurrentUser } from "@/lib/common"
 import { useCurrentUser } from "@/hooks/use-current-user"
@@ -72,6 +73,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             {isOrgAdmin && <NavClusters />}
             {isOrgAdmin && <NavDomains />}
             <NavAddons />
+            <NavApiTokens />
           </SidebarGroupContent>
         </SidebarGroup>
         {isOrgAdmin && (

--- a/frontend/src/components/nav-api-tokens.tsx
+++ b/frontend/src/components/nav-api-tokens.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Link, useLocation } from "react-router-dom"
+import { KeySquare } from "lucide-react"
+
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+
+export function NavApiTokens() {
+  const location = useLocation();
+  const isApiTokensActive = location.pathname.startsWith('/settings/api-tokens');
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          tooltip="API Tokens"
+          asChild
+          isActive={isApiTokensActive}
+        >
+          <Link to="/settings/api-tokens">
+            <KeySquare />
+            <span>API Tokens</span>
+          </Link>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}

--- a/frontend/src/components/nav-settings.tsx
+++ b/frontend/src/components/nav-settings.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Link, useLocation } from "react-router-dom"
-import { Users, FolderKanban, KeyRound } from "lucide-react"
+import { Users, FolderKanban } from "lucide-react"
 
 import {
   SidebarMenu,
@@ -26,14 +26,6 @@ export function NavSettings() {
           <Link to="/settings/projects">
             <FolderKanban />
             <span>Projects</span>
-          </Link>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
-      <SidebarMenuItem>
-        <SidebarMenuButton tooltip="API Tokens" asChild isActive={location.pathname.startsWith("/settings/api-tokens")}>
-          <Link to="/settings/api-tokens">
-            <KeyRound />
-            <span>API Tokens</span>
           </Link>
         </SidebarMenuButton>
       </SidebarMenuItem>

--- a/frontend/src/components/nav-settings.tsx
+++ b/frontend/src/components/nav-settings.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Link, useLocation } from "react-router-dom"
-import { Users, FolderKanban } from "lucide-react"
+import { Users, FolderKanban, KeyRound } from "lucide-react"
 
 import {
   SidebarMenu,
@@ -26,6 +26,14 @@ export function NavSettings() {
           <Link to="/settings/projects">
             <FolderKanban />
             <span>Projects</span>
+          </Link>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+      <SidebarMenuItem>
+        <SidebarMenuButton tooltip="API Tokens" asChild isActive={location.pathname.startsWith("/settings/api-tokens")}>
+          <Link to="/settings/api-tokens">
+            <KeyRound />
+            <span>API Tokens</span>
           </Link>
         </SidebarMenuButton>
       </SidebarMenuItem>

--- a/frontend/src/pages/api-tokens/access.ts
+++ b/frontend/src/pages/api-tokens/access.ts
@@ -1,0 +1,27 @@
+import type { ScopeList } from "@/api/api-tokens";
+
+// Actions that only observe. Anything outside this set (write, delete, exec,
+// create) makes a token capable of change, so read-only must not grant it.
+const READ_ONLY_ACTIONS = new Set(["read", "list"]);
+
+export const READ_ONLY = "read-only";
+export const FULL_ACCESS = "full-access";
+
+export function readOnlyScopes(scopes: ScopeList): string[] {
+  return (scopes.items ?? []).flatMap((entry) =>
+    entry.resource
+      ? (entry.actions ?? [])
+        .filter((action) => READ_ONLY_ACTIONS.has(action))
+        .map((action) => `${entry.resource}:${action}`)
+      : [],
+  );
+}
+
+// ponytail: the UI mints only these two levels, so "not all read/list" means
+// full access. A token scoped by hand through the API would read as Full
+// access too — the row's tooltip carries the exact scopes either way.
+export function accessLabel(scopes?: string[]): string {
+  if (!scopes?.length) return "—";
+  const readOnly = scopes.every((scope) => READ_ONLY_ACTIONS.has(scope.split(":")[1]));
+  return readOnly ? "Read-only" : "Full access";
+}

--- a/frontend/src/pages/api-tokens/access.ts
+++ b/frontend/src/pages/api-tokens/access.ts
@@ -17,9 +17,8 @@ export function readOnlyScopes(scopes: ScopeList): string[] {
   );
 }
 
-// ponytail: the UI mints only these two levels, so "not all read/list" means
-// full access. A token scoped by hand through the API would read as Full
-// access too — the row's tooltip carries the exact scopes either way.
+// Hand-scoped tokens from the API also read as "Full access"; the row title
+// carries the exact scopes.
 export function accessLabel(scopes?: string[]): string {
   if (!scopes?.length) return "—";
   const readOnly = scopes.every((scope) => READ_ONLY_ACTIONS.has(scope.split(":")[1]));

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -39,8 +39,14 @@ function scopeKey(resource: string, action: string): string {
 // Native <input type="date"> only carries a calendar day — treat it as the
 // end of that day in the user's local time so "expires on this date" reads
 // naturally, then hand the API an RFC3339 timestamp.
+//
+// Built from numeric y/m/d rather than parsing a "YYYY-MM-DDTHH:mm:ss" string:
+// a date-time string with no timezone offset is local time in every current
+// engine, but some older engines read it as UTC — the numeric constructor
+// can't be ambiguous either way.
 function endOfDayRFC3339(date: string): string {
-  return new Date(`${date}T23:59:59`).toISOString();
+  const [year, month, day] = date.split("-").map(Number);
+  return new Date(year, month - 1, day, 23, 59, 59).toISOString();
 }
 
 export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateTokenDialogProps) {

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -58,10 +58,14 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
     setFullAccess(true);
     setSelectedScopes(new Set());
     setError(null);
+    setScopesError(null);
     setCreated(null);
     setCopied(false);
     getApiTokenScopes()
-      .then(setScopes)
+      .then((res) => {
+        setScopes(res);
+        setScopesError(null);
+      })
       .catch((e) => setScopesError(getErrorMessage(e)));
   }, [open]);
 

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -11,8 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
-import { badgeVariants } from "@/components/ui/badge";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useToast } from "@/components/ui/use-toast";
 import { FieldShell } from "@/components/branded";
 import { cn } from "@/lib/utils";
@@ -23,36 +22,21 @@ import {
   type ScopeList,
 } from "@/api/api-tokens";
 import { getErrorMessage } from "@/api/client";
+import { API_BASE_URL } from "@/api/base-url";
 import { copyText } from "@/lib/clipboard";
+import { FULL_ACCESS, READ_ONLY, readOnlyScopes } from "../access";
 
 const COPY_FLASH_MS = 1400;
+
+// The CLI needs the server origin, which is the UI's own only when the API is
+// same-origin or dev-proxied. An absolute VITE_API_BASE_URL carries its own.
+const SERVER_URL = new URL(API_BASE_URL, window.location.origin).origin;
 
 interface CreateTokenDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** Called once the show-once token view is dismissed, so the list can refresh. */
   onCreated: () => void;
-}
-
-function scopeKey(resource: string, action: string): string {
-  return `${resource}:${action}`;
-}
-
-function ScopeChip({ label, selected, onToggle }: { label: string; selected: boolean; onToggle: () => void }) {
-  return (
-    <button
-      type="button"
-      aria-pressed={selected}
-      onClick={onToggle}
-      className={cn(
-        badgeVariants({ variant: selected ? "default" : "outline" }),
-        "cursor-pointer font-mono",
-        !selected && "text-muted-foreground hover:bg-accent hover:text-foreground",
-      )}
-    >
-      {label}
-    </button>
-  );
 }
 
 // Native <input type="date"> only carries a calendar day — treat it as the
@@ -72,8 +56,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
   const { toast } = useToast();
   const [name, setName] = useState("");
   const [expiry, setExpiry] = useState("");
-  const [fullAccess, setFullAccess] = useState(false);
-  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set());
+  const [preset, setPreset] = useState(READ_ONLY);
   const [scopes, setScopes] = useState<ScopeList | null>(null);
   const [scopesError, setScopesError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -88,8 +71,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
     if (!open) return;
     setName("");
     setExpiry("");
-    setFullAccess(false);
-    setSelectedScopes(new Set());
+    setPreset(READ_ONLY);
     setError(null);
     setScopesError(null);
     setCopied(false);
@@ -101,18 +83,11 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
       .catch((e) => setScopesError(getErrorMessage(e)));
   }, [open]);
 
-  function toggleScope(resource: string, action: string) {
-    const key = scopeKey(resource, action);
-    setSelectedScopes((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-      return next;
-    });
-  }
+  const grantedScopes = !scopes
+    ? []
+    : preset === FULL_ACCESS
+      ? [scopes.full_access_scope].filter((s): s is string => !!s)
+      : readOnlyScopes(scopes);
 
   async function handleCreate() {
     setError(null);
@@ -130,13 +105,8 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
       setError("Scopes haven't loaded yet.");
       return;
     }
-    if (fullAccess && !scopes.full_access_scope) {
-      setError("The server didn't provide a full-access scope.");
-      return;
-    }
-    const requestedScopes = fullAccess ? [scopes.full_access_scope as string] : [...selectedScopes];
-    if (requestedScopes.length === 0) {
-      setError("Select at least one scope.");
+    if (grantedScopes.length === 0) {
+      setError("The server didn't provide any scopes for this access level.");
       return;
     }
 
@@ -144,7 +114,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
     try {
       const res = await createApiToken({
         name: name.trim(),
-        scopes: requestedScopes,
+        scopes: grantedScopes,
         expires_at: expiry ? endOfDayRFC3339(expiry) : undefined,
       });
       setCreated(res);
@@ -184,11 +154,11 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
               <DialogTitle>Token created</DialogTitle>
               <DialogDescription>You won&apos;t see this again — copy it now.</DialogDescription>
             </DialogHeader>
-            <div className="space-y-4 py-2">
-              <div className="space-y-1.5">
+            <div className="min-w-0 space-y-4 py-2">
+              <div className="min-w-0 space-y-1.5">
                 <Label>Token</Label>
                 <div className="flex items-center gap-2">
-                  <pre className="flex-1 overflow-x-auto rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-xs">
+                  <pre className="min-w-0 flex-1 overflow-x-auto rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-xs">
                     {created.token}
                   </pre>
                   <Button
@@ -207,7 +177,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
                 <Input
                   id="token-quickstart"
                   readOnly
-                  value={`stackdome login --url ${window.location.origin} --token ${created.token}`}
+                  value={`stackdome login --url ${SERVER_URL} --token ${created.token}`}
                   onFocus={(e) => e.currentTarget.select()}
                   className="font-mono text-xs"
                 />
@@ -222,93 +192,82 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
             <DialogHeader>
               <DialogTitle>Create token</DialogTitle>
               <DialogDescription>
-                Tokens act on your behalf — scope them to only what the caller needs.
+                Tokens act on your behalf. Pick what the caller is for.
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-5 py-2">
               {error && <div className="text-sm text-danger bg-danger-bg p-3 rounded-md">{error}</div>}
 
-              <FieldShell label="Name" htmlFor="token-name" required>
-                <Input
-                  id="token-name"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  placeholder="e.g. ci, agent"
-                />
-              </FieldShell>
+              <div className="grid grid-cols-2 gap-4">
+                <FieldShell label="Name" htmlFor="token-name" required>
+                  <Input
+                    id="token-name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="e.g. ci, agent"
+                  />
+                </FieldShell>
 
-              <FieldShell label="Expires" htmlFor="token-expiry" hint="Leave blank for a token that never expires.">
-                <Input
-                  id="token-expiry"
-                  type="date"
-                  min={new Date().toISOString().slice(0, 10)}
-                  value={expiry}
-                  onChange={(e) => setExpiry(e.target.value)}
-                />
-              </FieldShell>
+                <FieldShell label="Expires" htmlFor="token-expiry" hint="Blank never expires.">
+                  <Input
+                    id="token-expiry"
+                    type="date"
+                    min={new Date().toISOString().slice(0, 10)}
+                    value={expiry}
+                    onChange={(e) => setExpiry(e.target.value)}
+                  />
+                </FieldShell>
+              </div>
 
-              <FieldShell label="Scopes" required>
-                <div className="rounded-md border border-border">
-                  <div className="flex items-center justify-between gap-2 p-3">
-                    <div className="space-y-0.5">
-                      <Label htmlFor="full-access" className="font-normal">
-                        Full access
-                      </Label>
-                      {fullAccess && (
-                        <p className="text-xs text-danger">This token can do anything you can.</p>
-                      )}
-                    </div>
-                    <Switch id="full-access" checked={fullAccess} onCheckedChange={setFullAccess} />
-                  </div>
-                  {scopesError && <p className="px-3 pb-3 text-xs text-danger">{scopesError}</p>}
-                  {!scopesError && !scopes && (
-                    <p className="px-3 pb-3 text-xs text-muted-foreground">Loading available scopes…</p>
-                  )}
-                  {!fullAccess && scopes && (
-                    <>
-                      <div className="flex items-center justify-between gap-2 border-t border-border px-3 py-2">
-                        <span className="text-xs text-muted-foreground">
-                          {selectedScopes.size} selected
-                        </span>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-auto px-2 py-1 text-xs"
-                          disabled={selectedScopes.size === 0}
-                          onClick={() => setSelectedScopes(new Set())}
+              <div className="space-y-2">
+                <span className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+                  Access
+                </span>
+                {scopesError && <p className="text-xs text-danger">{scopesError}</p>}
+                {!scopesError && !scopes && (
+                  <p className="text-xs text-muted-foreground">Loading available scopes…</p>
+                )}
+                {scopes && (
+                  <RadioGroup value={preset} onValueChange={setPreset} className="grid grid-cols-2 gap-3">
+                    {[
+                      {
+                        id: READ_ONLY,
+                        title: "Read-only",
+                        description: "Observe everything, change nothing.",
+                        grants: `${readOnlyScopes(scopes).length} scopes`,
+                      },
+                      {
+                        id: FULL_ACCESS,
+                        title: "Full access",
+                        description: "Everything you can do, including deploys.",
+                        grants: "all scopes",
+                      },
+                    ].map((option, index) => {
+                      const active = preset === option.id;
+                      return (
+                        <Label
+                          key={option.id}
+                          htmlFor={`preset-${option.id}`}
+                          className={cn(
+                            "flex cursor-pointer flex-col items-start gap-1 rounded-md border p-3 font-normal",
+                            active ? "border-brand-border bg-brand-bg" : "border-border hover:bg-muted/50",
+                          )}
                         >
-                          Clear
-                        </Button>
-                      </div>
-                      <div className="max-h-[280px] divide-y divide-border overflow-y-auto border-t border-border">
-                        {scopes.items?.map((resource) =>
-                          resource.resource ? (
-                            <div key={resource.resource} className="flex items-start gap-3 px-3 py-2">
-                              <span className="w-36 shrink-0 pt-1 font-mono text-xs break-all text-muted-foreground">
-                                {resource.resource}
-                              </span>
-                              <div className="flex flex-1 flex-wrap gap-1.5">
-                                {resource.actions?.map((action) => {
-                                  const key = scopeKey(resource.resource!, action);
-                                  return (
-                                    <ScopeChip
-                                      key={key}
-                                      label={action}
-                                      selected={selectedScopes.has(key)}
-                                      onToggle={() => toggleScope(resource.resource!, action)}
-                                    />
-                                  );
-                                })}
-                              </div>
-                            </div>
-                          ) : null,
-                        )}
-                      </div>
-                    </>
-                  )}
-                </div>
-              </FieldShell>
+                          <div className="flex w-full items-center justify-between">
+                            <span className={cn("font-mono text-[11px]", active ? "text-brand" : "text-muted-foreground")}>
+                              {String(index + 1).padStart(2, "0")}
+                            </span>
+                            <RadioGroupItem id={`preset-${option.id}`} value={option.id} />
+                          </div>
+                          <span className="text-sm font-medium text-foreground">{option.title}</span>
+                          <span className="text-xs text-muted-foreground">{option.description}</span>
+                          <span className="font-mono text-[11px] text-muted-foreground">{option.grants}</span>
+                        </Label>
+                      );
+                    })}
+                  </RadioGroup>
+                )}
+              </div>
             </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => onOpenChange(false)} disabled={creating}>

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -230,19 +230,9 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
                 {scopes && (
                   <RadioGroup value={preset} onValueChange={setPreset} className="grid grid-cols-2 gap-3">
                     {[
-                      {
-                        id: READ_ONLY,
-                        title: "Read-only",
-                        description: "Observe everything, change nothing.",
-                        grants: `${readOnlyScopes(scopes).length} scopes`,
-                      },
-                      {
-                        id: FULL_ACCESS,
-                        title: "Full access",
-                        description: "Everything you can do, including deploys.",
-                        grants: "all scopes",
-                      },
-                    ].map((option, index) => {
+                      { id: READ_ONLY, title: "Read-only", description: "Observe everything, change nothing." },
+                      { id: FULL_ACCESS, title: "Full access", description: "Everything you can do, including deploys." },
+                    ].map((option) => {
                       const active = preset === option.id;
                       return (
                         <Label
@@ -253,15 +243,11 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
                             active ? "border-brand-border bg-brand-bg" : "border-border hover:bg-muted/50",
                           )}
                         >
-                          <div className="flex w-full items-center justify-between">
-                            <span className={cn("font-mono text-[11px]", active ? "text-brand" : "text-muted-foreground")}>
-                              {String(index + 1).padStart(2, "0")}
-                            </span>
+                          <div className="flex w-full items-center justify-between gap-2">
+                            <span className="text-sm font-medium text-foreground">{option.title}</span>
                             <RadioGroupItem id={`preset-${option.id}`} value={option.id} />
                           </div>
-                          <span className="text-sm font-medium text-foreground">{option.title}</span>
                           <span className="text-xs text-muted-foreground">{option.description}</span>
-                          <span className="font-mono text-[11px] text-muted-foreground">{option.grants}</span>
                         </Label>
                       );
                     })}

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -12,8 +12,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { badgeVariants } from "@/components/ui/badge";
 import { useToast } from "@/components/ui/use-toast";
 import { FieldShell } from "@/components/branded";
+import { cn } from "@/lib/utils";
 import {
   createApiToken,
   getApiTokenScopes,
@@ -36,6 +38,23 @@ function scopeKey(resource: string, action: string): string {
   return `${resource}:${action}`;
 }
 
+function ScopeChip({ label, selected, onToggle }: { label: string; selected: boolean; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      onClick={onToggle}
+      className={cn(
+        badgeVariants({ variant: selected ? "default" : "outline" }),
+        "cursor-pointer font-mono",
+        !selected && "text-muted-foreground hover:bg-accent hover:text-foreground",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
 // Native <input type="date"> only carries a calendar day — treat it as the
 // end of that day in the user's local time so "expires on this date" reads
 // naturally, then hand the API an RFC3339 timestamp.
@@ -53,7 +72,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
   const { toast } = useToast();
   const [name, setName] = useState("");
   const [expiry, setExpiry] = useState("");
-  const [fullAccess, setFullAccess] = useState(true);
+  const [fullAccess, setFullAccess] = useState(false);
   const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set());
   const [scopes, setScopes] = useState<ScopeList | null>(null);
   const [scopesError, setScopesError] = useState<string | null>(null);
@@ -69,7 +88,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
     if (!open) return;
     setName("");
     setExpiry("");
-    setFullAccess(true);
+    setFullAccess(false);
     setSelectedScopes(new Set());
     setError(null);
     setScopesError(null);
@@ -99,6 +118,10 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
     setError(null);
     if (!name.trim()) {
       setError("Name is required.");
+      return;
+    }
+    if (expiry && new Date(endOfDayRFC3339(expiry)) <= new Date()) {
+      setError("Expiry must be in the future.");
       return;
     }
     // Scopes come from the server contract — never guess a full-access scope
@@ -154,7 +177,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && handleClose()}>
-      <DialogContent className="sm:max-w-[500px]">
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-[560px]">
         {created ? (
           <>
             <DialogHeader>
@@ -199,7 +222,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
             <DialogHeader>
               <DialogTitle>Create token</DialogTitle>
               <DialogDescription>
-                Issue an API token for scripts, CI, or agents to authenticate as you.
+                Tokens act on your behalf — scope them to only what the caller needs.
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-5 py-2">
@@ -218,45 +241,71 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
                 <Input
                   id="token-expiry"
                   type="date"
+                  min={new Date().toISOString().slice(0, 10)}
                   value={expiry}
                   onChange={(e) => setExpiry(e.target.value)}
                 />
               </FieldShell>
 
               <FieldShell label="Scopes" required>
-                <div className="space-y-3 rounded-md border border-border p-3">
-                  <div className="flex items-center justify-between gap-2">
-                    <Label htmlFor="full-access" className="font-normal">
-                      Full access
-                    </Label>
-                    <Switch id="full-access" checked={fullAccess} onCheckedChange={setFullAccess} />
-                  </div>
-                  {scopesError && <p className="text-xs text-danger">{scopesError}</p>}
-                  {!scopesError && !scopes && (
-                    <p className="text-xs text-muted-foreground">Loading available scopes…</p>
-                  )}
-                  {!fullAccess && (
-                    <div className="space-y-2 border-t border-border pt-3">
-                      {scopes?.items?.map((resource) =>
-                        resource.resource
-                          ? resource.actions?.map((action) => {
-                            const key = scopeKey(resource.resource!, action);
-                            return (
-                              <div key={key} className="flex items-center justify-between gap-2">
-                                <Label htmlFor={key} className="font-mono text-xs font-normal">
-                                  {key}
-                                </Label>
-                                <Switch
-                                  id={key}
-                                  checked={selectedScopes.has(key)}
-                                  onCheckedChange={() => toggleScope(resource.resource!, action)}
-                                />
-                              </div>
-                            );
-                          })
-                          : null,
+                <div className="rounded-md border border-border">
+                  <div className="flex items-center justify-between gap-2 p-3">
+                    <div className="space-y-0.5">
+                      <Label htmlFor="full-access" className="font-normal">
+                        Full access
+                      </Label>
+                      {fullAccess && (
+                        <p className="text-xs text-danger">This token can do anything you can.</p>
                       )}
                     </div>
+                    <Switch id="full-access" checked={fullAccess} onCheckedChange={setFullAccess} />
+                  </div>
+                  {scopesError && <p className="px-3 pb-3 text-xs text-danger">{scopesError}</p>}
+                  {!scopesError && !scopes && (
+                    <p className="px-3 pb-3 text-xs text-muted-foreground">Loading available scopes…</p>
+                  )}
+                  {!fullAccess && scopes && (
+                    <>
+                      <div className="flex items-center justify-between gap-2 border-t border-border px-3 py-2">
+                        <span className="text-xs text-muted-foreground">
+                          {selectedScopes.size} selected
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-auto px-2 py-1 text-xs"
+                          disabled={selectedScopes.size === 0}
+                          onClick={() => setSelectedScopes(new Set())}
+                        >
+                          Clear
+                        </Button>
+                      </div>
+                      <div className="max-h-[280px] divide-y divide-border overflow-y-auto border-t border-border">
+                        {scopes.items?.map((resource) =>
+                          resource.resource ? (
+                            <div key={resource.resource} className="flex items-start gap-3 px-3 py-2">
+                              <span className="w-36 shrink-0 pt-1 font-mono text-xs break-all text-muted-foreground">
+                                {resource.resource}
+                              </span>
+                              <div className="flex flex-1 flex-wrap gap-1.5">
+                                {resource.actions?.map((action) => {
+                                  const key = scopeKey(resource.resource!, action);
+                                  return (
+                                    <ScopeChip
+                                      key={key}
+                                      label={action}
+                                      selected={selectedScopes.has(key)}
+                                      onToggle={() => toggleScope(resource.resource!, action)}
+                                    />
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          ) : null,
+                        )}
+                      </div>
+                    </>
                   )}
                 </div>
               </FieldShell>

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useState } from "react";
+import { Copy, Check, Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { FieldShell } from "@/components/branded";
+import {
+  createApiToken,
+  getApiTokenScopes,
+  type APITokenCreateResponse,
+  type ScopeList,
+} from "@/api/api-tokens";
+import { getErrorMessage } from "@/api/client";
+
+interface CreateTokenDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called once the show-once token view is dismissed, so the list can refresh. */
+  onCreated: () => void;
+}
+
+function scopeKey(resource: string, action: string): string {
+  return `${resource}:${action}`;
+}
+
+// Native <input type="date"> only carries a calendar day — treat it as the
+// end of that day in the user's local time so "expires on this date" reads
+// naturally, then hand the API an RFC3339 timestamp.
+function endOfDayRFC3339(date: string): string {
+  return new Date(`${date}T23:59:59`).toISOString();
+}
+
+export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateTokenDialogProps) {
+  const [name, setName] = useState("");
+  const [expiry, setExpiry] = useState("");
+  const [fullAccess, setFullAccess] = useState(true);
+  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set());
+  const [scopes, setScopes] = useState<ScopeList | null>(null);
+  const [scopesError, setScopesError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [created, setCreated] = useState<APITokenCreateResponse | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setName("");
+    setExpiry("");
+    setFullAccess(true);
+    setSelectedScopes(new Set());
+    setError(null);
+    setCreated(null);
+    setCopied(false);
+    getApiTokenScopes()
+      .then(setScopes)
+      .catch((e) => setScopesError(getErrorMessage(e)));
+  }, [open]);
+
+  function toggleScope(resource: string, action: string) {
+    const key = scopeKey(resource, action);
+    setSelectedScopes((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }
+
+  async function handleCreate() {
+    setError(null);
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    const requestedScopes = fullAccess
+      ? [scopes?.full_access_scope ?? "*"]
+      : [...selectedScopes];
+    if (requestedScopes.length === 0) {
+      setError("Select at least one scope.");
+      return;
+    }
+
+    setCreating(true);
+    try {
+      const res = await createApiToken({
+        name: name.trim(),
+        scopes: requestedScopes,
+        expires_at: expiry ? endOfDayRFC3339(expiry) : undefined,
+      });
+      setCreated(res);
+    } catch (e) {
+      setError(getErrorMessage(e));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!created?.token) return;
+    await navigator.clipboard.writeText(created.token);
+    setCopied(true);
+  }
+
+  function handleClose() {
+    const wasCreated = created !== null;
+    onOpenChange(false);
+    if (wasCreated) onCreated();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && handleClose()}>
+      <DialogContent className="sm:max-w-[500px]">
+        {created ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Token created</DialogTitle>
+              <DialogDescription>You won&apos;t see this again — copy it now.</DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-2">
+              <div className="space-y-1.5">
+                <Label>Token</Label>
+                <div className="flex items-center gap-2">
+                  <pre className="flex-1 overflow-x-auto rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-xs">
+                    {created.token}
+                  </pre>
+                  <Button type="button" variant="outline" size="icon" onClick={handleCopy} title="Copy token">
+                    {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                  </Button>
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="token-quickstart">Quick start</Label>
+                <Input
+                  id="token-quickstart"
+                  readOnly
+                  value={`stackdome login --url ${window.location.origin} --token ${created.token}`}
+                  onFocus={(e) => e.currentTarget.select()}
+                  className="font-mono text-xs"
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button onClick={handleClose}>Done</Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Create token</DialogTitle>
+              <DialogDescription>
+                Issue an API token for scripts, CI, or agents to authenticate as you.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-5 py-2">
+              {error && <div className="text-sm text-danger bg-danger-bg p-3 rounded-md">{error}</div>}
+
+              <FieldShell label="Name" htmlFor="token-name" required>
+                <Input
+                  id="token-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g. ci, agent"
+                />
+              </FieldShell>
+
+              <FieldShell label="Expires" htmlFor="token-expiry" hint="Leave blank for a token that never expires.">
+                <Input
+                  id="token-expiry"
+                  type="date"
+                  value={expiry}
+                  onChange={(e) => setExpiry(e.target.value)}
+                />
+              </FieldShell>
+
+              <FieldShell label="Scopes" required>
+                <div className="space-y-3 rounded-md border border-border p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <Label htmlFor="full-access" className="font-normal">
+                      Full access
+                    </Label>
+                    <Switch id="full-access" checked={fullAccess} onCheckedChange={setFullAccess} />
+                  </div>
+                  {scopesError && <p className="text-xs text-danger">{scopesError}</p>}
+                  {!fullAccess && (
+                    <div className="space-y-2 border-t border-border pt-3">
+                      {scopes?.items?.map((resource) =>
+                        resource.resource
+                          ? resource.actions?.map((action) => {
+                            const key = scopeKey(resource.resource!, action);
+                            return (
+                              <div key={key} className="flex items-center justify-between gap-2">
+                                <Label htmlFor={key} className="font-mono text-xs font-normal">
+                                  {key}
+                                </Label>
+                                <Switch
+                                  id={key}
+                                  checked={selectedScopes.has(key)}
+                                  onCheckedChange={() => toggleScope(resource.resource!, action)}
+                                />
+                              </div>
+                            );
+                          })
+                          : null,
+                      )}
+                    </div>
+                  )}
+                </div>
+              </FieldShell>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={creating}>
+                Cancel
+              </Button>
+              <Button onClick={handleCreate} disabled={creating}>
+                {creating && <Loader2 className="h-4 w-4 animate-spin" />}
+                Create
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Copy, Check, Loader2 } from "lucide-react";
 import {
   Dialog,
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { useToast } from "@/components/ui/use-toast";
 import { FieldShell } from "@/components/branded";
 import {
   createApiToken,
@@ -20,6 +21,9 @@ import {
   type ScopeList,
 } from "@/api/api-tokens";
 import { getErrorMessage } from "@/api/client";
+import { copyText } from "@/lib/clipboard";
+
+const COPY_FLASH_MS = 1400;
 
 interface CreateTokenDialogProps {
   open: boolean;
@@ -40,6 +44,7 @@ function endOfDayRFC3339(date: string): string {
 }
 
 export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateTokenDialogProps) {
+  const { toast } = useToast();
   const [name, setName] = useState("");
   const [expiry, setExpiry] = useState("");
   const [fullAccess, setFullAccess] = useState(true);
@@ -50,6 +55,9 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
   const [error, setError] = useState<string | null>(null);
   const [created, setCreated] = useState<APITokenCreateResponse | null>(null);
   const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => () => { if (copyTimer.current) clearTimeout(copyTimer.current); }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -59,7 +67,6 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
     setSelectedScopes(new Set());
     setError(null);
     setScopesError(null);
-    setCreated(null);
     setCopied(false);
     getApiTokenScopes()
       .then((res) => {
@@ -88,9 +95,17 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
       setError("Name is required.");
       return;
     }
-    const requestedScopes = fullAccess
-      ? [scopes?.full_access_scope ?? "*"]
-      : [...selectedScopes];
+    // Scopes come from the server contract — never guess a full-access scope
+    // when that contract couldn't be read.
+    if (!scopes) {
+      setError("Scopes haven't loaded yet.");
+      return;
+    }
+    if (fullAccess && !scopes.full_access_scope) {
+      setError("The server didn't provide a full-access scope.");
+      return;
+    }
+    const requestedScopes = fullAccess ? [scopes.full_access_scope as string] : [...selectedScopes];
     if (requestedScopes.length === 0) {
       setError("Select at least one scope.");
       return;
@@ -113,13 +128,21 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
 
   async function handleCopy() {
     if (!created?.token) return;
-    await navigator.clipboard.writeText(created.token);
+    try {
+      await copyText(created.token);
+    } catch (e) {
+      toast({ title: "Copy failed", description: getErrorMessage(e), variant: "destructive" });
+      return;
+    }
     setCopied(true);
+    if (copyTimer.current) clearTimeout(copyTimer.current);
+    copyTimer.current = setTimeout(() => setCopied(false), COPY_FLASH_MS);
   }
 
   function handleClose() {
     const wasCreated = created !== null;
     onOpenChange(false);
+    setCreated(null);
     if (wasCreated) onCreated();
   }
 
@@ -139,7 +162,13 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
                   <pre className="flex-1 overflow-x-auto rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-xs">
                     {created.token}
                   </pre>
-                  <Button type="button" variant="outline" size="icon" onClick={handleCopy} title="Copy token">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={handleCopy}
+                    aria-label={copied ? "Copied" : "Copy token"}
+                  >
                     {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
                   </Button>
                 </div>
@@ -197,6 +226,9 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
                     <Switch id="full-access" checked={fullAccess} onCheckedChange={setFullAccess} />
                   </div>
                   {scopesError && <p className="text-xs text-danger">{scopesError}</p>}
+                  {!scopesError && !scopes && (
+                    <p className="text-xs text-muted-foreground">Loading available scopes…</p>
+                  )}
                   {!fullAccess && (
                     <div className="space-y-2 border-t border-border pt-3">
                       {scopes?.items?.map((resource) =>
@@ -227,7 +259,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
               <Button variant="outline" onClick={() => onOpenChange(false)} disabled={creating}>
                 Cancel
               </Button>
-              <Button onClick={handleCreate} disabled={creating}>
+              <Button onClick={handleCreate} disabled={creating || !scopes}>
                 {creating && <Loader2 className="h-4 w-4 animate-spin" />}
                 Create
               </Button>

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -219,10 +219,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
                 </FieldShell>
               </div>
 
-              <div className="space-y-2">
-                <span className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
-                  Access
-                </span>
+              <FieldShell label="Access" required>
                 {scopesError && <p className="text-xs text-danger">{scopesError}</p>}
                 {!scopesError && !scopes && (
                   <p className="text-xs text-muted-foreground">Loading available scopes…</p>
@@ -253,7 +250,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
                     })}
                   </RadioGroup>
                 )}
-              </div>
+              </FieldShell>
             </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => onOpenChange(false)} disabled={creating}>

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -52,6 +52,15 @@ function endOfDayRFC3339(date: string): string {
   return new Date(year, month - 1, day, 23, 59, 59).toISOString();
 }
 
+// Local, not toISOString(): the picker's floor has to agree with the local
+// end-of-day above, or today is greyed out for anyone west of UTC.
+function todayLocal(): string {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
 export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateTokenDialogProps) {
   const { toast } = useToast();
   const [name, setName] = useState("");
@@ -73,6 +82,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
     setExpiry("");
     setPreset(READ_ONLY);
     setError(null);
+    setScopes(null);
     setScopesError(null);
     setCopied(false);
     getApiTokenScopes()
@@ -156,7 +166,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
             </DialogHeader>
             <div className="min-w-0 space-y-4 py-2">
               <div className="min-w-0 space-y-1.5">
-                <Label>Token</Label>
+                <span className="flex items-center gap-2 text-sm leading-none font-medium select-none">Token</span>
                 <div className="flex items-center gap-2">
                   <pre className="min-w-0 flex-1 overflow-x-auto rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-xs">
                     {created.token}
@@ -212,7 +222,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
                   <Input
                     id="token-expiry"
                     type="date"
-                    min={new Date().toISOString().slice(0, 10)}
+                    min={todayLocal()}
                     value={expiry}
                     onChange={(e) => setExpiry(e.target.value)}
                   />
@@ -253,7 +263,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
               </FieldShell>
             </div>
             <DialogFooter>
-              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={creating}>
+              <Button variant="outline" onClick={handleClose} disabled={creating}>
                 Cancel
               </Button>
               <Button onClick={handleCreate} disabled={creating || !scopes}>

--- a/frontend/src/pages/api-tokens/index.tsx
+++ b/frontend/src/pages/api-tokens/index.tsx
@@ -103,7 +103,7 @@ export default function ApiTokensPage() {
         <PageHeader
           eyebrow="Platform"
           title="API Tokens"
-          subtitle="Issue tokens for scripts, CI, and agents to authenticate as you"
+          subtitle="Issue tokens for scripts, CI, and agents"
           actions={
             <Button onClick={() => setShowCreateDialog(true)}>
               <PlusCircle className="h-4 w-4" />
@@ -116,7 +116,7 @@ export default function ApiTokensPage() {
           <EmptyState
             icon={<KeyRound className="h-8 w-8" />}
             title="No API tokens yet"
-            description="Create a token to let scripts, CI, or agents authenticate as you."
+            description="Create a token to let scripts, CI, or agents call the API."
             action={
               <Button onClick={() => setShowCreateDialog(true)}>
                 <PlusCircle className="h-4 w-4" />

--- a/frontend/src/pages/api-tokens/index.tsx
+++ b/frontend/src/pages/api-tokens/index.tsx
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useState } from "react";
+import { PlusCircle, AlertCircle, Loader2, KeyRound } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { PageHeader, Panel, EmptyState } from "@/components/branded";
+import { useConfirm } from "@/components/branded/confirm";
+import { useToast } from "@/components/ui/use-toast";
+import { listApiTokens, revokeApiToken, type APIToken } from "@/api/api-tokens";
+import { getErrorMessage } from "@/api/client";
+import { useBreadcrumb } from "@/hooks/use-breadcrumb";
+import { CreateTokenDialog } from "./components/create-token-dialog";
+import { cn } from "@/lib/utils";
+
+function formatDate(value?: string): string {
+  if (!value) return "Never";
+  return new Date(value).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+export default function ApiTokensPage() {
+  const [tokens, setTokens] = useState<APIToken[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const { toast } = useToast();
+  const confirm = useConfirm();
+  const { setCustomLabel, setPathLoading } = useBreadcrumb();
+
+  const fetchTokens = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listApiTokens();
+      setTokens(data.items || []);
+    } catch (e) {
+      console.error("Failed to fetch API tokens:", e);
+      setError(getErrorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTokens();
+  }, [fetchTokens]);
+
+  useEffect(() => {
+    const currentPath = "/settings/api-tokens";
+    setCustomLabel(currentPath, "API Tokens");
+    setPathLoading(currentPath, loading);
+  }, [setCustomLabel, setPathLoading, loading]);
+
+  async function requestRevoke(token: APIToken) {
+    if (!token.id) return;
+    const ok = await confirm({
+      title: "Revoke token?",
+      description: `"${token.name}" will stop working immediately. This cannot be undone.`,
+      confirmLabel: "Revoke",
+      variant: "destructive",
+    });
+    if (!ok) return;
+    try {
+      await revokeApiToken(token.id);
+      fetchTokens();
+      toast({ title: "Token revoked", description: "The API token has been revoked.", variant: "success" });
+    } catch (e) {
+      console.error("Failed to revoke API token:", e);
+      toast({ title: "Failed to revoke token", description: getErrorMessage(e), variant: "destructive" });
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center min-h-[calc(100vh-4rem)] p-4">
+        <Loader2 className="h-10 w-10 animate-spin text-primary" />
+        <p className="mt-2 text-muted-foreground">Loading API tokens...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <AlertCircle className="mx-auto h-12 w-12 text-destructive mb-4" />
+        <h2 className="text-xl font-semibold mb-2">Error Loading API Tokens</h2>
+        <p className="text-muted-foreground mb-4">{error}</p>
+        <Button onClick={() => window.location.reload()}>Try Again</Button>
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <div className="p-8 space-y-8">
+        <PageHeader
+          eyebrow="Platform"
+          title="API Tokens"
+          subtitle="Issue tokens for scripts, CI, and agents to authenticate as you"
+          actions={
+            <Button onClick={() => setShowCreateDialog(true)}>
+              <PlusCircle className="h-4 w-4" />
+              Create token
+            </Button>
+          }
+        />
+
+        {tokens.length === 0 ? (
+          <EmptyState
+            icon={<KeyRound className="h-8 w-8" />}
+            title="No API tokens yet"
+            description="Create a token to let scripts, CI, or agents authenticate as you."
+            action={
+              <Button onClick={() => setShowCreateDialog(true)}>
+                <PlusCircle className="h-4 w-4" />
+                Create token
+              </Button>
+            }
+          />
+        ) : (
+          <Panel title="API Tokens" count={tokens.length} bodyClassName="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Prefix</TableHead>
+                  <TableHead>Scopes</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Expires</TableHead>
+                  <TableHead>Last used</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tokens.map((token) => {
+                  const revoked = !!token.revoked_at;
+                  return (
+                    <TableRow key={token.id} className={cn(revoked && "opacity-50")}>
+                      <TableCell className="font-medium">
+                        <div className="flex items-center gap-2">
+                          {token.name}
+                          {revoked && <Badge variant="secondary">Revoked</Badge>}
+                        </div>
+                      </TableCell>
+                      <TableCell className="font-mono text-xs text-muted-foreground">{token.token_prefix}</TableCell>
+                      <TableCell className="max-w-[220px] truncate text-xs text-muted-foreground" title={token.scopes?.join(", ")}>
+                        {token.scopes?.join(", ") || "—"}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">{formatDate(token.created_at)}</TableCell>
+                      <TableCell className="text-muted-foreground">{formatDate(token.expires_at)}</TableCell>
+                      <TableCell className="text-muted-foreground">{formatDate(token.last_used_at)}</TableCell>
+                      <TableCell className="text-right">
+                        {!revoked && (
+                          <Button variant="outline" size="sm" onClick={() => requestRevoke(token)}>
+                            Revoke
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </Panel>
+        )}
+
+        <CreateTokenDialog
+          open={showCreateDialog}
+          onOpenChange={setShowCreateDialog}
+          onCreated={fetchTokens}
+        />
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/pages/api-tokens/index.tsx
+++ b/frontend/src/pages/api-tokens/index.tsx
@@ -18,7 +18,10 @@ import { listApiTokens, revokeApiToken, type APIToken } from "@/api/api-tokens";
 import { getErrorMessage } from "@/api/client";
 import { useBreadcrumb } from "@/hooks/use-breadcrumb";
 import { CreateTokenDialog } from "./components/create-token-dialog";
+import { accessLabel } from "./access";
 import { cn } from "@/lib/utils";
+
+const COLUMN_HEAD_CLASS = "text-[11px] uppercase tracking-widest text-muted-foreground font-mono";
 
 function formatDate(value?: string): string {
   if (!value) return "Never";
@@ -41,7 +44,7 @@ export default function ApiTokensPage() {
       const data = await listApiTokens();
       setTokens(data.items || []);
     } catch (e) {
-      console.error("Failed to fetch API tokens:", e);
+      console.error("Failed to fetch API tokens:", getErrorMessage(e));
       setError(getErrorMessage(e));
     } finally {
       setLoading(false);
@@ -72,12 +75,14 @@ export default function ApiTokensPage() {
       fetchTokens();
       toast({ title: "Token revoked", description: "The API token has been revoked.", variant: "success" });
     } catch (e) {
-      console.error("Failed to revoke API token:", e);
+      console.error("Failed to revoke API token:", getErrorMessage(e));
       toast({ title: "Failed to revoke token", description: getErrorMessage(e), variant: "destructive" });
     }
   }
 
-  if (loading) {
+  // Only the first load takes over the page — a refetch after revoke keeps
+  // the table on screen instead of flashing back to a spinner.
+  if (loading && tokens.length === 0 && !error) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center min-h-[calc(100vh-4rem)] p-4">
         <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -92,7 +97,7 @@ export default function ApiTokensPage() {
         <AlertCircle className="mx-auto h-12 w-12 text-destructive mb-4" />
         <h2 className="text-xl font-semibold mb-2">Error Loading API Tokens</h2>
         <p className="text-muted-foreground mb-4">{error}</p>
-        <Button onClick={() => window.location.reload()}>Try Again</Button>
+        <Button onClick={fetchTokens}>Try Again</Button>
       </div>
     );
   }
@@ -128,35 +133,47 @@ export default function ApiTokensPage() {
           <Panel title="API Tokens" count={tokens.length} bodyClassName="p-0">
             <Table>
               <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Prefix</TableHead>
-                  <TableHead>Scopes</TableHead>
-                  <TableHead>Created</TableHead>
-                  <TableHead>Expires</TableHead>
-                  <TableHead>Last used</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
+                <TableRow className="hover:bg-transparent">
+                  <TableHead className={COLUMN_HEAD_CLASS}>Token</TableHead>
+                  <TableHead className={COLUMN_HEAD_CLASS}>Access</TableHead>
+                  <TableHead className={COLUMN_HEAD_CLASS}>Created</TableHead>
+                  <TableHead className={COLUMN_HEAD_CLASS}>Expires</TableHead>
+                  <TableHead className={COLUMN_HEAD_CLASS}>Last used</TableHead>
+                  <TableHead />
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {tokens.map((token) => {
                   const revoked = !!token.revoked_at;
+                  const expired = !revoked && !!token.expires_at && new Date(token.expires_at) < new Date();
+                  const dead = revoked || expired;
                   return (
-                    <TableRow key={token.id} className={cn(revoked && "opacity-50")}>
-                      <TableCell className="font-medium">
+                    <TableRow
+                      key={token.id}
+                      className={cn("border-b border-border hover:bg-muted/50", dead && "opacity-50")}
+                    >
+                      <TableCell className="py-3.5">
                         <div className="flex items-center gap-2">
-                          {token.name}
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium text-foreground">{token.name}</div>
+                            <div className="font-mono text-xs text-muted-foreground">{token.token_prefix}</div>
+                          </div>
                           {revoked && <Badge variant="secondary">Revoked</Badge>}
+                          {expired && <Badge variant="secondary">Expired</Badge>}
                         </div>
                       </TableCell>
-                      <TableCell className="font-mono text-xs text-muted-foreground">{token.token_prefix}</TableCell>
-                      <TableCell className="max-w-[220px] truncate text-xs text-muted-foreground" title={token.scopes?.join(", ")}>
-                        {token.scopes?.join(", ") || "—"}
+                      <TableCell className="py-3.5">
+                        <span
+                          className="inline-flex items-center rounded border border-border bg-muted px-2 py-px font-mono text-[11px] text-muted-foreground"
+                          title={token.scopes?.join(", ")}
+                        >
+                          {accessLabel(token.scopes)}
+                        </span>
                       </TableCell>
-                      <TableCell className="text-muted-foreground">{formatDate(token.created_at)}</TableCell>
-                      <TableCell className="text-muted-foreground">{formatDate(token.expires_at)}</TableCell>
-                      <TableCell className="text-muted-foreground">{formatDate(token.last_used_at)}</TableCell>
-                      <TableCell className="text-right">
+                      <TableCell className="py-3.5 text-sm text-muted-foreground">{formatDate(token.created_at)}</TableCell>
+                      <TableCell className="py-3.5 text-sm text-muted-foreground">{formatDate(token.expires_at)}</TableCell>
+                      <TableCell className="py-3.5 text-sm text-muted-foreground">{formatDate(token.last_used_at)}</TableCell>
+                      <TableCell className="py-3.5 text-right">
                         {!revoked && (
                           <Button variant="outline" size="sm" onClick={() => requestRevoke(token)}>
                             Revoke

--- a/frontend/src/pages/api-tokens/index.tsx
+++ b/frontend/src/pages/api-tokens/index.tsx
@@ -10,7 +10,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { PageHeader, Panel, EmptyState } from "@/components/branded";
 import { useConfirm } from "@/components/branded/confirm";
 import { useToast } from "@/components/ui/use-toast";
@@ -23,8 +22,11 @@ import { cn } from "@/lib/utils";
 
 const COLUMN_HEAD_CLASS = "text-[11px] uppercase tracking-widest text-muted-foreground font-mono";
 
-function formatDate(value?: string): string {
-  if (!value) return "Never";
+// The breadcrumb key must match the router path exactly or the label never applies.
+export const API_TOKENS_PATH = "/settings/api-tokens";
+
+function formatDate(value: string | undefined, fallback: string): string {
+  if (!value) return fallback;
   return new Date(value).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
 
@@ -57,9 +59,8 @@ export default function ApiTokensPage() {
   }, [fetchTokens]);
 
   useEffect(() => {
-    const currentPath = "/settings/api-tokens";
-    setCustomLabel(currentPath, "API Tokens");
-    setPathLoading(currentPath, loading);
+    setCustomLabel(API_TOKENS_PATH, "API Tokens");
+    setPathLoading(API_TOKENS_PATH, loading);
   }, [setCustomLabel, setPathLoading, loading]);
 
   // Revoked tokens are never deleted server-side, so they would pile up in the
@@ -109,53 +110,55 @@ export default function ApiTokensPage() {
   }
 
   return (
-    <TooltipProvider>
-      <div className="p-8 space-y-8">
-        <PageHeader
-          eyebrow="Platform"
-          title="API Tokens"
-          subtitle="Issue tokens for scripts, CI, and agents"
-          actions={
+    <div className="p-8 space-y-8">
+      <PageHeader
+        eyebrow="Platform"
+        title="API Tokens"
+        subtitle="Issue tokens for scripts, CI, and agents"
+        actions={
+          <Button onClick={() => setShowCreateDialog(true)}>
+            <PlusCircle className="h-4 w-4" />
+            Create token
+          </Button>
+        }
+      />
+
+      {tokens.length === 0 ? (
+        <EmptyState
+          icon={<KeyRound className="h-8 w-8" />}
+          title="No API tokens yet"
+          description="Create a token to let scripts, CI, or agents call the API."
+          action={
             <Button onClick={() => setShowCreateDialog(true)}>
               <PlusCircle className="h-4 w-4" />
               Create token
             </Button>
           }
         />
-
-        {visible.length === 0 ? (
-          <EmptyState
-            icon={<KeyRound className="h-8 w-8" />}
-            title={revokedCount > 0 ? "No active API tokens" : "No API tokens yet"}
-            description={
-              revokedCount > 0
-                ? "Every token here has been revoked. Create one to let scripts, CI, or agents call the API."
-                : "Create a token to let scripts, CI, or agents call the API."
-            }
-            action={
-              <Button onClick={() => setShowCreateDialog(true)}>
-                <PlusCircle className="h-4 w-4" />
-                Create token
-              </Button>
-            }
-          />
-        ) : (
-          <Panel
-            title="API Tokens"
-            count={visible.length}
-            bodyClassName="p-0"
-            action={
-              revokedCount > 0 && (
-                <button
-                  type="button"
-                  className="font-mono text-[11px] text-muted-foreground hover:text-foreground"
-                  onClick={() => setShowRevoked((prev) => !prev)}
-                >
-                  {showRevoked ? "Hide revoked" : `Show revoked (${revokedCount})`}
-                </button>
-              )
-            }
-          >
+      ) : (
+        <Panel
+          title="API Tokens"
+          count={visible.length}
+          bodyClassName="p-0"
+          action={
+            revokedCount > 0 && (
+              <button
+                type="button"
+                className="font-mono text-[11px] text-muted-foreground hover:text-foreground"
+                onClick={() => setShowRevoked((prev) => !prev)}
+              >
+                {showRevoked ? "Hide revoked" : `Show revoked (${revokedCount})`}
+              </button>
+            )
+          }
+        >
+          {visible.length === 0 ? (
+            <EmptyState
+              icon={<KeyRound className="h-8 w-8" />}
+              title="No active API tokens"
+              description="Every token here has been revoked."
+            />
+          ) : (
             <Table>
               <TableHeader>
                 <TableRow className="hover:bg-transparent">
@@ -164,7 +167,9 @@ export default function ApiTokensPage() {
                   <TableHead className={COLUMN_HEAD_CLASS}>Created</TableHead>
                   <TableHead className={COLUMN_HEAD_CLASS}>Expires</TableHead>
                   <TableHead className={COLUMN_HEAD_CLASS}>Last used</TableHead>
-                  <TableHead />
+                  <TableHead>
+                    <span className="sr-only">Actions</span>
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -195,9 +200,9 @@ export default function ApiTokensPage() {
                           {accessLabel(token.scopes)}
                         </span>
                       </TableCell>
-                      <TableCell className="py-3.5 text-sm text-muted-foreground">{formatDate(token.created_at)}</TableCell>
-                      <TableCell className="py-3.5 text-sm text-muted-foreground">{formatDate(token.expires_at)}</TableCell>
-                      <TableCell className="py-3.5 text-sm text-muted-foreground">{formatDate(token.last_used_at)}</TableCell>
+                      <TableCell className="py-3.5 text-sm text-muted-foreground">{formatDate(token.created_at, "—")}</TableCell>
+                      <TableCell className="py-3.5 text-sm text-muted-foreground">{formatDate(token.expires_at, "Never")}</TableCell>
+                      <TableCell className="py-3.5 text-sm text-muted-foreground">{formatDate(token.last_used_at, "Never")}</TableCell>
                       <TableCell className="py-3.5 text-right">
                         {!revoked && (
                           <Button variant="outline" size="sm" onClick={() => requestRevoke(token)}>
@@ -210,15 +215,15 @@ export default function ApiTokensPage() {
                 })}
               </TableBody>
             </Table>
-          </Panel>
-        )}
+          )}
+        </Panel>
+      )}
 
-        <CreateTokenDialog
-          open={showCreateDialog}
-          onOpenChange={setShowCreateDialog}
-          onCreated={fetchTokens}
-        />
-      </div>
-    </TooltipProvider>
+      <CreateTokenDialog
+        open={showCreateDialog}
+        onOpenChange={setShowCreateDialog}
+        onCreated={fetchTokens}
+      />
+    </div>
   );
 }

--- a/frontend/src/pages/api-tokens/index.tsx
+++ b/frontend/src/pages/api-tokens/index.tsx
@@ -33,6 +33,7 @@ export default function ApiTokensPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [showRevoked, setShowRevoked] = useState(false);
   const { toast } = useToast();
   const confirm = useConfirm();
   const { setCustomLabel, setPathLoading } = useBreadcrumb();
@@ -60,6 +61,11 @@ export default function ApiTokensPage() {
     setCustomLabel(currentPath, "API Tokens");
     setPathLoading(currentPath, loading);
   }, [setCustomLabel, setPathLoading, loading]);
+
+  // Revoked tokens are never deleted server-side, so they would pile up in the
+  // list forever. Keep them one click away instead of on screen.
+  const revokedCount = tokens.filter((token) => token.revoked_at).length;
+  const visible = showRevoked ? tokens : tokens.filter((token) => !token.revoked_at);
 
   async function requestRevoke(token: APIToken) {
     if (!token.id) return;
@@ -117,11 +123,15 @@ export default function ApiTokensPage() {
           }
         />
 
-        {tokens.length === 0 ? (
+        {visible.length === 0 ? (
           <EmptyState
             icon={<KeyRound className="h-8 w-8" />}
-            title="No API tokens yet"
-            description="Create a token to let scripts, CI, or agents call the API."
+            title={revokedCount > 0 ? "No active API tokens" : "No API tokens yet"}
+            description={
+              revokedCount > 0
+                ? "Every token here has been revoked. Create one to let scripts, CI, or agents call the API."
+                : "Create a token to let scripts, CI, or agents call the API."
+            }
             action={
               <Button onClick={() => setShowCreateDialog(true)}>
                 <PlusCircle className="h-4 w-4" />
@@ -130,7 +140,22 @@ export default function ApiTokensPage() {
             }
           />
         ) : (
-          <Panel title="API Tokens" count={tokens.length} bodyClassName="p-0">
+          <Panel
+            title="API Tokens"
+            count={visible.length}
+            bodyClassName="p-0"
+            action={
+              revokedCount > 0 && (
+                <button
+                  type="button"
+                  className="font-mono text-[11px] text-muted-foreground hover:text-foreground"
+                  onClick={() => setShowRevoked((prev) => !prev)}
+                >
+                  {showRevoked ? "Hide revoked" : `Show revoked (${revokedCount})`}
+                </button>
+              )
+            }
+          >
             <Table>
               <TableHeader>
                 <TableRow className="hover:bg-transparent">
@@ -143,7 +168,7 @@ export default function ApiTokensPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {tokens.map((token) => {
+                {visible.map((token) => {
                   const revoked = !!token.revoked_at;
                   const expired = !revoked && !!token.expires_at && new Date(token.expires_at) < new Date();
                   const dead = revoked || expired;

--- a/frontend/src/pages/api-tokens/tests/index.test.tsx
+++ b/frontend/src/pages/api-tokens/tests/index.test.tsx
@@ -51,6 +51,21 @@ describe("ApiTokensPage", () => {
     expect(screen.getByText(/sd_abc1/)).toBeInTheDocument();
   });
 
+  it("hides revoked tokens until asked for them", async () => {
+    vi.mocked(tokensApi.listApiTokens).mockResolvedValue({
+      items: [token, { ...token, id: "t9", name: "old", revoked_at: "2026-08-02T00:00:00Z" }],
+    });
+    renderPage();
+    expect(await screen.findByText("agent")).toBeInTheDocument();
+    expect(screen.queryByText("old")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /show revoked \(1\)/i }));
+    expect(await screen.findByText("old")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /hide revoked/i }));
+    expect(screen.queryByText("old")).not.toBeInTheDocument();
+  });
+
   it("marks a token past its expiry as Expired", async () => {
     vi.mocked(tokensApi.listApiTokens).mockResolvedValue({
       items: [{ ...token, id: "t3", name: "stale", expires_at: "2020-01-01T00:00:00Z" }],

--- a/frontend/src/pages/api-tokens/tests/index.test.tsx
+++ b/frontend/src/pages/api-tokens/tests/index.test.tsx
@@ -35,11 +35,6 @@ function renderPage() {
   );
 }
 
-// The dialog opens with Full access off, so a create needs at least one scope.
-async function pickScope(action: string) {
-  await userEvent.click(await screen.findByRole("button", { name: action }));
-}
-
 describe("ApiTokensPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -56,12 +51,20 @@ describe("ApiTokensPage", () => {
     expect(screen.getByText(/sd_abc1/)).toBeInTheDocument();
   });
 
+  it("marks a token past its expiry as Expired", async () => {
+    vi.mocked(tokensApi.listApiTokens).mockResolvedValue({
+      items: [{ ...token, id: "t3", name: "stale", expires_at: "2020-01-01T00:00:00Z" }],
+    });
+    renderPage();
+    expect(await screen.findByText("stale")).toBeInTheDocument();
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+  });
+
   it("shows the raw token exactly once after create, and never again once dismissed", async () => {
     vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
-    await pickScope("read");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     expect(await screen.findByText(/sd_raw_secret/)).toBeInTheDocument();
@@ -83,7 +86,6 @@ describe("ApiTokensPage", () => {
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
-    await pickScope("read");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     await screen.findByText(/sd_raw_secret/);
@@ -101,7 +103,6 @@ describe("ApiTokensPage", () => {
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
-    await pickScope("read");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     await screen.findByText(/sd_raw_secret/);
@@ -122,7 +123,6 @@ describe("ApiTokensPage", () => {
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
-    await pickScope("read");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     await screen.findByText(/sd_raw_secret/);
@@ -160,7 +160,6 @@ describe("ApiTokensPage", () => {
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
     fireEvent.change(screen.getByLabelText(/expires/i), { target: { value: "2036-12-31" } });
-    await pickScope("read");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
 
@@ -169,17 +168,35 @@ describe("ApiTokensPage", () => {
     expect(new Date(expires_at as string)).toEqual(new Date(2036, 11, 31, 23, 59, 59));
   });
 
-  it("opens with full access off and refuses to create with no scope selected", async () => {
+  it("defaults to read-only and never sends a mutating scope", async () => {
+    vi.mocked(tokensApi.getApiTokenScopes).mockResolvedValue({
+      full_access_scope: "*:*",
+      items: [{ resource: "stacks", actions: ["read", "list", "write", "delete", "exec"] }],
+    });
+    vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
-    expect(screen.getByRole("switch", { name: /full access/i })).not.toBeChecked();
+    expect(await screen.findByRole("radio", { name: /read-only/i })).toBeChecked();
 
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
 
-    expect(await screen.findByText(/select at least one scope/i)).toBeInTheDocument();
-    expect(tokensApi.createApiToken).not.toHaveBeenCalled();
+    await waitFor(() => expect(tokensApi.createApiToken).toHaveBeenCalled());
+    const { scopes } = vi.mocked(tokensApi.createApiToken).mock.calls[0][0];
+    expect(scopes).toEqual(["stacks:read", "stacks:list"]);
+  });
+
+  it("sends the server's full-access scope when Full access is picked", async () => {
+    vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await userEvent.click(await screen.findByRole("radio", { name: /full access/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() => expect(tokensApi.createApiToken).toHaveBeenCalled());
+    expect(vi.mocked(tokensApi.createApiToken).mock.calls[0][0].scopes).toEqual(["*"]);
   });
 
   it("rejects an expiry date in the past", async () => {
@@ -187,7 +204,6 @@ describe("ApiTokensPage", () => {
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
     fireEvent.change(screen.getByLabelText(/expires/i), { target: { value: "2020-01-01" } });
-    await pickScope("read");
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
 
     expect(await screen.findByText(/expiry must be in the future/i)).toBeInTheDocument();

--- a/frontend/src/pages/api-tokens/tests/index.test.tsx
+++ b/frontend/src/pages/api-tokens/tests/index.test.tsx
@@ -35,6 +35,11 @@ function renderPage() {
   );
 }
 
+// The dialog opens with Full access off, so a create needs at least one scope.
+async function pickScope(action: string) {
+  await userEvent.click(await screen.findByRole("button", { name: action }));
+}
+
 describe("ApiTokensPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -56,6 +61,7 @@ describe("ApiTokensPage", () => {
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await pickScope("read");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     expect(await screen.findByText(/sd_raw_secret/)).toBeInTheDocument();
@@ -77,6 +83,7 @@ describe("ApiTokensPage", () => {
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await pickScope("read");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     await screen.findByText(/sd_raw_secret/);
@@ -94,6 +101,7 @@ describe("ApiTokensPage", () => {
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await pickScope("read");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     await screen.findByText(/sd_raw_secret/);
@@ -114,6 +122,7 @@ describe("ApiTokensPage", () => {
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await pickScope("read");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     await screen.findByText(/sd_raw_secret/);
@@ -150,13 +159,39 @@ describe("ApiTokensPage", () => {
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
-    fireEvent.change(screen.getByLabelText(/expires/i), { target: { value: "2026-12-31" } });
+    fireEvent.change(screen.getByLabelText(/expires/i), { target: { value: "2036-12-31" } });
+    await pickScope("read");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
 
     await waitFor(() => expect(tokensApi.createApiToken).toHaveBeenCalled());
     const { expires_at } = vi.mocked(tokensApi.createApiToken).mock.calls[0][0];
-    expect(new Date(expires_at as string)).toEqual(new Date(2026, 11, 31, 23, 59, 59));
+    expect(new Date(expires_at as string)).toEqual(new Date(2036, 11, 31, 23, 59, 59));
+  });
+
+  it("opens with full access off and refuses to create with no scope selected", async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    expect(screen.getByRole("switch", { name: /full access/i })).not.toBeChecked();
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(await screen.findByText(/select at least one scope/i)).toBeInTheDocument();
+    expect(tokensApi.createApiToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects an expiry date in the past", async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    fireEvent.change(screen.getByLabelText(/expires/i), { target: { value: "2020-01-01" } });
+    await pickScope("read");
+    await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(await screen.findByText(/expiry must be in the future/i)).toBeInTheDocument();
+    expect(tokensApi.createApiToken).not.toHaveBeenCalled();
   });
 
   it("revokes a token via the confirm dialog", async () => {

--- a/frontend/src/pages/api-tokens/tests/index.test.tsx
+++ b/frontend/src/pages/api-tokens/tests/index.test.tsx
@@ -8,9 +8,14 @@ import ApiTokensPage from "../index";
 import * as tokensApi from "@/api/api-tokens";
 import { ConfirmProvider } from "@/components/branded/confirm";
 
+const toastMock = vi.fn();
+
 afterEach(cleanup);
 
 vi.mock("@/api/api-tokens");
+vi.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: toastMock, dismiss: vi.fn(), toasts: [] }),
+}));
 
 const token = {
   id: "t1",
@@ -46,14 +51,98 @@ describe("ApiTokensPage", () => {
     expect(screen.getByText(/sd_abc1/)).toBeInTheDocument();
   });
 
-  it("shows the raw token exactly once after create", async () => {
+  it("shows the raw token exactly once after create, and never again once dismissed", async () => {
     vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
     renderPage();
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     expect(await screen.findByText(/sd_raw_secret/)).toBeInTheDocument();
     expect(screen.getByText(/won't see this again/i)).toBeInTheDocument();
+
+    // Dismissing the show-once view must drop the secret from state entirely.
+    await userEvent.click(screen.getByRole("button", { name: /^done$/i }));
+    expect(screen.queryByText(/sd_raw_secret/)).not.toBeInTheDocument();
+
+    // Reopening the create dialog must not resurface the previous secret.
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    expect(await screen.findByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.queryByText(/sd_raw_secret/)).not.toBeInTheDocument();
+  });
+
+  it("copies the token via the Clipboard API when available", async () => {
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+    vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    await screen.findByText(/sd_raw_secret/);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy token" }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("sd_raw_secret");
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a textarea copy when the Clipboard API is unavailable (insecure context)", async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockReturnValue(true);
+    vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    await screen.findByText(/sd_raw_secret/);
+
+    // No throw / unhandled rejection from the missing Clipboard API.
+    await userEvent.click(screen.getByRole("button", { name: "Copy token" }));
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a destructive toast when copying fails entirely", async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn(() => {
+      throw new Error("copy blocked");
+    });
+    vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    await screen.findByText(/sd_raw_secret/);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy token" }));
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Copy failed", variant: "destructive" }),
+      ),
+    );
+    expect(screen.queryByRole("button", { name: "Copied" })).not.toBeInTheDocument();
+  });
+
+  it("disables Create and explains why while scopes haven't loaded", async () => {
+    let resolveScopes: (value: tokensApi.ScopeList) => void = () => {};
+    vi.mocked(tokensApi.getApiTokenScopes).mockReturnValue(
+      new Promise((resolve) => {
+        resolveScopes = resolve;
+      }),
+    );
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+
+    expect(screen.getByText(/loading available scopes/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^create$/i })).toBeDisabled();
+
+    resolveScopes({ full_access_scope: "*", items: [] });
+    await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
   });
 
   it("revokes a token via the confirm dialog", async () => {

--- a/frontend/src/pages/api-tokens/tests/index.test.tsx
+++ b/frontend/src/pages/api-tokens/tests/index.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import ApiTokensPage from "../index";
+import * as tokensApi from "@/api/api-tokens";
+import { ConfirmProvider } from "@/components/branded/confirm";
+
+afterEach(cleanup);
+
+vi.mock("@/api/api-tokens");
+
+const token = {
+  id: "t1",
+  name: "agent",
+  token_prefix: "sd_abc1",
+  scopes: ["*"],
+  created_at: "2026-08-01T00:00:00Z",
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ConfirmProvider>
+        <ApiTokensPage />
+      </ConfirmProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("ApiTokensPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(tokensApi.listApiTokens).mockResolvedValue({ items: [token] });
+    vi.mocked(tokensApi.getApiTokenScopes).mockResolvedValue({
+      full_access_scope: "*",
+      items: [{ resource: "stacks", actions: ["read", "write"] }],
+    });
+  });
+
+  it("lists tokens with their prefix", async () => {
+    renderPage();
+    expect(await screen.findByText("agent")).toBeInTheDocument();
+    expect(screen.getByText(/sd_abc1/)).toBeInTheDocument();
+  });
+
+  it("shows the raw token exactly once after create", async () => {
+    vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    expect(await screen.findByText(/sd_raw_secret/)).toBeInTheDocument();
+    expect(screen.getByText(/won't see this again/i)).toBeInTheDocument();
+  });
+
+  it("revokes a token via the confirm dialog", async () => {
+    vi.mocked(tokensApi.revokeApiToken).mockResolvedValue(undefined);
+    renderPage();
+    await screen.findByText("agent");
+
+    await userEvent.click(screen.getByRole("button", { name: /revoke/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog).toHaveTextContent(/revoke token\?/i);
+    await userEvent.click(screen.getByRole("button", { name: "Revoke" }));
+
+    await waitFor(() => expect(tokensApi.revokeApiToken).toHaveBeenCalledWith("t1"));
+  });
+});

--- a/frontend/src/pages/api-tokens/tests/index.test.tsx
+++ b/frontend/src/pages/api-tokens/tests/index.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import ApiTokensPage from "../index";
@@ -143,6 +143,20 @@ describe("ApiTokensPage", () => {
 
     resolveScopes({ full_access_scope: "*", items: [] });
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
+  });
+
+  it("sends an expires_at that is end-of-day local time for the chosen date", async () => {
+    vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    fireEvent.change(screen.getByLabelText(/expires/i), { target: { value: "2026-12-31" } });
+    await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() => expect(tokensApi.createApiToken).toHaveBeenCalled());
+    const { expires_at } = vi.mocked(tokensApi.createApiToken).mock.calls[0][0];
+    expect(new Date(expires_at as string)).toEqual(new Date(2026, 11, 31, 23, 59, 59));
   });
 
   it("revokes a token via the confirm dialog", async () => {

--- a/frontend/src/pages/api-tokens/tests/index.test.tsx
+++ b/frontend/src/pages/api-tokens/tests/index.test.tsx
@@ -10,7 +10,16 @@ import { ConfirmProvider } from "@/components/branded/confirm";
 
 const toastMock = vi.fn();
 
-afterEach(cleanup);
+// The clipboard tests clobber these globals; without a restore every later
+// test in the file inherits whatever the last one left behind.
+const realClipboard = navigator.clipboard;
+const realExecCommand = document.execCommand;
+
+afterEach(() => {
+  cleanup();
+  Object.assign(navigator, { clipboard: realClipboard });
+  document.execCommand = realExecCommand;
+});
 
 vi.mock("@/api/api-tokens");
 vi.mock("@/components/ui/use-toast", () => ({
@@ -236,5 +245,53 @@ describe("ApiTokensPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Revoke" }));
 
     await waitFor(() => expect(tokensApi.revokeApiToken).toHaveBeenCalledWith("t1"));
+  });
+
+  it("still offers the revoked toggle when every token is revoked", async () => {
+    vi.mocked(tokensApi.listApiTokens).mockResolvedValue({
+      items: [{ ...token, revoked_at: "2026-08-02T00:00:00Z" }],
+    });
+    renderPage();
+
+    const toggle = await screen.findByRole("button", { name: /show revoked \(1\)/i });
+    await userEvent.click(toggle);
+    expect(await screen.findByText("agent")).toBeInTheDocument();
+  });
+
+  it("shows the create error inline when the API rejects", async () => {
+    vi.mocked(tokensApi.createApiToken).mockRejectedValue(new Error("name already taken"));
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(await screen.findByText(/name already taken/i)).toBeInTheDocument();
+  });
+
+  it("toasts when a revoke fails", async () => {
+    vi.mocked(tokensApi.revokeApiToken).mockRejectedValue(new Error("revoke exploded"));
+    renderPage();
+    await screen.findByText("agent");
+
+    await userEvent.click(screen.getByRole("button", { name: /revoke/i }));
+    await screen.findByRole("alertdialog");
+    await userEvent.click(screen.getByRole("button", { name: "Revoke" }));
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Failed to revoke token", variant: "destructive" }),
+      ),
+    );
+  });
+
+  it("labels each row by what its scopes actually grant", async () => {
+    vi.mocked(tokensApi.listApiTokens).mockResolvedValue({
+      items: [token, { ...token, id: "t4", name: "reader", scopes: ["stacks:read", "stacks:list"] }],
+    });
+    renderPage();
+
+    expect(await screen.findByText("Full access")).toBeInTheDocument();
+    expect(screen.getByText("Read-only")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/stacks/components/editor/public-endpoint-row.tsx
+++ b/frontend/src/pages/stacks/components/editor/public-endpoint-row.tsx
@@ -3,6 +3,7 @@ import { ExternalLink, Copy, Check } from "lucide-react";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import type { StatusVariant } from "@/components/branded/status-variant";
+import { copyText } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 
 const COPY_FLASH_MS = 1400;
@@ -39,20 +40,6 @@ function hostOf(url: string): string {
   } catch {
     return url;
   }
-}
-
-async function copyText(text: string): Promise<void> {
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text);
-    return;
-  }
-  // Clipboard API unavailable (insecure context): textarea fallback.
-  const ta = document.createElement("textarea");
-  ta.value = text;
-  document.body.appendChild(ta);
-  ta.select();
-  document.execCommand("copy");
-  ta.remove();
 }
 
 function useCopyFlash() {


### PR DESCRIPTION
## 📝 What this does

Adds an API Tokens page under Settings so a user can mint, inspect, and revoke tokens for scripts, CI, and agents without touching the API directly. The backend already served `/api/v1/api-tokens`; this gives it a front door.

## 🔀 Changes

- Added an API Tokens page with create, list, and revoke, reachable from the sidebar
- Scoped new tokens by preset — read-only or full access — defaulting to read-only and reading the scope list from the server rather than guessing it
- Showed the raw token exactly once after create, with a copy that falls back to a textarea in insecure contexts
- Kept revoked tokens behind a toggle that stays reachable even when every token is revoked
- Moved the endpoint row's duplicated clipboard helper onto the shared `lib/clipboard`

## 🧪 How to test

- [x] Open Settings → API Tokens and create a read-only token
- [x] Confirm the raw token appears once, copies, and does not reappear after dismissing
- [x] Check the sent scopes contain no mutating action for a read-only token
- [x] Revoke a token and confirm it disappears from the default list
- [x] Revoke every remaining token — the `Show revoked` toggle must still be on screen
- [x] Pick today in the expiry picker; it must be selectable in a timezone west of UTC