### PR TITLE
Feature: stackfile JSON schema, deterministic transpiler, and export

### DIFF
--- a/cmd/installer/bootstrap.go
+++ b/cmd/installer/bootstrap.go
@@ -205,8 +205,7 @@ func domainExists(token, orgID, domain string) bool {
 func extractClusterCredentials() (clusterURL, caData, saToken string, err error) {
 	// Use the kubernetes service ClusterIP instead of the kubeconfig URL (127.0.0.1:6443),
 	// because the API server runs inside the cluster and needs an in-cluster address.
-	k8sSvcIP, err := output("kubectl", "get", "svc", "kubernetes",
-		"-o", "jsonpath={.spec.clusterIP}")
+	k8sSvcIP, err := output("kubectl", kubernetesServiceQueryArgs()...)
 	if err != nil {
 		return "", "", "", fmt.Errorf("getting kubernetes service IP: %w", err)
 	}
@@ -234,6 +233,14 @@ func extractClusterCredentials() (clusterURL, caData, saToken string, err error)
 	}
 
 	return clusterURL, caData, string(decoded), nil
+}
+
+func kubernetesServiceQueryArgs() []string {
+	return []string{
+		"get", "svc", "kubernetes",
+		"-n", "default",
+		"-o", "jsonpath={.spec.clusterIP}",
+	}
 }
 
 func registerCluster(token, orgID, clusterURL, caData, saToken string) (string, error) {

--- a/cmd/installer/bootstrap_test.go
+++ b/cmd/installer/bootstrap_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestKubernetesServiceQueryUsesDefaultNamespace(t *testing.T) {
+	want := []string{
+		"get", "svc", "kubernetes",
+		"-n", "default",
+		"-o", "jsonpath={.spec.clusterIP}",
+	}
+
+	if got := kubernetesServiceQueryArgs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("kubernetes service query args = %q, want %q", got, want)
+	}
+}

--- a/docs/stackfile-reference.md
+++ b/docs/stackfile-reference.md
@@ -1,0 +1,600 @@
+# Stackdome Stackfile Reference
+
+A stackfile is a YAML document that describes a complete stack: its workloads, how they are built or pulled, how they wire to each other, and how they consume secrets, addons, and volumes. It is the declarative authoring surface for both humans and agents.
+
+A stackfile **describes and connects**. It never creates secrets or addons — those must already exist in the project, and the stackfile references them by name.
+
+The machine-readable schema lives at `pkg/stackfile/schema.json` (JSON Schema draft-07). Unknown fields are rejected at parse time — a typo'd key is an error, never silently ignored.
+
+## Top-level structure
+
+```yaml
+name: my-stack          # required — stack name, unique within the project
+
+resources:              # required — at least 1, at most 50 workloads
+  api: { ... }
+  worker: { ... }
+
+volumes:                # optional — persistent volumes, at most 50
+  pg-data:
+    size: 5Gi
+```
+
+## Resources
+
+Each entry under `resources:` is one workload. Exactly one of `image` or `build` is required.
+
+```yaml
+resources:
+  api:
+    image: myorg/api:v1.2.0        # OR build: (never both)
+    command: ["/app/server"]        # optional container entrypoint override
+    args: ["--port", "3000"]        # optional args
+    workload_type: Service          # Service | StatefulService | Worker | Job | CronJob
+    replicas: 2                     # optional, >= 0
+    depends_on:                     # start ordering; must name resources in this file
+      - redis
+    ports: [ ... ]
+    env: { ... }
+    secrets: { ... }
+    addons: { ... }
+    volumes: [ ... ]
+```
+
+### Workload types
+
+| Type | Meaning |
+|---|---|
+| `Service` | Long-running, receives traffic. Default. |
+| `StatefulService` | Long-running with stable identity (databases, queues). |
+| `Worker` | Long-running, no ports. |
+| `Job` | Run-to-completion (migrations, one-off tasks). |
+| `CronJob` | Scheduled run-to-completion. Requires `schedule` (cron expression). |
+
+```yaml
+  nightly-report:
+    image: myorg/reporter:latest
+    workload_type: CronJob
+    schedule: "0 3 * * *"
+```
+
+### Building from source
+
+```yaml
+  api:
+    build:
+      repo: https://github.com/myorg/api.git   # required
+      branch: main                             # branch OR tag, not both
+      commit: 4f2a91c                          # optional SHA pin; requires branch or tag
+      dockerfile: Dockerfile.prod              # default: Dockerfile
+      context: ./services/api                  # default: .
+```
+
+Rules:
+
+- `branch` and `tag` are mutually exclusive.
+- `commit` pins a SHA and requires `branch` or `tag` alongside it.
+- Neither branch nor tag: the server resolves the repository's default branch.
+- Clone credentials come from the preview config or an org-level git integration — never from the stackfile.
+
+### Ports
+
+```yaml
+    ports:
+      - name: http          # required
+        port: 3000          # required, 1–65535
+        protocol: TCP       # optional
+        public: true        # expose via ingress
+        subdomain: api      # subdomain prefix for the public URL
+```
+
+At most 20 ports per resource. Ports do double duty: they configure networking **and** they define the resource's outputs (next section).
+
+## Outputs and how to consume them
+
+Three kinds of things produce outputs: resources, addons, and secrets. Each has its own vocabulary and consumption syntax.
+
+### Resource outputs
+
+A resource's outputs are derived entirely from its `ports`:
+
+| Output | Available |
+|---|---|
+| `host` | always — in-cluster service DNS name |
+| `port` | per port — the port number |
+| `url` | per port — in-cluster `host:port` URL |
+| `public_host` | per port, only if `public: true` |
+| `public_url` | per port, only if `public: true` |
+
+**Naming rule:** a resource with **one** port uses bare names (`port`, `url`, `public_url`). A resource with **multiple** ports suffixes with the port name (`port.http`, `url.grpc`, `public_url.web`). `host` is always bare. Referencing bare `url` on a multi-port resource is rejected as ambiguous.
+
+#### Your own outputs — `{{ self.X }}`
+
+The ref must be the **entire value**. No templates, no mixing with other refs.
+
+```yaml
+  api:
+    ports:
+      - name: http
+        port: 3000
+        public: true
+        subdomain: api
+    env:
+      SITE_URL: "{{ self.public_url }}"   # OK
+      PORT: "{{ self.port }}"             # OK
+      # INVALID: "https://{{ self.public_host }}/cb" — self refs cannot be templated
+```
+
+#### Another resource's outputs — `{{ <resource>.X }}`
+
+Exact ref or template. **All refs in one value must come from the same source resource.**
+
+```yaml
+  api:
+    env:
+      REDIS_HOST: "{{ redis.host }}"                          # exact
+      REDIS_URL: "redis://{{ redis.host }}:{{ redis.port }}"  # template, one source
+      # INVALID: "{{ redis.host }}:{{ db.port }}" — two sources in one value
+
+  redis:
+    image: redis:7
+    ports:
+      - name: redis
+        port: 6379
+```
+
+Multi-port source:
+
+```yaml
+  api:
+    env:
+      GRPC_ADDR: "{{ backend.url.grpc }}"
+      HTTP_ADDR: "{{ backend.url.http }}"
+
+  backend:
+    image: myorg/backend:latest
+    ports:
+      - name: http
+        port: 8080
+      - name: grpc
+        port: 9090
+```
+
+Everything is validated at parse time: an unknown output name errors with the list of valid outputs for that resource.
+
+### Addon outputs
+
+Declared under a resource's `addons:` block. The addon must already exist in the project; the block key is its name. Currently supported type: `postgres`.
+
+Postgres outputs: `host`, `port`, `database`, `username`, `password`, `sslmode`, `ca_certificate`, `url`.
+
+Inside the addon's `env:`, outputs are referenced **bare** — no prefix, since the block already names the addon. Templates are fine and may mix any outputs.
+
+```yaml
+  api:
+    addons:
+      main-db:
+        type: postgres
+        database: api_production     # scope credentials to this database
+        env:
+          DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+          PGSSLMODE: "{{ sslmode }}"
+```
+
+`{{ postgres.host }}` (dotted) is invalid — bare names only, rejected at parse time.
+
+#### Superuser credentials
+
+```yaml
+  migration-runner:
+    image: myorg/api:latest
+    workload_type: Job
+    addons:
+      main-db:
+        type: postgres
+        database: api_production
+        superuser: true
+        env:
+          DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+```
+
+With `superuser: true`, `{{ username }}` / `{{ password }}` resolve to superuser credentials instead of the app owner role. The addon itself must have been provisioned with `enable_superuser_access` — the stackfile only requests the connection, it cannot enable it.
+
+Typical pattern: the app connects plain (owner credentials); a dedicated `Job` resource connects with `superuser: true` for DDL, extensions, or migrations.
+
+### Secret outputs
+
+Each key of a project secret is an output. Consumption is a plain map — no `{{ }}`, no templating:
+
+```yaml
+  api:
+    secrets:
+      jwt-secret:                    # secret name in the project
+        JWT_SECRET: jwt_signing_key  # ENV_VAR: secret_key
+      smtp-creds:
+        SMTP_USER: username
+        SMTP_PASS: password
+```
+
+### Cheat sheet
+
+| Source | Syntax | Where | Templates |
+|---|---|---|---|
+| self | `{{ self.port }}` | `env:` | no — whole value only |
+| other resource | `{{ redis.host }}` | `env:` | yes — one source per value |
+| addon | `{{ host }}` (bare) | addon's `env:` | yes — free mix |
+| secret | `ENV_VAR: key` map | `secrets:` | no |
+
+## Volumes
+
+Declare volumes at the top level, mount them per resource:
+
+```yaml
+resources:
+  db:
+    image: postgres:16
+    workload_type: StatefulService
+    volumes:
+      - name: pg-data                       # must be declared below
+        path: /var/lib/postgresql/data      # absolute mount path
+
+volumes:
+  pg-data:
+    size: 5Gi                # required — e.g. 512Mi, 5Gi, 1Ti
+    access_mode: ReadWriteOnce   # default; also ReadOnlyMany, ReadWriteMany
+```
+
+A mount referencing an undeclared volume is a parse error.
+
+## Complete example
+
+```yaml
+name: my-app
+
+resources:
+  api:
+    build:
+      repo: https://github.com/myorg/api.git
+      branch: main
+    ports:
+      - name: http
+        port: 3000
+        public: true
+        subdomain: api
+    env:
+      SITE_URL: "{{ self.public_url }}"
+      CACHE_URL: "redis://{{ redis.host }}:{{ redis.port }}"
+    secrets:
+      jwt-secret:
+        JWT_SECRET: jwt_signing_key
+    addons:
+      main-db:
+        type: postgres
+        database: app_production
+        env:
+          DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+    depends_on:
+      - redis
+
+  migrate:
+    image: myorg/api:latest
+    workload_type: Job
+    command: ["/app/migrate"]
+    addons:
+      main-db:
+        type: postgres
+        database: app_production
+        superuser: true
+        env:
+          DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+
+  redis:
+    image: redis:7-alpine
+    workload_type: StatefulService
+    ports:
+      - name: redis
+        port: 6379
+    volumes:
+      - name: redis-data
+        path: /data
+
+volumes:
+  redis-data:
+    size: 1Gi
+```
+
+## Validation summary
+
+Checked at parse time (before anything reaches the server):
+
+- `name` and at least one resource required; unknown fields anywhere are errors.
+- Exactly one of `image` / `build` per resource.
+- `branch` xor `tag`; `commit` requires one of them.
+- Port numbers 1–65535; every port named; max 20 ports, 50 resources, 50 volumes; file size max 1 MiB.
+- Volume mounts must reference declared volumes; `depends_on` must reference resources in the file; no self-dependency.
+- Every `{{ ref }}` checked against the source's real outputs; self refs whole-value only; one source resource per env value; addon refs bare-name only.
+- Secrets and addons are validated for existence when the stack is resolved server-side.
+
+## Example stackfiles
+
+These live in `pkg/stackfile/testdata/` and double as test fixtures — every one is validated against the schema and round-tripped through the transpiler on each test run.
+
+### Shared database, owner + superuser (`superuser_migration.yaml`)
+
+One postgres addon, two consumers: the app on owner credentials, a migration `Job` on superuser credentials.
+
+```yaml
+name: superuser-migration
+
+resources:
+  app:
+    image: myorg/api:latest
+    ports:
+      - name: http
+        port: 3000
+        public: true
+        subdomain: api
+    addons:
+      main-db:
+        type: postgres
+        database: app_production
+        env:
+          DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+
+  migrate:
+    image: myorg/api:latest
+    workload_type: Job
+    command: ["/app/migrate"]
+    addons:
+      main-db:
+        type: postgres
+        database: app_production
+        superuser: true
+        env:
+          DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+    depends_on:
+      - app
+```
+
+### Everything at once (`kitchen_sink.yaml`)
+
+Secrets, addon templating, cross-resource refs, self refs, a stateful cache with a volume:
+
+```yaml
+name: kitchen-sink
+
+resources:
+  api:
+    image: api:latest
+    ports:
+      - name: http
+        port: 3000
+        public: true
+        subdomain: api
+    env:
+      SITE_URL: "{{ self.public_url }}"
+      CACHE_HOST: "{{ redis.host }}"
+      CACHE_URL: "redis://{{ redis.host }}:6379"
+      LOG_LEVEL: info
+    secrets:
+      jwt-secret:
+        JWT_SECRET: jwt_signing_key
+      smtp-creds:
+        SMTP_USER: username
+        SMTP_PASS: password
+    addons:
+      main-db:
+        type: postgres
+        database: api_production
+        env:
+          DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - name: redis
+        port: 6379
+        protocol: TCP
+    volumes:
+      - name: redis-data
+        path: /data
+    workload_type: StatefulService
+
+  worker:
+    image: api:latest
+    env:
+      ROLE: worker
+      CACHE_URL: "redis://{{ redis.host }}:6379"
+    secrets:
+      jwt-secret:
+        JWT_SECRET: jwt_signing_key
+    addons:
+      main-db:
+        type: postgres
+        database: api_production
+        env:
+          DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+    depends_on:
+      - redis
+
+volumes:
+  redis-data:
+    size: 2Gi
+```
+
+Other fixtures: `basic_image.yaml` (minimal), `build_from_source.yaml` (git build), `with_secrets.yaml`, `with_addon.yaml`, `with_addon_superuser.yaml`, `infisical.yaml` (real-world multi-resource app), `simple_nginx.yaml`.
+
+## JSON Schema
+
+Source of truth: `pkg/stackfile/schema.json`, embedded in the server binary. Point your editor at it (`# yaml-language-server: $schema=...`) for autocomplete and inline validation.
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stackdome.com/schemas/stackfile.schema.json",
+  "title": "Stackdome Stackfile",
+  "type": "object",
+  "required": ["name", "resources"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stack name, unique within the project."
+    },
+    "resources": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 50,
+      "description": "Workloads keyed by resource name.",
+      "additionalProperties": { "$ref": "#/definitions/resource" }
+    },
+    "volumes": {
+      "type": "object",
+      "maxProperties": 50,
+      "description": "Persistent volumes keyed by volume name.",
+      "additionalProperties": { "$ref": "#/definitions/volume" }
+    }
+  },
+  "definitions": {
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "oneOf": [
+        { "required": ["image"], "not": { "required": ["build"] } },
+        { "required": ["build"], "not": { "required": ["image"] } }
+      ],
+      "properties": {
+        "image": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Container image reference. Mutually exclusive with build."
+        },
+        "build": { "$ref": "#/definitions/build" },
+        "command": { "type": "array", "items": { "type": "string" } },
+        "args": { "type": "array", "items": { "type": "string" } },
+        "ports": {
+          "type": "array",
+          "maxItems": 20,
+          "items": { "$ref": "#/definitions/port" }
+        },
+        "env": {
+          "type": "object",
+          "description": "Env vars. Values may reference outputs: {{ self.port }}, {{ other-resource.host }}, or templates like redis://{{ redis.host }}:{{ redis.port }}. All refs in one value must use the same source resource.",
+          "additionalProperties": { "type": "string" }
+        },
+        "secrets": {
+          "type": "object",
+          "description": "Secret name -> { ENV_VAR: secret_key }. Secrets must already exist in the project.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        },
+        "addons": {
+          "type": "object",
+          "description": "Addon name -> connection config. Addons must already exist in the project.",
+          "additionalProperties": { "$ref": "#/definitions/addon" }
+        },
+        "volumes": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/volumeMount" }
+        },
+        "depends_on": { "type": "array", "items": { "type": "string" } },
+        "workload_type": {
+          "type": "string",
+          "enum": ["Service", "StatefulService", "Worker", "Job", "CronJob"],
+          "description": "Defaults to Service."
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Cron expression. Only for workload_type CronJob."
+        },
+        "replicas": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo"],
+      "not": { "required": ["branch", "tag"] },
+      "dependencies": {
+        "commit": { "anyOf": [{ "required": ["branch"] }, { "required": ["tag"] }] }
+      },
+      "properties": {
+        "repo": { "type": "string", "minLength": 1, "description": "Git repository URL." },
+        "branch": { "type": "string" },
+        "tag": { "type": "string" },
+        "commit": { "type": "string", "description": "Commit SHA pin; requires branch or tag." },
+        "dockerfile": { "type": "string", "description": "Path to the Dockerfile." },
+        "context": { "type": "string", "description": "Build context directory." }
+      }
+    },
+    "port": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "port"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "protocol": { "type": "string" },
+        "public": { "type": "boolean", "description": "Expose publicly via ingress." },
+        "subdomain": { "type": "string", "description": "Subdomain prefix for the public URL." }
+      }
+    },
+    "volume": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["size"],
+      "properties": {
+        "size": {
+          "type": "string",
+          "pattern": "^[0-9]+[KMGTP]i?$",
+          "description": "Volume size, e.g. 5Gi."
+        },
+        "access_mode": {
+          "type": "string",
+          "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"],
+          "description": "Defaults to ReadWriteOnce."
+        }
+      }
+    },
+    "volumeMount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "path"],
+      "properties": {
+        "name": { "type": "string", "description": "Name of a volume declared in top-level volumes." },
+        "path": { "type": "string", "description": "Absolute mount path in the container." }
+      }
+    },
+    "addon": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "enum": ["postgres"] },
+        "database": { "type": "string", "description": "Database to connect to (postgres)." },
+        "superuser": { "type": "boolean", "description": "Use superuser credentials (postgres)." },
+        "env": {
+          "type": "object",
+          "description": "Env vars templated from addon outputs, e.g. postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}. Bare output names, no prefix.",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+```
+
+## Not expressible in a stackfile
+
+These exist in the Stack API but have no stackfile syntax (the exporter fails loudly on them rather than dropping them):
+
+- Init containers, restart triggers, labels/annotations.
+- Private image pull credentials, git integration selection, push targets.
+- Building an image from a volume; volume sources (git repo / remote dir / build artifact), storage class, sub-path or read-only mounts.
+- Mounting secrets or outputs as files (everything is env).
+- Addon provisioning (version, storage, backups, instances) — stackfiles connect to addons, they never create them.

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.430
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/lo v1.51.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/cli v29.5.3+incompatible h1:nbEFfz774vBwQ5KRYv7c/AghjReqnGISvrRhzjV0evs=
@@ -403,6 +405,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.51.0 h1:kysRYLbHy/MB7kQZf5DSN50JHmMsNEdeY24VzJFu7wI=
 github.com/samber/lo v1.51.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/pkg/stackfile/connections.go
+++ b/pkg/stackfile/connections.go
@@ -1,0 +1,182 @@
+package stackfile
+
+import (
+	"strings"
+
+	openapi "github.com/Stackdome/stackdome/pkg/api/openapi"
+	"k8s.io/utils/ptr"
+)
+
+// buildConnections synthesizes the stack's topology edges:
+//   - env vars referencing another resource -> env connections
+//   - secret mappings -> env connections from secrets
+//   - addon blocks -> env connections from addons (with per-type config)
+//   - volume mounts -> volume_mount connections
+func (sf *Stackfile) buildConnections() []openapi.StackConnection {
+	var connections []openapi.StackConnection
+	for _, resourceName := range sortedKeys(sf.Resources) {
+		res := sf.Resources[resourceName]
+		connections = append(connections, buildEnvRefConnections(resourceName, res.Env)...)
+		connections = append(connections, buildSecretConnections(resourceName, res.Secrets)...)
+		connections = append(connections, buildAddonConnections(resourceName, res.Addons)...)
+		connections = append(connections, buildVolumeMountConnections(resourceName, res.Volumes)...)
+	}
+	return connections
+}
+
+func buildEnvRefConnections(targetResource string, env map[string]string) []openapi.StackConnection {
+	grouped := make(map[string][]openapi.ConnectionMapping)
+
+	for _, envName := range sortedKeys(env) {
+		value := env[envName]
+		refs := findRefs(value)
+		if len(refs) == 0 || isSelfRef(value) {
+			// Literals and self refs live in execution config, not connections.
+			continue
+		}
+
+		// Validate guarantees all refs in one value share a source.
+		source := refs[0].Source
+
+		var vr openapi.ValueRef
+		if isExactRef(value) && len(refs) == 1 {
+			vr.Output = ptr.To(refs[0].Output)
+		} else {
+			tmpl := value
+			values := make(map[string]openapi.OutputValueRef)
+			for _, r := range refs {
+				varName := outputToVarName(r.Output)
+				tmpl = strings.Replace(tmpl, r.RawMatch, "{{ "+varName+" }}", 1)
+				values[varName] = openapi.OutputValueRef{Output: r.Output}
+			}
+			vr.Template = ptr.To(tmpl)
+			vr.Values = &values
+		}
+
+		grouped[source] = append(grouped[source], openapi.ConnectionMapping{
+			Target: envTarget(envName),
+			Value:  vr,
+		})
+	}
+
+	var connections []openapi.StackConnection
+	for _, source := range sortedKeys(grouped) {
+		connections = append(connections, openapi.StackConnection{
+			Kind:     connectionKindEnv,
+			From:     nodeRef(nodeTypeStackResource, source),
+			To:       nodeRef(nodeTypeStackResource, targetResource),
+			Mappings: grouped[source],
+		})
+	}
+	return connections
+}
+
+func buildSecretConnections(targetResource string, secrets map[string]SecretMapping) []openapi.StackConnection {
+	var connections []openapi.StackConnection
+
+	for _, secretName := range sortedKeys(secrets) {
+		mapping := secrets[secretName]
+		mappings := make([]openapi.ConnectionMapping, 0, len(mapping))
+		for _, envName := range sortedKeys(mapping) {
+			mappings = append(mappings, openapi.ConnectionMapping{
+				Target: envTarget(envName),
+				Value:  openapi.ValueRef{Output: ptr.To(mapping[envName])},
+			})
+		}
+
+		connections = append(connections, openapi.StackConnection{
+			Kind:     connectionKindEnv,
+			From:     nodeRef(nodeTypeSecret, secretName),
+			To:       nodeRef(nodeTypeStackResource, targetResource),
+			Mappings: mappings,
+		})
+	}
+	return connections
+}
+
+func buildAddonConnections(targetResource string, addons map[string]AddonConnectionConfig) []openapi.StackConnection {
+	var connections []openapi.StackConnection
+
+	for _, addonName := range sortedKeys(addons) {
+		addon := addons[addonName]
+		connections = append(connections, openapi.StackConnection{
+			Kind:     connectionKindEnv,
+			From:     nodeRef("addon/"+addon.Type, addonName),
+			To:       nodeRef(nodeTypeStackResource, targetResource),
+			Mappings: buildAddonMappings(addon.Env),
+			Config:   buildAddonConfig(addon),
+		})
+	}
+	return connections
+}
+
+func buildAddonMappings(env map[string]string) []openapi.ConnectionMapping {
+	mappings := make([]openapi.ConnectionMapping, 0, len(env))
+	for _, envName := range sortedKeys(env) {
+		envValue := env[envName]
+		refs := findAddonRefs(envValue)
+
+		var vr openapi.ValueRef
+		if len(refs) == 1 && refs[0].RawMatch == envValue {
+			vr.Output = ptr.To(refs[0].Output)
+		} else {
+			values := make(map[string]openapi.OutputValueRef)
+			for _, r := range refs {
+				values[r.Output] = openapi.OutputValueRef{Output: r.Output}
+			}
+			vr.Template = ptr.To(envValue)
+			vr.Values = &values
+		}
+
+		mappings = append(mappings, openapi.ConnectionMapping{
+			Target: envTarget(envName),
+			Value:  vr,
+		})
+	}
+	return mappings
+}
+
+func buildAddonConfig(addon AddonConnectionConfig) *openapi.StackConnectionConfig {
+	if addon.Postgres == nil {
+		return nil
+	}
+	pg := addon.Postgres
+	if pg.Database == "" && !pg.Superuser {
+		return nil
+	}
+	pgConfig := &openapi.PostgresEnvConfig{}
+	if pg.Database != "" {
+		pgConfig.Database = ptr.To(pg.Database)
+	}
+	if pg.Superuser {
+		pgConfig.Superuser = ptr.To(true)
+	}
+	return &openapi.StackConnectionConfig{
+		PostgresEnvConfig: pgConfig,
+	}
+}
+
+func buildVolumeMountConnections(targetResource string, mounts []VolumeMountDef) []openapi.StackConnection {
+	var connections []openapi.StackConnection
+	for _, m := range mounts {
+		connections = append(connections, openapi.StackConnection{
+			Kind: connectionKindVolumeMount,
+			From: nodeRef(nodeTypeVolume, m.Name),
+			To:   nodeRef(nodeTypeStackResource, targetResource),
+			Config: &openapi.StackConnectionConfig{
+				VolumeMountConfig: &openapi.VolumeMountConfig{
+					MountPath: m.Path,
+				},
+			},
+		})
+	}
+	return connections
+}
+
+func nodeRef(nodeType, name string) openapi.TopologyNodeRef {
+	return openapi.TopologyNodeRef{Type: nodeType, Name: ptr.To(name)}
+}
+
+func envTarget(envName string) openapi.ConnectionTarget {
+	return openapi.ConnectionTarget{Type: targetTypeEnv, Name: ptr.To(envName)}
+}

--- a/pkg/stackfile/connections_test.go
+++ b/pkg/stackfile/connections_test.go
@@ -1,0 +1,55 @@
+package stackfile
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	openapi "github.com/Stackdome/stackdome/pkg/api/openapi"
+)
+
+var _ = Describe("superuser addon connections", func() {
+	// One addon, two consumers: the app on owner credentials, the
+	// migration Job on superuser credentials.
+	var stack openapi.Stack
+
+	BeforeEach(func() {
+		sf, err := Load(loadFixtureBytes("superuser_migration.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		stack, err = sf.ToStack()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	addonConnTo := func(target string) openapi.StackConnection {
+		for _, c := range stack.Spec.Connections {
+			if c.From.Type == "addon/"+PostgresAddonType && c.To.GetName() == target {
+				return c
+			}
+		}
+		Fail("no addon connection to " + target)
+		return openapi.StackConnection{}
+	}
+
+	It("gives the app owner credentials scoped to the database", func() {
+		conn := addonConnTo("app")
+		pg := conn.Config.PostgresEnvConfig
+		Expect(pg.GetDatabase()).To(Equal("app_production"))
+		Expect(pg.Superuser).To(BeNil())
+	})
+
+	It("gives the migration job superuser credentials", func() {
+		conn := addonConnTo("migrate")
+		pg := conn.Config.PostgresEnvConfig
+		Expect(pg.GetDatabase()).To(Equal("app_production"))
+		Expect(pg.GetSuperuser()).To(BeTrue())
+	})
+
+	It("templates the same DATABASE_URL mapping for both", func() {
+		for _, target := range []string{"app", "migrate"} {
+			conn := addonConnTo(target)
+			Expect(conn.Mappings).To(HaveLen(1))
+			m := conn.Mappings[0]
+			Expect(m.Target.GetName()).To(Equal("DATABASE_URL"))
+			Expect(m.Value.GetTemplate()).To(ContainSubstring("{{ username }}:{{ password }}"))
+			Expect(*m.Value.Values).To(HaveKey("password"))
+		}
+	})
+})

--- a/pkg/stackfile/convert.go
+++ b/pkg/stackfile/convert.go
@@ -2,25 +2,15 @@ package stackfile
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
-	"strings"
 
 	openapi "github.com/Stackdome/stackdome/pkg/api/openapi"
-	"github.com/samber/lo"
 	"k8s.io/utils/ptr"
 )
 
-var (
-	// Matches a full-value ref: the entire string is {{ source.output }}
-	exactRefPattern = regexp.MustCompile(`^\{\{\s*([\w-]+(?:\.[\w-]+)+)\s*\}\}$`)
-	// Matches embedded refs within a larger string
-	embeddedRefPattern = regexp.MustCompile(`\{\{\s*([\w-]+(?:\.[\w-]+)+)\s*\}\}`)
-	// addonVarPattern matches {{ varname }} in addon env templates.
-	// Addon vars are plain output names (host, port, username) — no source prefix.
-	addonVarPattern = regexp.MustCompile(`\{\{\s*([\w-]+)\s*\}\}`)
-)
-
+// ToStack converts a validated Stackfile into an API Stack document,
+// ready for the stack apply endpoint. Output is deterministic: resources,
+// volumes, connections, and mappings are emitted in sorted order.
 func (sf *Stackfile) ToStack() (openapi.Stack, error) {
 	resources, err := sf.buildResources()
 	if err != nil {
@@ -39,12 +29,7 @@ func (sf *Stackfile) ToStack() (openapi.Stack, error) {
 
 func (sf *Stackfile) buildResources() ([]openapi.StackResource, error) {
 	resources := make([]openapi.StackResource, 0, len(sf.Resources))
-	names := make([]string, 0, len(sf.Resources))
-	for name := range sf.Resources {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
+	for _, name := range sortedKeys(sf.Resources) {
 		res := sf.Resources[name]
 		sr := openapi.StackResource{
 			Name:      name,
@@ -92,18 +77,15 @@ func buildGitSource(b *BuildConfig) (*openapi.GitSource, error) {
 	if b.Dockerfile != "" {
 		source.SetDockerfilePath(b.Dockerfile)
 	}
-	switch {
-	case b.Branch != "":
+	// Validate guarantees: branch and tag are exclusive, commit requires one
+	// of them (matching the API's git_commit_requires_ref rule).
+	if b.Branch != "" {
 		source.SetBranch(b.Branch)
-		if b.Commit != "" {
-			source.SetCommit(b.Commit)
-		}
-	case b.Tag != "":
+	}
+	if b.Tag != "" {
 		source.SetTag(b.Tag)
-		if b.Commit != "" {
-			source.SetCommit(b.Commit)
-		}
-	case b.Commit != "":
+	}
+	if b.Commit != "" {
 		source.SetCommit(b.Commit)
 	}
 	// No branch or tag: the server resolves the repository's default branch.
@@ -151,9 +133,9 @@ func buildExecutionConfig(env map[string]string, command, args []string) *openap
 		ev := openapi.EnvVar{Name: name}
 		switch {
 		case isSelfRef(value):
-			output := extractSelfOutput(value)
-			ev.SelfOutput = ptr.To(output)
+			ev.SelfOutput = ptr.To(extractSelfOutput(value))
 		case hasResourceRef(value):
+			// Becomes an env connection; see buildEnvRefConnections.
 			continue
 		default:
 			ev.Value = ptr.To(value)
@@ -169,62 +151,6 @@ func buildExecutionConfig(env map[string]string, command, args []string) *openap
 	}
 
 	return cfg
-}
-
-type envRef struct {
-	Source   string
-	Output   string
-	RawMatch string // the exact substring matched, e.g. "{{ redis.host }}"
-}
-
-func findRefs(value string) []envRef {
-	matches := embeddedRefPattern.FindAllStringSubmatch(value, -1)
-	var refs []envRef
-	for _, m := range matches {
-		parts := strings.SplitN(m[1], ".", 2)
-		if len(parts) == 2 {
-			refs = append(refs, envRef{Source: parts[0], Output: parts[1], RawMatch: m[0]})
-		}
-	}
-	return refs
-}
-
-func isExactRef(value string) bool {
-	return exactRefPattern.MatchString(value)
-}
-
-func isSelfRef(value string) bool {
-	refs := findRefs(value)
-	for _, r := range refs {
-		if r.Source == sourceSelf {
-			return true
-		}
-	}
-	return false
-}
-
-func extractSelfOutput(value string) string {
-	refs := findRefs(value)
-	for _, r := range refs {
-		if r.Source == sourceSelf {
-			return r.Output
-		}
-	}
-	return ""
-}
-
-func hasResourceRef(value string) bool {
-	refs := findRefs(value)
-	for _, r := range refs {
-		if r.Source != sourceSelf {
-			return true
-		}
-	}
-	return false
-}
-
-func outputToVarName(output string) string {
-	return strings.ReplaceAll(output, ".", "_")
 }
 
 func buildVolumeMounts(mounts []VolumeMountDef) []openapi.VolumeMount {
@@ -246,252 +172,20 @@ func (sf *Stackfile) buildVolumes() []openapi.Volume {
 		return nil
 	}
 	volumes := make([]openapi.Volume, 0, len(sf.Volumes))
-	names := make([]string, 0, len(sf.Volumes))
-	for name := range sf.Volumes {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
+	for _, name := range sortedKeys(sf.Volumes) {
 		v := sf.Volumes[name]
-		accessMode := openapi.VolumeAccessMode("ReadWriteOnce")
+		accessMode := openapi.VolumeAccessMode(defaultAccessMode)
 		if v.AccessMode != "" {
 			accessMode = openapi.VolumeAccessMode(v.AccessMode)
 		}
-		vol := openapi.Volume{
+		volumes = append(volumes, openapi.Volume{
 			Name: name,
 			Spec: openapi.VolumeSpec{
 				Size:               v.Size,
 				AccessMode:         accessMode,
 				NeedsSyncBeforeUse: false,
 			},
-		}
-		volumes = append(volumes, vol)
-	}
-	return volumes
-}
-
-func (sf *Stackfile) buildConnections() []openapi.StackConnection {
-	var connections []openapi.StackConnection
-
-	names := make([]string, 0, len(sf.Resources))
-	for name := range sf.Resources {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, resourceName := range names {
-		res := sf.Resources[resourceName]
-		connections = append(connections, buildEnvRefConnections(resourceName, res.Env)...)
-		connections = append(connections, buildSecretConnections(resourceName, res.Secrets)...)
-		connections = append(connections, buildAddonConnections(resourceName, res.Addons)...)
-		connections = append(connections, buildVolumeMountConnections(resourceName, res.Volumes)...)
-	}
-
-	return connections
-}
-
-func buildEnvRefConnections(targetResource string, env map[string]string) []openapi.StackConnection {
-	grouped := make(map[string][]openapi.ConnectionMapping)
-
-	for envName, value := range env {
-		refsInCurrentEnv := findRefs(value)
-		if len(refsInCurrentEnv) == 0 {
-			continue
-		}
-
-		_, currentEnvIsSelfRef := lo.Find(refsInCurrentEnv, func(r envRef) bool { return r.Source == sourceSelf })
-		if currentEnvIsSelfRef {
-			// skip self refs, they will be handled in execution config
-			continue
-		}
-
-		source := refsInCurrentEnv[0].Source
-
-		var vr openapi.ValueRef
-		if isExactRef(value) && len(refsInCurrentEnv) == 1 {
-			vr.Output = ptr.To(refsInCurrentEnv[0].Output)
-		} else {
-			tmpl := value
-			values := make(map[string]openapi.OutputValueRef)
-			for _, r := range refsInCurrentEnv {
-				varName := outputToVarName(r.Output)
-				tmpl = strings.Replace(tmpl, r.RawMatch, "{{ "+varName+" }}", 1)
-				values[varName] = openapi.OutputValueRef{Output: r.Output}
-			}
-			vr.Template = ptr.To(tmpl)
-			vr.Values = &values
-		}
-
-		mapping := openapi.ConnectionMapping{
-			Target: openapi.ConnectionTarget{
-				Type: targetTypeEnv,
-				Name: ptr.To(envName),
-			},
-			Value: vr,
-		}
-		grouped[source] = append(grouped[source], mapping)
-	}
-
-	var connections []openapi.StackConnection
-	for source, mappings := range grouped {
-		conn := openapi.StackConnection{
-			Kind: connectionKindEnv,
-			From: openapi.TopologyNodeRef{
-				Type: nodeTypeStackResource,
-				Name: ptr.To(source),
-			},
-			To: openapi.TopologyNodeRef{
-				Type: nodeTypeStackResource,
-				Name: ptr.To(targetResource),
-			},
-			Mappings: mappings,
-		}
-		connections = append(connections, conn)
-	}
-	return connections
-}
-
-func buildSecretConnections(targetResource string, secrets map[string]SecretMapping) []openapi.StackConnection {
-	var connections []openapi.StackConnection
-
-	for secretName, mapping := range secrets {
-		var mappings []openapi.ConnectionMapping
-		for envName, secretKey := range mapping {
-			mappings = append(mappings, openapi.ConnectionMapping{
-				Target: openapi.ConnectionTarget{
-					Type: targetTypeEnv,
-					Name: ptr.To(envName),
-				},
-				Value: openapi.ValueRef{
-					Output: ptr.To(secretKey),
-				},
-			})
-		}
-
-		conn := openapi.StackConnection{
-			Kind: connectionKindEnv,
-			From: openapi.TopologyNodeRef{
-				Type: nodeTypeSecret,
-				Name: ptr.To(secretName),
-			},
-			To: openapi.TopologyNodeRef{
-				Type: nodeTypeStackResource,
-				Name: ptr.To(targetResource),
-			},
-			Mappings: mappings,
-		}
-		connections = append(connections, conn)
-	}
-	return connections
-}
-
-func buildAddonConnections(targetResource string, addons map[string]AddonConnectionConfig) []openapi.StackConnection {
-	var connections []openapi.StackConnection
-
-	for addonName, addon := range addons {
-		mappings := buildAddonMappings(addon.Env)
-
-		conn := openapi.StackConnection{
-			Kind: connectionKindEnv,
-			From: openapi.TopologyNodeRef{
-				Type: "addon/" + addon.Type,
-				Name: ptr.To(addonName),
-			},
-			To: openapi.TopologyNodeRef{
-				Type: nodeTypeStackResource,
-				Name: ptr.To(targetResource),
-			},
-			Mappings: mappings,
-			Config:   buildAddonConfig(addon),
-		}
-
-		connections = append(connections, conn)
-	}
-	return connections
-}
-
-type addonRef struct {
-	Output   string
-	RawMatch string
-}
-
-func findAddonRefs(value string) []addonRef {
-	matches := addonVarPattern.FindAllStringSubmatch(value, -1)
-	var refs []addonRef
-	for _, m := range matches {
-		refs = append(refs, addonRef{Output: m[1], RawMatch: m[0]})
-	}
-	return refs
-}
-
-func buildAddonMappings(env map[string]string) []openapi.ConnectionMapping {
-	var mappings []openapi.ConnectionMapping
-	for envName, envValue := range env {
-		refs := findAddonRefs(envValue)
-
-		var vr openapi.ValueRef
-		switch {
-		case len(refs) == 1 && refs[0].RawMatch == envValue:
-			vr.Output = ptr.To(refs[0].Output)
-		default:
-			values := make(map[string]openapi.OutputValueRef)
-			for _, r := range refs {
-				values[r.Output] = openapi.OutputValueRef{Output: r.Output}
-			}
-			vr.Template = ptr.To(envValue)
-			vr.Values = &values
-		}
-
-		mappings = append(mappings, openapi.ConnectionMapping{
-			Target: openapi.ConnectionTarget{
-				Type: targetTypeEnv,
-				Name: ptr.To(envName),
-			},
-			Value: vr,
 		})
 	}
-	return mappings
-}
-
-func buildAddonConfig(addon AddonConnectionConfig) *openapi.StackConnectionConfig {
-	if addon.Postgres == nil {
-		return nil
-	}
-	pg := addon.Postgres
-	if pg.Database == "" && !pg.Superuser {
-		return nil
-	}
-	pgConfig := &openapi.PostgresEnvConfig{}
-	if pg.Database != "" {
-		pgConfig.Database = ptr.To(pg.Database)
-	}
-	if pg.Superuser {
-		pgConfig.Superuser = ptr.To(true)
-	}
-	return &openapi.StackConnectionConfig{
-		PostgresEnvConfig: pgConfig,
-	}
-}
-
-func buildVolumeMountConnections(targetResource string, mounts []VolumeMountDef) []openapi.StackConnection {
-	var connections []openapi.StackConnection
-	for _, m := range mounts {
-		conn := openapi.StackConnection{
-			Kind: connectionKindVolumeMount,
-			From: openapi.TopologyNodeRef{
-				Type: nodeTypeVolume,
-				Name: ptr.To(m.Name),
-			},
-			To: openapi.TopologyNodeRef{
-				Type: nodeTypeStackResource,
-				Name: ptr.To(targetResource),
-			},
-			Config: &openapi.StackConnectionConfig{
-				VolumeMountConfig: &openapi.VolumeMountConfig{
-					MountPath: m.Path,
-				},
-			},
-		}
-		connections = append(connections, conn)
-	}
-	return connections
+	return volumes
 }

--- a/pkg/stackfile/convert_test.go
+++ b/pkg/stackfile/convert_test.go
@@ -163,7 +163,7 @@ func TestToStack_BuildWithCommit(t *testing.T) {
 	sf := &Stackfile{
 		Name: "commit-build",
 		Resources: map[string]Resource{
-			"app": {Build: &BuildConfig{Repo: "https://github.com/x/y.git", Commit: "abc123"}},
+			"app": {Build: &BuildConfig{Repo: "https://github.com/x/y.git", Branch: "main", Commit: "abc123"}},
 		},
 	}
 
@@ -174,6 +174,9 @@ func TestToStack_BuildWithCommit(t *testing.T) {
 	rev := stack.Spec.StackResources[0].Source.Git
 	if rev.Commit == nil || *rev.Commit != "abc123" {
 		t.Errorf("expected commit 'abc123', got %v", rev.Commit)
+	}
+	if rev.Branch == nil || *rev.Branch != "main" {
+		t.Errorf("expected branch 'main', got %v", rev.Branch)
 	}
 }
 

--- a/pkg/stackfile/export.go
+++ b/pkg/stackfile/export.go
@@ -1,0 +1,377 @@
+package stackfile
+
+import (
+	"fmt"
+	"strings"
+
+	openapi "github.com/Stackdome/stackdome/pkg/api/openapi"
+)
+
+// FromStack converts an API Stack document back into a Stackfile.
+//
+// It covers exactly the subset a stackfile can express. Constructs outside
+// that subset (init containers, file targets, build-artifact connections,
+// volume sources, registry credentials, ...) fail with an error naming the
+// construct — never silently dropped. Connections must carry name-based
+// node refs; id-only refs (a stack fetched after secret/addon resolution)
+// need the names restored first.
+func FromStack(stack *openapi.Stack) (*Stackfile, error) {
+	sf := &Stackfile{
+		Name:      stack.Name,
+		Resources: make(map[string]Resource, len(stack.Spec.StackResources)),
+	}
+
+	for _, v := range stack.Spec.Volumes {
+		vol, err := exportVolume(v)
+		if err != nil {
+			return nil, err
+		}
+		if sf.Volumes == nil {
+			sf.Volumes = make(map[string]VolumeDef)
+		}
+		sf.Volumes[v.Name] = vol
+	}
+
+	for _, sr := range stack.Spec.StackResources {
+		res, err := exportResource(sr)
+		if err != nil {
+			return nil, err
+		}
+		sf.Resources[sr.Name] = res
+	}
+
+	for _, conn := range stack.Spec.Connections {
+		if err := applyConnection(sf, conn); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := Validate(sf); err != nil {
+		return nil, fmt.Errorf("exported stackfile failed validation: %w", err)
+	}
+	return sf, nil
+}
+
+func exportVolume(v openapi.Volume) (VolumeDef, error) {
+	spec := v.Spec
+	switch {
+	case spec.StorageClass != nil && *spec.StorageClass != "":
+		return VolumeDef{}, unsupported("volume %q: storage_class", v.Name)
+	case spec.NeedsSyncBeforeUse:
+		return VolumeDef{}, unsupported("volume %q: needs_sync_before_use", v.Name)
+	case spec.Source != nil:
+		return VolumeDef{}, unsupported("volume %q: volume source", v.Name)
+	}
+	vol := VolumeDef{Size: spec.Size}
+	if string(spec.AccessMode) != defaultAccessMode {
+		vol.AccessMode = string(spec.AccessMode)
+	}
+	return vol, nil
+}
+
+func exportResource(sr openapi.StackResource) (Resource, error) {
+	res := Resource{DependsOn: sr.DependsOn}
+
+	switch {
+	case sr.InitSpec != nil:
+		return res, unsupported("resource %q: init_spec", sr.Name)
+	case sr.LifecycleConfig != nil:
+		return res, unsupported("resource %q: lifecycle_config", sr.Name)
+	case len(sr.Labels) > 0 || len(sr.Annotations) > 0:
+		return res, unsupported("resource %q: labels/annotations", sr.Name)
+	}
+
+	if err := exportSource(sr.Name, sr.Source, &res); err != nil {
+		return res, err
+	}
+
+	if sr.WorkloadType != nil {
+		res.WorkloadType = *sr.WorkloadType
+	}
+	if sr.Schedule != nil {
+		res.Schedule = *sr.Schedule
+	}
+	res.Replicas = sr.Replicas
+
+	for _, p := range sr.Ports {
+		port := PortDef{Name: p.Name, Port: p.Number, Public: p.ExposedToPublic}
+		if p.Protocol != nil {
+			port.Protocol = *p.Protocol
+		}
+		if p.SubdomainPrefix != nil {
+			port.Subdomain = *p.SubdomainPrefix
+		}
+		res.Ports = append(res.Ports, port)
+	}
+
+	if err := exportExecutionConfig(sr.Name, sr.ExecutionConfig, &res); err != nil {
+		return res, err
+	}
+
+	for _, vm := range sr.VolumeMounts {
+		if vm.SourceSubPath != nil && *vm.SourceSubPath != "" {
+			return res, unsupported("resource %q: volume mount source_sub_path", sr.Name)
+		}
+		res.Volumes = append(res.Volumes, VolumeMountDef{Name: vm.SourceVolumeName, Path: vm.TargetPath})
+	}
+
+	return res, nil
+}
+
+func exportSource(name string, source *openapi.SourceSpec, res *Resource) error {
+	if source == nil {
+		return unsupported("resource %q: missing source", name)
+	}
+	switch {
+	case source.Image != nil:
+		if source.Image.RegistryCredentialsId != nil {
+			return unsupported("resource %q: image registry_credentials_id", name)
+		}
+		res.Image = source.Image.Ref
+
+	case source.Git != nil:
+		git := source.Git
+		if git.IntegrationId != nil {
+			return unsupported("resource %q: git integration_id", name)
+		}
+		if git.Push != nil {
+			return unsupported("resource %q: git push target", name)
+		}
+		res.Build = &BuildConfig{
+			Repo:       git.RepoUrl,
+			Branch:     git.GetBranch(),
+			Tag:        git.GetTag(),
+			Commit:     git.GetCommit(),
+			Dockerfile: git.GetDockerfilePath(),
+			Context:    git.GetBuildContext(),
+		}
+
+	case source.Volume != nil:
+		return unsupported("resource %q: volume build source", name)
+
+	default:
+		return unsupported("resource %q: empty source", name)
+	}
+	return nil
+}
+
+func exportExecutionConfig(name string, cfg *openapi.ExecutionConfig, res *Resource) error {
+	if cfg == nil {
+		return nil
+	}
+	res.Command = cfg.Command
+	res.Args = cfg.Args
+	for _, ev := range cfg.EnvironmentVariables {
+		switch {
+		case ev.SelfOutput != nil:
+			setEnv(res, ev.Name, "{{ "+sourceSelf+"."+*ev.SelfOutput+" }}")
+		case ev.Value != nil:
+			setEnv(res, ev.Name, *ev.Value)
+		default:
+			return unsupported("resource %q: env var %q has neither value nor self_output", name, ev.Name)
+		}
+	}
+	return nil
+}
+
+// applyConnection folds a topology edge back into the target resource's
+// env / secrets / addons / volumes blocks.
+func applyConnection(sf *Stackfile, conn openapi.StackConnection) error {
+	to, err := refName(conn.To)
+	if err != nil {
+		return err
+	}
+	res, ok := sf.Resources[to]
+	if !ok {
+		return fmt.Errorf("connection targets unknown resource %q", to)
+	}
+
+	switch conn.Kind {
+	case connectionKindVolumeMount:
+		// Volume mounts are already exported from the resource's volume_mounts;
+		// the connection is the same fact restated. Just check they agree.
+		return checkVolumeMountConnection(res, conn)
+	case connectionKindEnv:
+	default:
+		return unsupported("connection kind %q", conn.Kind)
+	}
+
+	from, err := refName(conn.From)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case conn.From.Type == nodeTypeStackResource:
+		err = applyResourceEnvConnection(&res, from, conn.Mappings)
+	case conn.From.Type == nodeTypeSecret:
+		err = applySecretConnection(&res, from, conn.Mappings)
+	case strings.HasPrefix(conn.From.Type, "addon/"):
+		err = applyAddonConnection(&res, from, strings.TrimPrefix(conn.From.Type, "addon/"), conn.Mappings, conn.Config)
+	default:
+		err = unsupported("connection from node type %q", conn.From.Type)
+	}
+	if err != nil {
+		return err
+	}
+
+	sf.Resources[to] = res
+	return nil
+}
+
+func applyResourceEnvConnection(res *Resource, from string, mappings []openapi.ConnectionMapping) error {
+	for _, m := range mappings {
+		envName, err := envTargetName(m.Target)
+		if err != nil {
+			return err
+		}
+		value, err := valueRefToDSL(from, m.Value)
+		if err != nil {
+			return err
+		}
+		if err := setEnvUnique(res, envName, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applySecretConnection(res *Resource, secretName string, mappings []openapi.ConnectionMapping) error {
+	for _, m := range mappings {
+		envName, err := envTargetName(m.Target)
+		if err != nil {
+			return err
+		}
+		if m.Value.Output == nil {
+			return unsupported("secret %q: templated secret values", secretName)
+		}
+		if res.Secrets == nil {
+			res.Secrets = make(map[string]SecretMapping)
+		}
+		if res.Secrets[secretName] == nil {
+			res.Secrets[secretName] = make(SecretMapping)
+		}
+		res.Secrets[secretName][envName] = *m.Value.Output
+	}
+	return nil
+}
+
+func applyAddonConnection(res *Resource, addonName, addonType string, mappings []openapi.ConnectionMapping, config *openapi.StackConnectionConfig) error {
+	addon := AddonConnectionConfig{Type: addonType, Env: make(map[string]string)}
+
+	if config != nil {
+		if config.PostgresEnvConfig == nil {
+			return unsupported("addon %q: non-postgres connection config", addonName)
+		}
+		pg := config.PostgresEnvConfig
+		if pg.CredentialScope != nil {
+			return unsupported("addon %q: credential_scope", addonName)
+		}
+		addon.Postgres = &PostgresAddonConfig{
+			Database:  pg.GetDatabase(),
+			Superuser: pg.GetSuperuser(),
+		}
+	}
+
+	for _, m := range mappings {
+		envName, err := envTargetName(m.Target)
+		if err != nil {
+			return err
+		}
+		value, err := addonValueRefToDSL(addonName, m.Value)
+		if err != nil {
+			return err
+		}
+		addon.Env[envName] = value
+	}
+
+	if res.Addons == nil {
+		res.Addons = make(map[string]AddonConnectionConfig)
+	}
+	res.Addons[addonName] = addon
+	return nil
+}
+
+// valueRefToDSL renders a mapping value back into env DSL, e.g.
+// output "host" from "redis" -> "{{ redis.host }}", and a template
+// "redis://{{ host_val }}" back into "redis://{{ redis.host }}".
+func valueRefToDSL(from string, v openapi.ValueRef) (string, error) {
+	if v.Output != nil {
+		return "{{ " + from + "." + *v.Output + " }}", nil
+	}
+	if v.Template == nil || v.Values == nil {
+		return "", unsupported("connection from %q: mapping without output or template", from)
+	}
+	rendered := *v.Template
+	for key, ref := range *v.Values {
+		rendered = templateVarPattern(key).ReplaceAllString(rendered, "{{ "+from+"."+ref.Output+" }}")
+	}
+	return rendered, nil
+}
+
+func addonValueRefToDSL(addonName string, v openapi.ValueRef) (string, error) {
+	if v.Output != nil {
+		return "{{ " + *v.Output + " }}", nil
+	}
+	if v.Template == nil || v.Values == nil {
+		return "", unsupported("addon %q: mapping without output or template", addonName)
+	}
+	rendered := *v.Template
+	for key, ref := range *v.Values {
+		rendered = templateVarPattern(key).ReplaceAllString(rendered, "{{ "+ref.Output+" }}")
+	}
+	return rendered, nil
+}
+
+func checkVolumeMountConnection(res Resource, conn openapi.StackConnection) error {
+	from, err := refName(conn.From)
+	if err != nil {
+		return err
+	}
+	if conn.Config == nil || conn.Config.VolumeMountConfig == nil {
+		return fmt.Errorf("volume_mount connection from %q missing mount config", from)
+	}
+	cfg := conn.Config.VolumeMountConfig
+	if cfg.SubPath != nil || cfg.ReadOnly != nil {
+		return unsupported("volume mount %q: sub_path/read_only", from)
+	}
+	for _, vm := range res.Volumes {
+		if vm.Name == from && vm.Path == cfg.MountPath {
+			return nil
+		}
+	}
+	return fmt.Errorf("volume_mount connection from %q has no matching volume mount on the resource", from)
+}
+
+func envTargetName(t openapi.ConnectionTarget) (string, error) {
+	if t.Type != targetTypeEnv || t.Name == nil {
+		return "", unsupported("connection target type %q", t.Type)
+	}
+	return *t.Name, nil
+}
+
+func refName(ref openapi.TopologyNodeRef) (string, error) {
+	if ref.Name == nil || *ref.Name == "" {
+		return "", fmt.Errorf("%s node ref has no name (id-only refs cannot be exported)", ref.Type)
+	}
+	return *ref.Name, nil
+}
+
+func setEnv(res *Resource, name, value string) {
+	if res.Env == nil {
+		res.Env = make(map[string]string)
+	}
+	res.Env[name] = value
+}
+
+func setEnvUnique(res *Resource, name, value string) error {
+	if existing, ok := res.Env[name]; ok {
+		return fmt.Errorf("env var %q set twice (%q and %q)", name, existing, value)
+	}
+	setEnv(res, name, value)
+	return nil
+}
+
+func unsupported(format string, args ...any) error {
+	return fmt.Errorf("not expressible in a stackfile: "+format, args...)
+}

--- a/pkg/stackfile/export_test.go
+++ b/pkg/stackfile/export_test.go
@@ -1,0 +1,87 @@
+package stackfile
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	openapi "github.com/Stackdome/stackdome/pkg/api/openapi"
+	"k8s.io/utils/ptr"
+)
+
+func loadFixtureBytes(name string) []byte {
+	content, err := os.ReadFile(filepath.Join(testdataPath(""), name))
+	Expect(err).NotTo(HaveOccurred())
+	return content
+}
+
+var _ = Describe("FromStack", func() {
+	It("round-trips every fixture through ToStack and back", func() {
+		entries, err := os.ReadDir(testdataPath(""))
+		Expect(err).NotTo(HaveOccurred())
+		for _, e := range entries {
+			sf, err := Load(loadFixtureBytes(e.Name()))
+			Expect(err).NotTo(HaveOccurred(), "fixture %s", e.Name())
+
+			stack, err := sf.ToStack()
+			Expect(err).NotTo(HaveOccurred(), "fixture %s", e.Name())
+
+			exported, err := FromStack(&stack)
+			Expect(err).NotTo(HaveOccurred(), "fixture %s", e.Name())
+
+			stack2, err := exported.ToStack()
+			Expect(err).NotTo(HaveOccurred(), "fixture %s", e.Name())
+			Expect(stack2).To(Equal(stack), "fixture %s must survive a round trip", e.Name())
+		}
+	})
+
+	It("rejects constructs a stackfile cannot express", func() {
+		stack := openapi.Stack{
+			Name: "unsupported",
+			Spec: openapi.StackSpec{
+				StackResources: []openapi.StackResource{{
+					Name:     "web",
+					Source:   &openapi.SourceSpec{Image: openapi.NewImageSource("nginx:latest")},
+					InitSpec: &openapi.InitSpec{Command: []string{"sh"}},
+				}},
+			},
+		}
+		_, err := FromStack(&stack)
+		Expect(err).To(MatchError(ContainSubstring("init_spec")))
+	})
+
+	It("rejects id-only node refs", func() {
+		stack := openapi.Stack{
+			Name: "id-refs",
+			Spec: openapi.StackSpec{
+				StackResources: []openapi.StackResource{{
+					Name:   "web",
+					Source: &openapi.SourceSpec{Image: openapi.NewImageSource("nginx:latest")},
+				}},
+				Connections: []openapi.StackConnection{{
+					Kind: connectionKindEnv,
+					From: openapi.TopologyNodeRef{Type: nodeTypeSecret, Id: ptr.To("some-uuid")},
+					To:   openapi.TopologyNodeRef{Type: nodeTypeStackResource, Name: ptr.To("web")},
+				}},
+			},
+		}
+		_, err := FromStack(&stack)
+		Expect(err).To(MatchError(ContainSubstring("id-only")))
+	})
+})
+
+var _ = Describe("ToStack determinism", func() {
+	It("emits identical documents across repeated conversions", func() {
+		sf, err := Load(loadFixtureBytes("kitchen_sink.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+
+		first, err := sf.ToStack()
+		Expect(err).NotTo(HaveOccurred())
+		for range 5 {
+			again, err := sf.ToStack()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(again).To(Equal(first))
+		}
+	})
+})

--- a/pkg/stackfile/parse.go
+++ b/pkg/stackfile/parse.go
@@ -1,6 +1,7 @@
 package stackfile
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strings"
@@ -18,7 +19,10 @@ func Load(content []byte) (*Stackfile, error) {
 		return nil, fmt.Errorf("stackfile too large (%d bytes, max %d)", len(content), MaxStackfileSize)
 	}
 	var sf Stackfile
-	if err := yaml.Unmarshal(content, &sf); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(content))
+	// Reject unknown keys: a typo'd field silently vanishing is worse than an error.
+	dec.KnownFields(true)
+	if err := dec.Decode(&sf); err != nil {
 		return nil, fmt.Errorf("failed to parse stackfile: %w", err)
 	}
 
@@ -50,18 +54,12 @@ func Validate(sf *Stackfile) error {
 			if res.Build.Repo == "" {
 				return fmt.Errorf("resource '%s' build config missing 'repo'", name)
 			}
-			set := 0
-			if res.Build.Branch != "" {
-				set++
+			if res.Build.Branch != "" && res.Build.Tag != "" {
+				return fmt.Errorf("resource '%s' build config: 'branch' and 'tag' are mutually exclusive", name)
 			}
-			if res.Build.Tag != "" {
-				set++
-			}
-			if res.Build.Commit != "" {
-				set++
-			}
-			if set > 1 {
-				return fmt.Errorf("resource '%s' build config: only one of 'branch', 'tag', or 'commit' can be set", name)
+			// Matches the API's git_commit_requires_ref rule.
+			if res.Build.Commit != "" && res.Build.Branch == "" && res.Build.Tag == "" {
+				return fmt.Errorf("resource '%s' build config: 'commit' requires 'branch' or 'tag'", name)
 			}
 			if res.Build.Dockerfile != "" && !strings.HasSuffix(res.Build.Dockerfile, "Dockerfile") && !strings.Contains(res.Build.Dockerfile, "Dockerfile.") && !strings.Contains(res.Build.Dockerfile, "dockerfile") {
 				return fmt.Errorf("resource '%s' build config: 'dockerfile' should be a path to a Dockerfile", name)
@@ -206,6 +204,9 @@ func validateAddonEnv(resourceName, addonName string, addon AddonConnectionConfi
 	}
 
 	for envKey, envVal := range addon.Env {
+		if dotted := embeddedRefPattern.FindString(envVal); dotted != "" {
+			return fmt.Errorf("resource '%s' addon '%s' env var '%s': addon outputs are bare names — use '{{ host }}', not '%s'", resourceName, addonName, envKey, dotted)
+		}
 		refs := findAddonRefs(envVal)
 		if len(refs) == 0 {
 			return fmt.Errorf("resource '%s' addon '%s' env var '%s': value must use {{ output }} references (e.g., '{{ host }}'), got bare string '%s'", resourceName, addonName, envKey, envVal)

--- a/pkg/stackfile/parse_test.go
+++ b/pkg/stackfile/parse_test.go
@@ -43,3 +43,76 @@ var _ = Describe("output validation (human-readable scheme)", func() {
 		Entry("bare url (ambiguous) rejected", models.OutputNameURL, false),
 	)
 })
+
+var _ = Describe("Load strictness", func() {
+	It("rejects unknown fields", func() {
+		_, err := Load([]byte(`
+name: bad
+resources:
+  web:
+    image: nginx:latest
+    stateful: true
+`))
+		Expect(err).To(MatchError(ContainSubstring("stateful")))
+	})
+
+	It("rejects unknown fields in addon blocks", func() {
+		_, err := Load([]byte(`
+name: bad
+resources:
+  web:
+    image: nginx:latest
+    addons:
+      db:
+        type: postgres
+        size: 10Gi
+        env:
+          DB_HOST: "{{ host }}"
+`))
+		Expect(err).To(MatchError(ContainSubstring(`unknown field "size" in addon config`)))
+	})
+
+	It("rejects dotted refs in addon env", func() {
+		_, err := Load([]byte(`
+name: bad
+resources:
+  web:
+    image: nginx:latest
+    addons:
+      db:
+        type: postgres
+        env:
+          DB_HOST: "{{ postgres.host }}"
+`))
+		Expect(err).To(MatchError(ContainSubstring("bare names")))
+	})
+})
+
+var _ = Describe("build ref validation", func() {
+	load := func(build string) error {
+		_, err := Load([]byte(`
+name: refs
+resources:
+  app:
+    build:
+      repo: https://example.com/repo.git
+` + build))
+		return err
+	}
+
+	It("rejects branch with tag", func() {
+		Expect(load("      branch: main\n      tag: v1.0.0\n")).To(MatchError(ContainSubstring("mutually exclusive")))
+	})
+
+	It("rejects a bare commit", func() {
+		Expect(load("      commit: abc123\n")).To(MatchError(ContainSubstring("requires 'branch' or 'tag'")))
+	})
+
+	It("accepts commit pinned to a branch", func() {
+		Expect(load("      branch: main\n      commit: abc123\n")).To(Succeed())
+	})
+
+	It("accepts commit pinned to a tag", func() {
+		Expect(load("      tag: v1.0.0\n      commit: abc123\n")).To(Succeed())
+	})
+})

--- a/pkg/stackfile/refs.go
+++ b/pkg/stackfile/refs.go
@@ -1,0 +1,108 @@
+package stackfile
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// The env-value reference DSL:
+//   - {{ self.port }}            — own output, must be the whole value
+//   - {{ redis.host }}           — another resource's output, exact or embedded
+//   - redis://{{ redis.host }}   — template; all refs must share one source
+//   - addon env uses bare output names: {{ host }}, {{ username }}
+var (
+	// Matches a full-value ref: the entire string is {{ source.output }}
+	exactRefPattern = regexp.MustCompile(`^\{\{\s*([\w-]+(?:\.[\w-]+)+)\s*\}\}$`)
+	// Matches embedded refs within a larger string
+	embeddedRefPattern = regexp.MustCompile(`\{\{\s*([\w-]+(?:\.[\w-]+)+)\s*\}\}`)
+	// addonVarPattern matches {{ varname }} in addon env templates.
+	// Addon vars are plain output names (host, port, username) — no source prefix.
+	addonVarPattern = regexp.MustCompile(`\{\{\s*([\w-]+)\s*\}\}`)
+)
+
+type envRef struct {
+	Source   string
+	Output   string
+	RawMatch string // the exact substring matched, e.g. "{{ redis.host }}"
+}
+
+func findRefs(value string) []envRef {
+	matches := embeddedRefPattern.FindAllStringSubmatch(value, -1)
+	var refs []envRef
+	for _, m := range matches {
+		parts := strings.SplitN(m[1], ".", 2)
+		if len(parts) == 2 {
+			refs = append(refs, envRef{Source: parts[0], Output: parts[1], RawMatch: m[0]})
+		}
+	}
+	return refs
+}
+
+func isExactRef(value string) bool {
+	return exactRefPattern.MatchString(value)
+}
+
+func isSelfRef(value string) bool {
+	for _, r := range findRefs(value) {
+		if r.Source == sourceSelf {
+			return true
+		}
+	}
+	return false
+}
+
+func extractSelfOutput(value string) string {
+	for _, r := range findRefs(value) {
+		if r.Source == sourceSelf {
+			return r.Output
+		}
+	}
+	return ""
+}
+
+func hasResourceRef(value string) bool {
+	for _, r := range findRefs(value) {
+		if r.Source != sourceSelf {
+			return true
+		}
+	}
+	return false
+}
+
+// outputToVarName turns an output accessor into a template variable name,
+// e.g. "port.http" -> "port_http". Template keys cannot contain dots.
+func outputToVarName(output string) string {
+	return strings.ReplaceAll(output, ".", "_")
+}
+
+type addonRef struct {
+	Output   string
+	RawMatch string
+}
+
+func findAddonRefs(value string) []addonRef {
+	matches := addonVarPattern.FindAllStringSubmatch(value, -1)
+	var refs []addonRef
+	for _, m := range matches {
+		refs = append(refs, addonRef{Output: m[1], RawMatch: m[0]})
+	}
+	return refs
+}
+
+// templateVarPattern matches a specific template variable, e.g. {{key}} or {{ key }}.
+func templateVarPattern(key string) *regexp.Regexp {
+	return regexp.MustCompile(`\{\{\s*` + regexp.QuoteMeta(key) + `\s*\}\}`)
+}
+
+// sortedKeys returns the map's keys in stable order. Map iteration is
+// randomized in Go; every builder walks maps through this so the generated
+// Stack document is byte-identical across runs.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/stackfile/schema.go
+++ b/pkg/stackfile/schema.go
@@ -1,0 +1,8 @@
+package stackfile
+
+import _ "embed"
+
+// SchemaJSON is the JSON Schema (draft-07) for stackfile documents.
+//
+//go:embed schema.json
+var SchemaJSON []byte

--- a/pkg/stackfile/schema.json
+++ b/pkg/stackfile/schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stackdome.com/schemas/stackfile.schema.json",
+  "title": "Stackdome Stackfile",
+  "type": "object",
+  "required": ["name", "resources"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stack name, unique within the project."
+    },
+    "resources": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 50,
+      "description": "Workloads keyed by resource name.",
+      "additionalProperties": { "$ref": "#/definitions/resource" }
+    },
+    "volumes": {
+      "type": "object",
+      "maxProperties": 50,
+      "description": "Persistent volumes keyed by volume name.",
+      "additionalProperties": { "$ref": "#/definitions/volume" }
+    }
+  },
+  "definitions": {
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "oneOf": [
+        { "required": ["image"], "not": { "required": ["build"] } },
+        { "required": ["build"], "not": { "required": ["image"] } }
+      ],
+      "properties": {
+        "image": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Container image reference. Mutually exclusive with build."
+        },
+        "build": { "$ref": "#/definitions/build" },
+        "command": { "type": "array", "items": { "type": "string" } },
+        "args": { "type": "array", "items": { "type": "string" } },
+        "ports": {
+          "type": "array",
+          "maxItems": 20,
+          "items": { "$ref": "#/definitions/port" }
+        },
+        "env": {
+          "type": "object",
+          "description": "Env vars. Values may reference outputs: {{ self.port }}, {{ other-resource.host }}, or templates like redis://{{ redis.host }}:{{ redis.port }}. All refs in one value must use the same source resource.",
+          "additionalProperties": { "type": "string" }
+        },
+        "secrets": {
+          "type": "object",
+          "description": "Secret name -> { ENV_VAR: secret_key }. Secrets must already exist in the project.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        },
+        "addons": {
+          "type": "object",
+          "description": "Addon name -> connection config. Addons must already exist in the project.",
+          "additionalProperties": { "$ref": "#/definitions/addon" }
+        },
+        "volumes": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/volumeMount" }
+        },
+        "depends_on": { "type": "array", "items": { "type": "string" } },
+        "workload_type": {
+          "type": "string",
+          "enum": ["Service", "StatefulService", "Worker", "Job", "CronJob"],
+          "description": "Defaults to Service."
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Cron expression. Only for workload_type CronJob."
+        },
+        "replicas": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo"],
+      "not": { "required": ["branch", "tag"] },
+      "dependencies": {
+        "commit": { "anyOf": [{ "required": ["branch"] }, { "required": ["tag"] }] }
+      },
+      "properties": {
+        "repo": { "type": "string", "minLength": 1, "description": "Git repository URL." },
+        "branch": { "type": "string" },
+        "tag": { "type": "string" },
+        "commit": { "type": "string", "description": "Commit SHA pin; requires branch or tag." },
+        "dockerfile": { "type": "string", "description": "Path to the Dockerfile." },
+        "context": { "type": "string", "description": "Build context directory." }
+      }
+    },
+    "port": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "port"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "protocol": { "type": "string" },
+        "public": { "type": "boolean", "description": "Expose publicly via ingress." },
+        "subdomain": { "type": "string", "description": "Subdomain prefix for the public URL." }
+      }
+    },
+    "volume": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["size"],
+      "properties": {
+        "size": {
+          "type": "string",
+          "pattern": "^[0-9]+[KMGTP]i?$",
+          "description": "Volume size, e.g. 5Gi."
+        },
+        "access_mode": {
+          "type": "string",
+          "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"],
+          "description": "Defaults to ReadWriteOnce."
+        }
+      }
+    },
+    "volumeMount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "path"],
+      "properties": {
+        "name": { "type": "string", "description": "Name of a volume declared in top-level volumes." },
+        "path": { "type": "string", "description": "Absolute mount path in the container." }
+      }
+    },
+    "addon": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "enum": ["postgres"] },
+        "database": { "type": "string", "description": "Database to connect to (postgres)." },
+        "superuser": { "type": "boolean", "description": "Use superuser credentials (postgres)." },
+        "env": {
+          "type": "object",
+          "description": "Env vars templated from addon outputs, e.g. postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}. Bare output names, no prefix.",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/pkg/stackfile/schema_test.go
+++ b/pkg/stackfile/schema_test.go
@@ -1,0 +1,167 @@
+package stackfile
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+func compileSchema() *jsonschema.Schema {
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(SchemaJSON))
+	Expect(err).NotTo(HaveOccurred())
+	c := jsonschema.NewCompiler()
+	Expect(c.AddResource("stackfile.schema.json", doc)).To(Succeed())
+	schema, err := c.Compile("stackfile.schema.json")
+	Expect(err).NotTo(HaveOccurred())
+	return schema
+}
+
+// yamlToJSONValue re-encodes YAML through JSON so the validator sees
+// json-typed values (float64 numbers, string-keyed maps).
+func yamlToJSONValue(content []byte) any {
+	var v any
+	Expect(yaml.Unmarshal(content, &v)).To(Succeed())
+	raw, err := json.Marshal(v)
+	Expect(err).NotTo(HaveOccurred())
+	parsed, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	Expect(err).NotTo(HaveOccurred())
+	return parsed
+}
+
+var _ = Describe("Stackfile JSON Schema", func() {
+	var schema *jsonschema.Schema
+
+	BeforeEach(func() {
+		schema = compileSchema()
+	})
+
+	It("accepts every testdata fixture", func() {
+		entries, err := os.ReadDir(testdataPath(""))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).NotTo(BeEmpty())
+		for _, e := range entries {
+			content, err := os.ReadFile(filepath.Join(testdataPath(""), e.Name()))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(schema.Validate(yamlToJSONValue(content))).To(Succeed(), "fixture %s", e.Name())
+		}
+	})
+
+	DescribeTable("rejects invalid documents",
+		func(doc string) {
+			Expect(schema.Validate(yamlToJSONValue([]byte(doc)))).NotTo(Succeed())
+		},
+		Entry("missing name", `
+resources:
+  web:
+    image: nginx:latest
+`),
+		Entry("no resources", `
+name: empty
+resources: {}
+`),
+		Entry("both image and build", `
+name: bad
+resources:
+  web:
+    image: nginx:latest
+    build:
+      repo: https://example.com/repo.git
+`),
+		Entry("neither image nor build", `
+name: bad
+resources:
+  web:
+    ports:
+      - name: http
+        port: 80
+`),
+		Entry("unknown resource field", `
+name: bad
+resources:
+  web:
+    image: nginx:latest
+    stateful: true
+`),
+		Entry("branch and tag together", `
+name: bad
+resources:
+  web:
+    build:
+      repo: https://example.com/repo.git
+      branch: main
+      tag: v1.0.0
+`),
+		Entry("commit without branch or tag", `
+name: bad
+resources:
+  web:
+    build:
+      repo: https://example.com/repo.git
+      commit: abc123
+`),
+		Entry("port out of range", `
+name: bad
+resources:
+  web:
+    image: nginx:latest
+    ports:
+      - name: http
+        port: 70000
+`),
+		Entry("invalid access mode", `
+name: bad
+resources:
+  web:
+    image: nginx:latest
+volumes:
+  data:
+    size: 1Gi
+    access_mode: ReadWriteSometimes
+`),
+		Entry("invalid volume size format", `
+name: bad
+resources:
+  web:
+    image: nginx:latest
+volumes:
+  data:
+    size: five-gigs
+`),
+		Entry("invalid workload type", `
+name: bad
+resources:
+  web:
+    image: nginx:latest
+    workload_type: Deployment
+`),
+	)
+
+	It("accepts commit pinned to a branch", func() {
+		doc := `
+name: pinned
+resources:
+  web:
+    build:
+      repo: https://example.com/repo.git
+      branch: main
+      commit: abc123
+`
+		Expect(schema.Validate(yamlToJSONValue([]byte(doc)))).To(Succeed())
+	})
+
+	It("accepts a minimal valid document", func() {
+		doc := `
+name: minimal
+resources:
+  web:
+    image: nginx:latest
+`
+		Expect(schema.Validate(yamlToJSONValue([]byte(doc)))).To(Succeed())
+	})
+})

--- a/pkg/stackfile/testdata/infisical.yaml
+++ b/pkg/stackfile/testdata/infisical.yaml
@@ -36,7 +36,7 @@ resources:
     volumes:
       - name: pg-data
         path: /var/lib/postgresql/data
-    stateful: true
+    workload_type: StatefulService
 
   redis:
     image: redis:latest

--- a/pkg/stackfile/testdata/kitchen_sink.yaml
+++ b/pkg/stackfile/testdata/kitchen_sink.yaml
@@ -25,6 +25,8 @@ resources:
         database: api_production
         env:
           DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+          URL: "{{url}}"
+          PASSWORD: "{{ca_certificate}}"
     depends_on:
       - redis
 
@@ -37,7 +39,7 @@ resources:
     volumes:
       - name: redis-data
         path: /data
-    stateful: true
+    workload_type: StatefulService
 
   worker:
     image: api:latest

--- a/pkg/stackfile/testdata/superuser_migration.yaml
+++ b/pkg/stackfile/testdata/superuser_migration.yaml
@@ -1,0 +1,30 @@
+name: superuser-migration
+
+resources:
+  app:
+    image: myorg/api:latest
+    ports:
+      - name: http
+        port: 3000
+        public: true
+        subdomain: api
+    addons:
+      main-db:
+        type: postgres
+        database: app_production
+        env:
+          DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+
+  migrate:
+    image: myorg/api:latest
+    workload_type: Job
+    command: ["/app/migrate"]
+    addons:
+      main-db:
+        type: postgres
+        database: app_production
+        superuser: true
+        env:
+          DATABASE_URL: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
+    depends_on:
+      - app

--- a/pkg/stackfile/types.go
+++ b/pkg/stackfile/types.go
@@ -1,6 +1,8 @@
 package stackfile
 
 import (
+	"fmt"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/Stackdome/stackdome/pkg/models"
@@ -10,6 +12,8 @@ const (
 	PostgresAddonType = "postgres"
 
 	sourceSelf = "self"
+
+	defaultAccessMode = string(models.READ_WRITE_ONCE)
 
 	connectionKindEnv         = string(models.ConnectionKindEnv)
 	connectionKindVolumeMount = string(models.ConnectionKindVolumeMount)
@@ -78,10 +82,11 @@ type SecretMapping map[string]string
 
 type AddonConnectionConfig struct {
 	Type string `yaml:"type"`
-	// Env vars to inject into the resource, with values templated from the addon outputs. E.g. for a postgres addon we might have:
+	// Env vars templated from the addon's outputs. Output names are bare —
+	// no addon prefix (the block already names the addon):
 	// env:
-	//   POSTGRES_HOST: {{ postgres.host }}
-	//   POSTGRES_URI: postgres://{{ postgres.host }}:{{ postgres.port }}
+	//   POSTGRES_HOST: "{{ host }}"
+	//   POSTGRES_URI: "postgres://{{ username }}:{{ password }}@{{ host }}:{{ port }}/{{ database }}"
 	Env      map[string]string    `yaml:"env"`
 	Postgres *PostgresAddonConfig `yaml:"-"`
 
@@ -93,8 +98,24 @@ type PostgresAddonConfig struct {
 	Superuser bool   `yaml:"superuser,omitempty"`
 }
 
+// addonConfigFields are the keys allowed in an addon block. The custom
+// unmarshaler bypasses the decoder's KnownFields check, so unknown keys
+// are rejected here instead.
+var addonConfigFields = map[string]bool{
+	"type": true, "env": true, "database": true, "superuser": true, //nolint:goconst // yaml field names, not a shared constant
+
+}
+
 func (a *AddonConnectionConfig) UnmarshalYAML(node *yaml.Node) error {
 	a.rawNode = *node
+
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i < len(node.Content)-1; i += 2 {
+			if key := node.Content[i].Value; !addonConfigFields[key] {
+				return fmt.Errorf("unknown field %q in addon config", key)
+			}
+		}
+	}
 
 	var base struct {
 		Type string            `yaml:"type"`


### PR DESCRIPTION
## 📝 What this does
Hardens the stackfile pipeline ahead of stackfiles becoming the primary authoring surface for humans and agents: a published JSON Schema with strict parsing, a deterministic and restructured stackfile→Stack transpiler, and a new reverse transpiler (Stack→stackfile) with round-trip guarantees. Ships a full stackfile reference doc.

## 🔀 Changes
- Added a draft-07 JSON Schema for stackfiles, embedded in the binary and validated against every test fixture; parsing now rejects unknown keys (including inside addon blocks) instead of silently dropping them
- Made ToStack deterministic — connections and mappings emit in sorted order, so the same stackfile always produces a byte-identical Stack document
- Aligned git ref rules with the API: branch and tag are exclusive, commit requires one of them (previously commit-only passed locally and failed server-side)
- Added FromStack, a reverse transpiler that fails loudly on constructs a stackfile cannot express; every fixture round-trips to an identical Stack
- Split the converter by responsibility (refs / convert / connections / export), fixed the stale dotted addon-ref doc, and added a fixture covering owner + superuser consumers of one postgres addon, plus docs/stackfile-reference.md

## 🧪 How to test
- [ ] Run `go test ./pkg/stackfile/` — schema, round-trip, determinism, and strict-parse suites
- [ ] Load a stackfile with a typo'd field (e.g. `stateful: true`) and confirm it errors instead of parsing
- [ ] Validate a stackfile against `pkg/stackfile/schema.json` in an editor with YAML schema support