### PR TITLE
Fix: workqueue duplicate operands, release deadline, worker concurrency

### DIFF
--- a/cmd/environment/env.go
+++ b/cmd/environment/env.go
@@ -775,7 +775,7 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 		Env:              e.Name,
 	})
 
-	e.WorkerManager.RegisterWorker(stackWorker, &models.Stack{})
+	e.WorkerManager.RegisterWorker(stackWorker, models.StackOperand{})
 
 	releaseWorker := releaseworker.NewReleaseWorker(releaseworker.ReleaseWorkerSpec{
 		ReleaseService:       e.Services.StackReleaseService,
@@ -803,14 +803,14 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 		ReleaseWorkerEnqueuer: e.WorkerManager,
 		Env:                   e.Name,
 	})
-	e.WorkerManager.RegisterWorker(releaseWorker, &models.StackRelease{})
+	e.WorkerManager.RegisterWorker(releaseWorker, models.StackReleaseOperand{})
 
 	releaseGCWorker := releasegcworker.NewReleaseGCWorker(releasegcworker.ReleaseGCWorkerSpec{
 		ReleaseStore: pgstore.NewStackReleaseStore(pgstore.StackReleaseStoreSpec{SessionFactory: e.DBSession}),
 		StackStore:   pgstore.NewStackStore(&pgstore.StackStoreSpec{SessionFactory: e.DBSession}),
 		Env:          e.Name,
 	})
-	e.WorkerManager.RegisterWorker(releaseGCWorker, &releasegcworker.ReleaseGCRequest{})
+	e.WorkerManager.RegisterWorker(releaseGCWorker, releasegcworker.ReleaseGCRequest{})
 
 	volumeWorker := volumeworker.NewVolumeWorker(volumeworker.VolumeWorkerSpec{
 		VolumeService:  e.Services.VolumeService,
@@ -822,7 +822,7 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 		VolumeCrBuilder: builders.NewClusterResourceBuilder(builders.ClusterResourceBuilderSpec{}),
 		Env:             e.Name,
 	})
-	e.WorkerManager.RegisterWorker(volumeWorker, &models.Volume{})
+	e.WorkerManager.RegisterWorker(volumeWorker, models.VolumeOperand{})
 
 	pgAddonWorker := postgresaddonworker.NewPostgresAddonWorker(postgresaddonworker.PostgresAddonWorkerSpec{
 		PostgresAddonService: e.Services.PostgresAddonService,
@@ -834,7 +834,7 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 		CRBuilder:            builders.NewPostgresClusterBuilder(),
 		Env:                  e.Name,
 	})
-	e.WorkerManager.RegisterWorker(pgAddonWorker, &models.PostgresAddon{})
+	e.WorkerManager.RegisterWorker(pgAddonWorker, models.PostgresAddonOperand{})
 
 	inviteEmailWorker := inviteworker.NewInviteWorker(inviteworker.InviteWorkerSpec{
 		InviteService:  e.Services.OrgInviteService,
@@ -842,14 +842,14 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 		LeadershipFlag: e.LeadershipFlag,
 		Env:            e.Name,
 	})
-	e.WorkerManager.RegisterWorker(inviteEmailWorker, &models.OrgInvite{})
+	e.WorkerManager.RegisterWorker(inviteEmailWorker, models.OrgInviteOperand{})
 
 	inviteCleanupWorker := inviteworker.NewInviteCleanupWorker(inviteworker.InviteCleanupWorkerSpec{
 		InviteService:  e.Services.OrgInviteService,
 		LeadershipFlag: e.LeadershipFlag,
 		Env:            e.Name,
 	})
-	e.WorkerManager.RegisterWorker(inviteCleanupWorker, &inviteworker.InviteCleanupBatch{})
+	e.WorkerManager.RegisterWorker(inviteCleanupWorker, inviteworker.InviteCleanupRequest{})
 
 	previewStackStore := pgstore.NewPreviewStackStore(pgstore.PreviewStackStoreSpec{
 		SessionFactory: e.DBSession,
@@ -872,7 +872,7 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 		CommentService:      previewCommentService,
 		Env:                 e.Name,
 	})
-	e.WorkerManager.RegisterWorker(previewWorker, &models.PreviewStack{})
+	e.WorkerManager.RegisterWorker(previewWorker, models.PreviewStackOperand{})
 
 	return nil
 }

--- a/pkg/controllers/stack/stack_controller.go
+++ b/pkg/controllers/stack/stack_controller.go
@@ -150,7 +150,7 @@ func (w *stackReconciler) enqueueActiveRelease(ctx context.Context, stackID stri
 	if active == nil {
 		return
 	}
-	if err := w.enqueuer.Enqueue(&models.StackRelease{ID: active.ID}); err != nil {
+	if err := w.enqueuer.Enqueue(models.StackReleaseOperand{ID: active.ID}); err != nil {
 		w.Log.Error(ctx, "Failed to enqueue release '%s': %v", active.ID, err)
 	}
 }

--- a/pkg/models/worker_operands.go
+++ b/pkg/models/worker_operands.go
@@ -1,0 +1,19 @@
+package models
+
+// Workqueue operands. Must be comparable values, never pointers:
+//   - the workqueue dedups and rate-limits by map-key equality,
+//   - a pointer's map key is its address, so every allocation looks like
+//     new work and duplicates accumulate for long-running operands,
+//   - value keys also guarantee no two goroutines process the same
+//     operand concurrently once workers run with multiple goroutines.
+type StackOperand struct{ ID string }
+
+type StackReleaseOperand struct{ ID string }
+
+type VolumeOperand struct{ ID string }
+
+type PostgresAddonOperand struct{ ID string }
+
+type OrgInviteOperand struct{ ID string }
+
+type PreviewStackOperand struct{ ID string }

--- a/pkg/services/org_invite_service.go
+++ b/pkg/services/org_invite_service.go
@@ -149,7 +149,7 @@ func (s *orgInviteService) Create(ctx context.Context, email, projectName string
 	}
 
 	if s.BackgroundJobEnqueuer != nil {
-		if err := s.BackgroundJobEnqueuer.Enqueue(&models.OrgInvite{ID: created.ID}); err != nil {
+		if err := s.BackgroundJobEnqueuer.Enqueue(models.OrgInviteOperand{ID: created.ID}); err != nil {
 			s.logger.Error(ctx, "failed to enqueue invite email job: %s", err.Error())
 		}
 	}
@@ -217,7 +217,7 @@ func (s *orgInviteService) Resend(ctx context.Context, orgID, id string) *errors
 	}
 
 	if s.BackgroundJobEnqueuer != nil {
-		if err := s.BackgroundJobEnqueuer.Enqueue(&models.OrgInvite{ID: id}); err != nil {
+		if err := s.BackgroundJobEnqueuer.Enqueue(models.OrgInviteOperand{ID: id}); err != nil {
 			s.logger.Error(ctx, "failed to enqueue invite email job for resend: %s", err.Error())
 		}
 	}

--- a/pkg/services/postgres_addon_service.go
+++ b/pkg/services/postgres_addon_service.go
@@ -258,9 +258,7 @@ func (s *postgresAddonService) CreatePostgresAddon(ctx context.Context, postgres
 		return nil, err
 	}
 
-	if err := s.BackgroundJobEnqueuer.Enqueue(&models.PostgresAddon{
-		ID: createdPostgresAddon.ID,
-	}); err != nil {
+	if err := s.BackgroundJobEnqueuer.Enqueue(models.PostgresAddonOperand{ID: createdPostgresAddon.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue background job for postgres addon '%s': %s", createdPostgresAddon.Name, err.Error())
 	}
 
@@ -347,9 +345,7 @@ func (s *postgresAddonService) UpdatePostgresAddon(ctx context.Context, id strin
 		return nil, err
 	}
 
-	if err := s.BackgroundJobEnqueuer.Enqueue(&models.PostgresAddon{
-		ID: updatedPostgresAddon.ID,
-	}); err != nil {
+	if err := s.BackgroundJobEnqueuer.Enqueue(models.PostgresAddonOperand{ID: updatedPostgresAddon.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue background job for postgres addon '%s': %s", updatedPostgresAddon.Name, err.Error())
 	}
 
@@ -454,9 +450,7 @@ func (s *postgresAddonService) DeletePostgresAddon(ctx context.Context, id strin
 		return nil, errors.GeneralError("failed to update PostgreSQL addon status for deletion: %s", err.Error())
 	}
 
-	if err := s.BackgroundJobEnqueuer.Enqueue(&models.PostgresAddon{
-		ID: id,
-	}); err != nil {
+	if err := s.BackgroundJobEnqueuer.Enqueue(models.PostgresAddonOperand{ID: id}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue background job for postgres addon '%s': %s", postgresAddon.Name, err.Error())
 	}
 
@@ -555,9 +549,7 @@ func (s *postgresAddonService) TriggerBackup(ctx context.Context, id string) *er
 		return err
 	}
 
-	if err := s.BackgroundJobEnqueuer.Enqueue(&models.PostgresAddon{
-		ID: id,
-	}); err != nil {
+	if err := s.BackgroundJobEnqueuer.Enqueue(models.PostgresAddonOperand{ID: id}); err != nil {
 		return errors.GeneralError("failed to enqueue backup job for postgres addon '%s': %s", id, err.Error())
 	}
 	return nil
@@ -582,7 +574,7 @@ func (s *postgresAddonService) TriggerHibernate(ctx context.Context, id string, 
 		return err
 	}
 
-	if err := s.BackgroundJobEnqueuer.Enqueue(&models.PostgresAddon{ID: id}); err != nil {
+	if err := s.BackgroundJobEnqueuer.Enqueue(models.PostgresAddonOperand{ID: id}); err != nil {
 		return errors.GeneralError("failed to enqueue hibernation job for postgres addon '%s': %s", postgresAddon.Name, err.Error())
 	}
 	return nil
@@ -607,7 +599,7 @@ func (s *postgresAddonService) TriggerFence(ctx context.Context, id string, enab
 		return err
 	}
 
-	if err := s.BackgroundJobEnqueuer.Enqueue(&models.PostgresAddon{ID: id}); err != nil {
+	if err := s.BackgroundJobEnqueuer.Enqueue(models.PostgresAddonOperand{ID: id}); err != nil {
 		return errors.GeneralError("failed to enqueue fencing job for postgres addon '%s': %s", postgresAddon.Name, err.Error())
 	}
 	return nil

--- a/pkg/services/postgres_addon_service_test.go
+++ b/pkg/services/postgres_addon_service_test.go
@@ -63,7 +63,7 @@ var _ = Describe("PostgresAddonService DeletePostgresAddon", func() {
 				Expect(status.State).To(Equal(models.PostgresAddonStateDeleting))
 				return nil
 			})
-		enqueuer.EXPECT().Enqueue(&models.PostgresAddon{ID: "pg-1"}).Return(nil)
+		enqueuer.EXPECT().Enqueue(models.PostgresAddonOperand{ID: "pg-1"}).Return(nil)
 
 		deleted, err := svc.DeletePostgresAddon(ctx, "pg-1")
 		Expect(err).To(BeNil())
@@ -131,7 +131,7 @@ var _ = Describe("CreatePostgresAddon storage class defaulting", func() {
 				return capturedAddon, nil
 			})
 		permissions.EXPECT().Check(gomock.Any(), projectID, auth.ResourceAddonsPostgres, addonID, auth.ActionRead).Return(nil)
-		enqueuer.EXPECT().Enqueue(&models.PostgresAddon{ID: addonID}).Return(nil)
+		enqueuer.EXPECT().Enqueue(models.PostgresAddonOperand{ID: addonID}).Return(nil)
 	}
 
 	BeforeEach(func() {
@@ -283,7 +283,7 @@ var _ = Describe("UpdatePostgresAddon storage class carry-forward", func() {
 				Expect(addon.Storage.StorageClass).To(Equal(existingStorageClass))
 				return addon, nil
 			})
-		enqueuer.EXPECT().Enqueue(&models.PostgresAddon{ID: addonID}).Return(nil)
+		enqueuer.EXPECT().Enqueue(models.PostgresAddonOperand{ID: addonID}).Return(nil)
 
 		update := newUpdateFixture()
 		update.Storage.StorageClass = ""

--- a/pkg/services/preview_stack_service.go
+++ b/pkg/services/preview_stack_service.go
@@ -173,7 +173,7 @@ func (s *previewStackService) provisionPreview(ctx context.Context, config *mode
 		return nil, sErr
 	}
 
-	if err := s.BackgroundJobEnqueuer.Enqueue(&models.PreviewStack{ID: created.ID}); err != nil {
+	if err := s.BackgroundJobEnqueuer.Enqueue(models.PreviewStackOperand{ID: created.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue preview stack processing: %v", err)
 	}
 
@@ -241,7 +241,7 @@ func (s *previewStackService) syncPreview(ctx context.Context, preview *models.P
 		return sErr
 	}
 
-	if err := s.BackgroundJobEnqueuer.Enqueue(&models.PreviewStack{ID: preview.ID}); err != nil {
+	if err := s.BackgroundJobEnqueuer.Enqueue(models.PreviewStackOperand{ID: preview.ID}); err != nil {
 		return errors.GeneralError("failed to enqueue preview stack sync: %v", err)
 	}
 
@@ -323,7 +323,7 @@ func (s *previewStackService) deletePreview(ctx context.Context, preview *models
 		return sErr
 	}
 
-	if err := s.BackgroundJobEnqueuer.Enqueue(&models.PreviewStack{ID: preview.ID}); err != nil {
+	if err := s.BackgroundJobEnqueuer.Enqueue(models.PreviewStackOperand{ID: preview.ID}); err != nil {
 		return errors.GeneralError("failed to enqueue preview stack deletion: %v", err)
 	}
 

--- a/pkg/services/preview_stack_service_webhook_test.go
+++ b/pkg/services/preview_stack_service_webhook_test.go
@@ -59,7 +59,7 @@ var _ = Describe("previewStackService InternalCreateFromWebhook", func() {
 				return preview, nil
 			},
 		)
-		enqueuer.EXPECT().Enqueue(&models.PreviewStack{ID: "preview-1"}).Return(nil)
+		enqueuer.EXPECT().Enqueue(models.PreviewStackOperand{ID: "preview-1"}).Return(nil)
 
 		created, sErr := svc.InternalCreateFromWebhook(ctx, config, "7", "feature", "abc123")
 		Expect(sErr).To(BeNil())

--- a/pkg/services/stack_apply_test.go
+++ b/pkg/services/stack_apply_test.go
@@ -92,7 +92,7 @@ func TestApplyStack_CreatesWhenMissing(t *testing.T) {
 	env.referenceService.EXPECT().ReprojectSpec(ctx, "stack-1").Return(nil)
 	created := &models.Stack{ID: "stack-1", Name: "demo", ProjectID: projectID}
 	env.stackStore.EXPECT().GetByID(ctx, "stack-1").Return(created, nil)
-	env.backgroundEnqueue.EXPECT().EnqueueAfterCommit(ctx, &models.Stack{ID: "stack-1"}).Return(nil)
+	env.backgroundEnqueue.EXPECT().EnqueueAfterCommit(ctx, models.StackOperand{ID: "stack-1"}).Return(nil)
 
 	got, wasCreated, serr := env.svc.ApplyStack(ctx, spec)
 	assert.Nil(t, serr)

--- a/pkg/services/stack_release_service.go
+++ b/pkg/services/stack_release_service.go
@@ -180,7 +180,7 @@ func (s *stackReleaseService) createReleaseForStack(ctx context.Context, stack *
 		return nil, txErr
 	}
 
-	if err := s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, &models.StackRelease{ID: created.ID}); err != nil {
+	if err := s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, models.StackReleaseOperand{ID: created.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue release: %s", err.Error())
 	}
 	return created, nil
@@ -256,7 +256,7 @@ func (s *stackReleaseService) RollbackRelease(ctx context.Context, stackID, from
 		return nil, txErr
 	}
 
-	if err := s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, &models.StackRelease{ID: created.ID}); err != nil {
+	if err := s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, models.StackReleaseOperand{ID: created.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue release: %s", err.Error())
 	}
 	return created, nil

--- a/pkg/services/stack_release_service_test.go
+++ b/pkg/services/stack_release_service_test.go
@@ -251,7 +251,7 @@ var _ = Describe("stackReleaseService release creation records release_created",
 			releaseStore.EXPECT().Create(ctx, gomock.Any()).Return(created, nil)
 			referenceSvc.EXPECT().ProjectRelease(ctx, created).Return(nil)
 			recorder.EXPECT().RecordReleaseCreated(ctx, created).Return(nil)
-			enqueuer.EXPECT().EnqueueAfterCommit(ctx, &models.StackRelease{ID: "rel-1"}).Return(nil)
+			enqueuer.EXPECT().EnqueueAfterCommit(ctx, models.StackReleaseOperand{ID: "rel-1"}).Return(nil)
 
 			got, serr := svc.createReleaseForStack(ctx, stack, models.ReleaseCause{Kind: models.ReleaseCauseManual}, createEventsUserID)
 			Expect(serr).To(BeNil())
@@ -291,7 +291,7 @@ var _ = Describe("stackReleaseService release creation records release_created",
 			releaseStore.EXPECT().Create(ctx, gomock.Any()).Return(created, nil)
 			referenceSvc.EXPECT().ProjectRelease(ctx, created).Return(nil)
 			recorder.EXPECT().RecordReleaseCreated(ctx, created).Return(nil)
-			enqueuer.EXPECT().EnqueueAfterCommit(ctx, &models.StackRelease{ID: "rel-2"}).Return(nil)
+			enqueuer.EXPECT().EnqueueAfterCommit(ctx, models.StackReleaseOperand{ID: "rel-2"}).Return(nil)
 
 			got, serr := svc.RollbackRelease(ctx, createEventsStackID, rollbackFromRelID)
 			Expect(serr).To(BeNil())

--- a/pkg/services/stack_service.go
+++ b/pkg/services/stack_service.go
@@ -235,11 +235,11 @@ func (s *stackService) InternalCreateStack(ctx context.Context, spec *models.Sta
 	if err != nil {
 		return nil, err
 	}
-	if err := s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, &models.Stack{ID: createdStack.ID}); err != nil {
+	if err := s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, models.StackOperand{ID: createdStack.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue background job for stack '%s': %s", spec.Name, err.Error())
 	}
 	for _, v := range createdStack.Volumes {
-		_ = s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, &models.Volume{ID: v.ID})
+		_ = s.BackgroundJobEnqueuer.EnqueueAfterCommit(ctx, models.VolumeOperand{ID: v.ID})
 	}
 	s.logger.WithFields(map[string]interface{}{
 		logger.FieldStackID:   createdStack.ID,
@@ -343,7 +343,7 @@ func (s *stackService) InternalUpdateStack(ctx context.Context, ID string, spec 
 	}
 	for _, v := range updatedStack.Volumes {
 		if _, existed := existingVolumeIDs[v.ID]; !existed {
-			if enqErr := s.BackgroundJobEnqueuer.Enqueue(&models.Volume{ID: v.ID}); enqErr != nil {
+			if enqErr := s.BackgroundJobEnqueuer.Enqueue(models.VolumeOperand{ID: v.ID}); enqErr != nil {
 				return nil, errors.GeneralError("failed to enqueue volume '%s': %s", v.ID, enqErr.Error())
 			}
 		}
@@ -504,7 +504,7 @@ func (s *stackService) CreateStackVolume(ctx context.Context, stackID string, vo
 		return nil, txErr
 	}
 
-	if enqErr := s.BackgroundJobEnqueuer.Enqueue(&models.Volume{ID: created.ID}); enqErr != nil {
+	if enqErr := s.BackgroundJobEnqueuer.Enqueue(models.VolumeOperand{ID: created.ID}); enqErr != nil {
 		return nil, errors.GeneralError("failed to enqueue volume '%s': %s", created.ID, enqErr.Error())
 	}
 	return created, nil
@@ -746,9 +746,7 @@ func (s *stackService) InternalDeleteStack(ctx context.Context, stack *models.St
 	if err != nil {
 		return nil, errors.GeneralError("failed to update stack '%s' for deletion: %s", stack.Name, err.Error())
 	}
-	if err := s.BackgroundJobEnqueuer.Enqueue(&models.Stack{
-		ID: stack.ID,
-	}); err != nil {
+	if err := s.BackgroundJobEnqueuer.Enqueue(models.StackOperand{ID: stack.ID}); err != nil {
 		return nil, errors.GeneralError("failed to enqueue background job for stack '%s': %s", stack.Name, err.Error())
 	}
 	s.logger.WithField(logger.FieldStackID, stack.ID).Info(ctx, "marked stack for deletion")

--- a/pkg/services/stack_volume_create_test.go
+++ b/pkg/services/stack_volume_create_test.go
@@ -49,7 +49,7 @@ func TestStackService_CreateStackVolume(t *testing.T) {
 		mockStackStore.EXPECT().GetByID(ctx, stackID).Return(stack, nil)
 		created := &models.Volume{ID: "v-1", Name: "web-data"}
 		mockVolumeService.EXPECT().InternalCreateWithTx(ctx, stack, newVolume).Return(created, nil)
-		mockEnqueuer.EXPECT().Enqueue(&models.Volume{ID: "v-1"}).Return(nil)
+		mockEnqueuer.EXPECT().Enqueue(models.VolumeOperand{ID: "v-1"}).Return(nil)
 
 		got, serr := svc.CreateStackVolume(ctx, stackID, newVolume)
 		assert.Nil(t, serr)

--- a/pkg/worker/invite/invite_cleanup_worker.go
+++ b/pkg/worker/invite/invite_cleanup_worker.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/Stackdome/stackdome/pkg/errors"
-	"github.com/Stackdome/stackdome/pkg/models"
 	"github.com/Stackdome/stackdome/pkg/services"
 	"github.com/Stackdome/stackdome/pkg/stores"
 	"github.com/Stackdome/stackdome/pkg/worker"
@@ -14,9 +13,9 @@ import (
 
 const InviteCleanupWorkerName = "invite-cleanup-worker"
 
-type InviteCleanupBatch struct {
-	Items []*models.OrgInvite
-}
+// InviteCleanupRequest is a comparable singleton operand: successive ticks
+// dedup to one queue entry, and Execute queries the expired set itself.
+type InviteCleanupRequest struct{}
 
 type inviteCleanupWorker struct {
 	inviteService  services.OrgInviteService
@@ -48,25 +47,23 @@ func (w *inviteCleanupWorker) GetInput(ctx context.Context) ([]worker.Operand, *
 		return nil, nil
 	}
 
-	params := stores.ListParams{Page: 1, PageSize: stores.MaxPageSize}
-	result, serr := w.inviteService.InternalListExpiredOrPastDue(ctx, time.Now().UTC(), params)
-	if serr != nil {
-		return nil, w.WorkerError.NewError("failed to list expired invites: %v", serr)
-	}
-
-	if len(result.Items) == 0 {
-		return nil, nil
-	}
-
-	return []worker.Operand{&InviteCleanupBatch{Items: result.Items}}, nil
+	return []worker.Operand{InviteCleanupRequest{}}, nil
 }
 
 func (w *inviteCleanupWorker) Execute(ctx context.Context, operand worker.Operand) (worker.Result, *errors.ServiceError) {
-	batch, ok := operand.(*InviteCleanupBatch)
-	if !ok {
-		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected *InviteCleanupBatch")
+	if _, ok := operand.(InviteCleanupRequest); !ok {
+		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected InviteCleanupRequest")
 	}
-	invites := batch.Items
+
+	params := stores.ListParams{Page: 1, PageSize: stores.MaxPageSize}
+	result, serr := w.inviteService.InternalListExpiredOrPastDue(ctx, time.Now().UTC(), params)
+	if serr != nil {
+		return worker.Result{}, w.WorkerError.NewError("failed to list expired invites: %v", serr)
+	}
+	invites := result.Items
+	if len(invites) == 0 {
+		return worker.Result{}, nil
+	}
 
 	w.Logger().Info(ctx, "Cleaning up %d expired invites", len(invites))
 

--- a/pkg/worker/invite/invite_worker.go
+++ b/pkg/worker/invite/invite_worker.go
@@ -56,15 +56,15 @@ func (w *inviteWorker) GetInput(ctx context.Context) ([]worker.Operand, *errors.
 
 	operands := make([]worker.Operand, len(result.Items))
 	for i, invite := range result.Items {
-		operands[i] = invite
+		operands[i] = models.OrgInviteOperand{ID: invite.ID}
 	}
 	return operands, nil
 }
 
 func (w *inviteWorker) Execute(ctx context.Context, operand worker.Operand) (worker.Result, *errors.ServiceError) {
-	id, ok := operand.(*models.OrgInvite)
+	id, ok := operand.(models.OrgInviteOperand)
 	if !ok {
-		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected *models.OrgInvite")
+		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected models.OrgInviteOperand")
 	}
 
 	invite, serr := w.inviteService.InternalGetByID(ctx, id.ID)

--- a/pkg/worker/postgresaddon/postgres_addon_worker.go
+++ b/pkg/worker/postgresaddon/postgres_addon_worker.go
@@ -52,9 +52,9 @@ func (w *postgresAddonWorker) Interval() time.Duration {
 }
 
 func (w *postgresAddonWorker) Execute(ctx context.Context, operand worker.Operand) (worker.Result, *errors.ServiceError) {
-	addonRef, ok := operand.(*models.PostgresAddon)
+	addonRef, ok := operand.(models.PostgresAddonOperand)
 	if !ok {
-		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected *models.PostgresAddon")
+		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected models.PostgresAddonOperand")
 	}
 
 	addon, err := w.postgresAddonService.InternalGetPostgresAddon(ctx, addonRef.ID)
@@ -109,7 +109,7 @@ func (w *postgresAddonWorker) GetInput(ctx context.Context) ([]worker.Operand, *
 
 	operands := make([]worker.Operand, len(addons))
 	for i, addon := range addons {
-		operands[i] = &models.PostgresAddon{ID: addon.ID}
+		operands[i] = models.PostgresAddonOperand{ID: addon.ID}
 	}
 	return operands, nil
 }

--- a/pkg/worker/postgresaddon/postgres_addon_worker_test.go
+++ b/pkg/worker/postgresaddon/postgres_addon_worker_test.go
@@ -49,7 +49,7 @@ var _ = Describe("PostgresAddonWorker", func() {
 			operands, err := w.GetInput(ctx)
 			Expect(err).To(BeNil())
 			Expect(operands).To(HaveLen(1))
-			Expect(operands[0]).To(Equal(worker.Operand(&models.PostgresAddon{ID: "addon-1"})))
+			Expect(operands[0]).To(Equal(worker.Operand(models.PostgresAddonOperand{ID: "addon-1"})))
 		})
 	})
 })

--- a/pkg/worker/preview/preview_worker.go
+++ b/pkg/worker/preview/preview_worker.go
@@ -49,9 +49,9 @@ func NewPreviewWorker(spec PreviewWorkerSpec) worker.Worker {
 }
 
 func (w *previewWorker) Execute(ctx context.Context, operand worker.Operand) (worker.Result, *errors.ServiceError) {
-	previewRef, ok := operand.(*models.PreviewStack)
+	previewRef, ok := operand.(models.PreviewStackOperand)
 	if !ok {
-		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected *models.PreviewStack")
+		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected models.PreviewStackOperand")
 	}
 
 	preview, serr := w.previewStackStore.GetByID(ctx, previewRef.ID)
@@ -110,7 +110,7 @@ func (w *previewWorker) GetInput(ctx context.Context) ([]worker.Operand, *errors
 			return nil, w.WorkerError.NewError("failed to list active previews: %v", sErr)
 		}
 		for _, p := range previews {
-			operands = append(operands, &models.PreviewStack{ID: p.ID})
+			operands = append(operands, models.PreviewStackOperand{ID: p.ID})
 		}
 		if len(previews) < activePreviewPageSize {
 			break

--- a/pkg/worker/release/converge.go
+++ b/pkg/worker/release/converge.go
@@ -71,9 +71,8 @@ func (r *convergeReconciler) Reconcile(ctx context.Context, release *models.Stac
 		return resultStop, nil
 	}
 
-	// No deploy timeout: the agent reconciles level-triggered, so convergence
-	// can arrive at any time. Poll until converged, superseded, or a real
-	// failure signal (build failed, apply error) terminates the release.
+	// Poll until converged, superseded, a failure signal (build failed,
+	// apply error), or the deadline reconciler times the release out.
 	return resultRequeueAfter(convergencePollInterval), nil
 }
 

--- a/pkg/worker/release/deadline_reconciler.go
+++ b/pkg/worker/release/deadline_reconciler.go
@@ -1,0 +1,43 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Stackdome/stackdome/pkg/logger"
+	"github.com/Stackdome/stackdome/pkg/models"
+)
+
+type deadlineReconciler struct {
+	releaseService releaseService
+	logger         logger.Logger
+}
+
+func newDeadlineReconciler(spec ReleaseWorkerSpec) *deadlineReconciler {
+	return &deadlineReconciler{
+		releaseService: spec.ReleaseService,
+		logger:         logger.NewLoggerWithPrefix(context.Background(), "release-deadline"),
+	}
+}
+
+func (r *deadlineReconciler) Name() string { return "deadline" }
+
+// Fails a release still in progress convergenceTimeout after creation.
+// Runs after the gatekeeper so supersede/CAS decisions happen first; covers
+// every later phase (render, apply, converge), not just convergence polling.
+func (r *deadlineReconciler) Reconcile(ctx context.Context, release *models.StackRelease) (subReconcilerResult, error) {
+	if release.State != models.ReleaseStateInProgress {
+		return resultNil, nil
+	}
+	if time.Since(release.CreatedAt) <= convergenceTimeout {
+		return resultNil, nil
+	}
+
+	msg := fmt.Sprintf("release did not converge within %d minutes", int(convergenceTimeout.Minutes()))
+	if _, err := r.releaseService.MarkFailed(ctx, release.ID, msg, nil); err != nil {
+		return resultNil, fmt.Errorf("failed to mark release failed on deadline: %w", err)
+	}
+	r.logger.Info(ctx, "release %s: %s", release.ID, msg)
+	return resultStop, nil
+}

--- a/pkg/worker/release/deadline_reconciler_test.go
+++ b/pkg/worker/release/deadline_reconciler_test.go
@@ -1,0 +1,71 @@
+package release
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	"github.com/Stackdome/stackdome/pkg/models"
+)
+
+var _ = Describe("deadlineReconciler", func() {
+	var (
+		ctrl       *gomock.Controller
+		releaseSvc *MockreleaseService
+		r          *deadlineReconciler
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		releaseSvc = NewMockreleaseService(ctrl)
+		r = newDeadlineReconciler(ReleaseWorkerSpec{ReleaseService: releaseSvc})
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("fails an InProgress release older than the convergence timeout", func() {
+		release := &models.StackRelease{
+			ID:        "rel-1",
+			State:     models.ReleaseStateInProgress,
+			CreatedAt: time.Now().Add(-convergenceTimeout - time.Minute),
+		}
+		releaseSvc.EXPECT().
+			MarkFailed(ctx, "rel-1", "release did not converge within 45 minutes", nil).
+			Return(true, nil)
+
+		result, err := r.Reconcile(ctx, release)
+		Expect(err).To(BeNil())
+		Expect(result.resultStop).To(BeTrue())
+	})
+
+	It("leaves an InProgress release inside the timeout alone", func() {
+		release := &models.StackRelease{
+			ID:        "rel-1",
+			State:     models.ReleaseStateInProgress,
+			CreatedAt: time.Now().Add(-time.Minute),
+		}
+
+		result, err := r.Reconcile(ctx, release)
+		Expect(err).To(BeNil())
+		Expect(result.resultNil).To(BeTrue())
+	})
+
+	It("ignores releases not yet InProgress even when old", func() {
+		release := &models.StackRelease{
+			ID:        "rel-1",
+			State:     models.ReleaseStatePending,
+			CreatedAt: time.Now().Add(-convergenceTimeout - time.Hour),
+		}
+
+		result, err := r.Reconcile(ctx, release)
+		Expect(err).To(BeNil())
+		Expect(result.resultNil).To(BeTrue())
+	})
+})

--- a/pkg/worker/release/release_worker.go
+++ b/pkg/worker/release/release_worker.go
@@ -19,6 +19,10 @@ import (
 const (
 	ReleaseWorkerName       = "release-worker"
 	convergencePollInterval = 15 * time.Second
+	// A release that hasn't reached a terminal state within this window is
+	// failed by the deadline reconciler — bounds background load from
+	// workloads that will never become ready (e.g. crashlooping apps).
+	convergenceTimeout = 45 * time.Minute
 )
 
 type ReleaseWorkerSpec struct {
@@ -55,6 +59,7 @@ func NewReleaseWorker(spec ReleaseWorkerSpec) worker.Worker {
 		releaseWorkerEnqueuer: spec.ReleaseWorkerEnqueuer,
 		subReconcilers: []subReconciler{
 			newGatekeeperReconciler(spec),
+			newDeadlineReconciler(spec),
 			newSimulatorReconciler(spec),
 			newValidationReconciler(spec),
 			newRenderReconciler(spec),
@@ -70,9 +75,9 @@ func (w *releaseWorker) Interval() time.Duration {
 }
 
 func (w *releaseWorker) Execute(ctx context.Context, operand worker.Operand) (worker.Result, *errors.ServiceError) {
-	releaseRef, ok := operand.(*models.StackRelease)
+	releaseRef, ok := operand.(models.StackReleaseOperand)
 	if !ok {
-		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected *models.StackRelease")
+		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected models.StackReleaseOperand")
 	}
 
 	release, serr := w.releaseService.InternalGet(ctx, releaseRef.ID)
@@ -99,7 +104,7 @@ func (w *releaseWorker) Execute(ctx context.Context, operand worker.Operand) (wo
 	if w.releaseWorkerEnqueuer != nil {
 		updated, _ := w.releaseService.InternalGet(ctx, releaseRef.ID)
 		if updated != nil && updated.State.Terminal() {
-			if err := w.releaseWorkerEnqueuer.Enqueue(&releasegc.ReleaseGCRequest{StackID: updated.StackID}); err != nil {
+			if err := w.releaseWorkerEnqueuer.Enqueue(releasegc.ReleaseGCRequest{StackID: updated.StackID}); err != nil {
 				w.Logger().Error(ctx, "failed to enqueue release GC for stack %s: %v", updated.StackID, err)
 			}
 		}
@@ -134,7 +139,7 @@ func (w *releaseWorker) GetInput(ctx context.Context) ([]worker.Operand, *errors
 	}
 	operands := make([]worker.Operand, 0, len(releases))
 	for _, r := range releases {
-		operands = append(operands, &models.StackRelease{ID: r.ID})
+		operands = append(operands, models.StackReleaseOperand{ID: r.ID})
 	}
 	return operands, nil
 }

--- a/pkg/worker/releasegc/release_gc_worker.go
+++ b/pkg/worker/releasegc/release_gc_worker.go
@@ -56,9 +56,9 @@ func (w *releaseGCWorker) Interval() time.Duration {
 }
 
 func (w *releaseGCWorker) Execute(ctx context.Context, operand worker.Operand) (worker.Result, *errors.ServiceError) {
-	req, ok := operand.(*ReleaseGCRequest)
+	req, ok := operand.(ReleaseGCRequest)
 	if !ok {
-		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected *ReleaseGCRequest")
+		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected ReleaseGCRequest")
 	}
 
 	stack, stackErr := w.stackStore.GetByID(ctx, req.StackID)
@@ -95,7 +95,7 @@ func (w *releaseGCWorker) GetInput(ctx context.Context) ([]worker.Operand, *erro
 	}
 	operands := make([]worker.Operand, 0, len(stackIDs))
 	for _, id := range stackIDs {
-		operands = append(operands, &ReleaseGCRequest{StackID: id})
+		operands = append(operands, ReleaseGCRequest{StackID: id})
 	}
 	return operands, nil
 }

--- a/pkg/worker/stack/stack_worker.go
+++ b/pkg/worker/stack/stack_worker.go
@@ -55,9 +55,9 @@ func NewStackWorker(spec StackWorkerSpec) worker.Worker {
 }
 
 func (w *stackWorker) Execute(ctx context.Context, operand worker.Operand) (worker.Result, *errors.ServiceError) {
-	stackID, ok := operand.(*models.Stack)
+	stackID, ok := operand.(models.StackOperand)
 	if !ok {
-		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected *models.Stack")
+		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected models.StackOperand")
 	}
 
 	log := w.Logger().WithField(logger.FieldStackID, stackID.ID)
@@ -119,9 +119,7 @@ func (w *stackWorker) GetInput(ctx context.Context) ([]worker.Operand, *errors.S
 
 	operands := make([]worker.Operand, 0)
 	for _, stack := range res {
-		operands = append(operands, &models.Stack{
-			ID: stack.ID,
-		})
+		operands = append(operands, models.StackOperand{ID: stack.ID})
 	}
 	return operands, nil
 }

--- a/pkg/worker/volume/volume_worker.go
+++ b/pkg/worker/volume/volume_worker.go
@@ -51,9 +51,9 @@ func NewVolumeWorker(spec VolumeWorkerSpec) worker.Worker {
 }
 
 func (w *volumeWorker) Execute(ctx context.Context, operand worker.Operand) (worker.Result, *errors.ServiceError) {
-	volumeRef, ok := operand.(*models.Volume)
+	volumeRef, ok := operand.(models.VolumeOperand)
 	if !ok {
-		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected *models.Volume")
+		return worker.Result{}, w.WorkerError.NewError("invalid operand type, expected models.VolumeOperand")
 	}
 
 	vol, serr := w.volumeService.InternalGet(ctx, volumeRef.ID)
@@ -138,7 +138,7 @@ func (w *volumeWorker) GetInput(ctx context.Context) ([]worker.Operand, *errors.
 
 	operands := make([]worker.Operand, len(volumes))
 	for i, vol := range volumes {
-		operands[i] = &models.Volume{ID: vol.ID}
+		operands[i] = models.VolumeOperand{ID: vol.ID}
 	}
 	return operands, nil
 }

--- a/pkg/worker/volume/volume_worker_test.go
+++ b/pkg/worker/volume/volume_worker_test.go
@@ -42,8 +42,8 @@ var _ = Describe("VolumeWorker", func() {
 			operands, err := w.GetInput(ctx)
 			Expect(err).To(BeNil())
 			Expect(operands).To(HaveLen(2))
-			Expect(operands[0]).To(Equal(worker.Operand(&models.Volume{ID: "vol-1"})))
-			Expect(operands[1]).To(Equal(worker.Operand(&models.Volume{ID: "vol-2"})))
+			Expect(operands[0]).To(Equal(worker.Operand(models.VolumeOperand{ID: "vol-1"})))
+			Expect(operands[1]).To(Equal(worker.Operand(models.VolumeOperand{ID: "vol-2"})))
 		})
 	})
 

--- a/pkg/worker/workermanager/worker_manager.go
+++ b/pkg/worker/workermanager/worker_manager.go
@@ -18,6 +18,11 @@ import (
 // TODO: set a reasonable value for this based on metrics and testing.
 const MaxOperandRequeue = math.MaxInt32
 
+// Goroutines draining each worker's queue. The workqueue never hands the
+// same key to two goroutines (in-flight keys re-queue as dirty), so this
+// only requires operands to be comparable values — see models.StackOperand.
+const maxConcurrentReconciles = 6
+
 type WorkerManager interface {
 	Start(ctx context.Context) error
 	Find(operand interface{}) workerlib.Worker
@@ -57,8 +62,17 @@ func NewWorkerManager(spec WorkerManagerSpec) *serviceWorkerManager {
 	return workerMgr
 }
 
+// The operand prototype must be a comparable value type: the workqueue
+// dedups and rate-limits by map-key equality, and a pointer's key is its
+// address, so pointer operands silently break dedup (and non-comparable
+// values panic inside the queue). Enqueue routes by the same type, so
+// rejecting the prototype here covers every enqueue path.
 func (s *serviceWorkerManager) RegisterWorker(worker workerlib.Worker, operand interface{}) {
-	s.registeredWorkers[reflect.TypeOf(operand)] = worker
+	t := reflect.TypeOf(operand)
+	if t.Kind() == reflect.Pointer || !t.Comparable() {
+		panic(fmt.Sprintf("worker %q operand prototype must be a comparable value type, got %s", worker.Name(), t))
+	}
+	s.registeredWorkers[t] = worker
 }
 func (s *serviceWorkerManager) Start(ctx context.Context) error {
 	if len(s.registeredWorkers) == 0 {
@@ -146,8 +160,16 @@ func (s *serviceWorkerManager) startWorker(ctx context.Context, worker workerlib
 	// Populate worker queue once before starting the worker loop.
 	s.populateWorkerQueue(ctx, worker)
 
-	for s.processNextWorkItemForWorker(ctx, worker) {
+	var wg sync.WaitGroup
+	for range maxConcurrentReconciles {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for s.processNextWorkItemForWorker(ctx, worker) {
+			}
+		}()
 	}
+	wg.Wait()
 }
 
 func (s *serviceWorkerManager) populateWorkerQueue(ctx context.Context, worker workerlib.Worker) {

--- a/pkg/worker/workermanager/worker_manager_suite_test.go
+++ b/pkg/worker/workermanager/worker_manager_suite_test.go
@@ -1,0 +1,13 @@
+package workermanager
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestWorkerManager(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Worker Manager Suite")
+}

--- a/pkg/worker/workermanager/worker_manager_test.go
+++ b/pkg/worker/workermanager/worker_manager_test.go
@@ -1,0 +1,132 @@
+package workermanager
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Stackdome/stackdome/pkg/errors"
+	workerlib "github.com/Stackdome/stackdome/pkg/worker"
+)
+
+type testOperand struct{ ID string }
+
+// testWorker wraps a real BaseWorker (real workqueue) around a configurable
+// Execute so queue semantics — dedup, per-key serialization, concurrency —
+// are exercised for real instead of mocked away.
+type testWorker struct {
+	execute func(ctx context.Context, operand workerlib.Operand) (workerlib.Result, *errors.ServiceError)
+	workerlib.BaseWorker
+}
+
+func (w *testWorker) Execute(ctx context.Context, operand workerlib.Operand) (workerlib.Result, *errors.ServiceError) {
+	return w.execute(ctx, operand)
+}
+
+func (w *testWorker) GetInput(ctx context.Context) ([]workerlib.Operand, *errors.ServiceError) {
+	return nil, nil
+}
+
+func newTestWorker(execute func(ctx context.Context, operand workerlib.Operand) (workerlib.Result, *errors.ServiceError)) *testWorker {
+	return &testWorker{
+		execute:    execute,
+		BaseWorker: workerlib.NewBaseWorker("test-worker", "test"),
+	}
+}
+
+var _ = Describe("serviceWorkerManager", func() {
+	var mgr *serviceWorkerManager
+
+	startManager := func(w workerlib.Worker) {
+		mgr = NewWorkerManager(WorkerManagerSpec{Environment: "test"})
+		mgr.RegisterWorker(w, testOperand{})
+		Expect(mgr.Start(context.Background())).To(Succeed())
+	}
+
+	It("rejects pointer and non-comparable operand prototypes at registration", func() {
+		w := newTestWorker(nil)
+		mgr := NewWorkerManager(WorkerManagerSpec{Environment: "test"})
+
+		Expect(func() { mgr.RegisterWorker(w, &testOperand{}) }).To(PanicWith(ContainSubstring("comparable value type")))
+		Expect(func() { mgr.RegisterWorker(w, struct{ IDs []string }{}) }).To(PanicWith(ContainSubstring("comparable value type")))
+		Expect(func() { mgr.RegisterWorker(w, testOperand{}) }).NotTo(Panic())
+	})
+
+	It("dedups value operands enqueued while one is already queued or in flight", func() {
+		gate := make(chan struct{})
+		var calls atomic.Int32
+		w := newTestWorker(func(ctx context.Context, operand workerlib.Operand) (workerlib.Result, *errors.ServiceError) {
+			calls.Add(1)
+			<-gate
+			return workerlib.Result{}, nil
+		})
+		startManager(w)
+		defer mgr.Stop(false)
+
+		Expect(mgr.Enqueue(testOperand{ID: "a"})).To(Succeed())
+		Eventually(calls.Load).Should(BeEquivalentTo(1))
+
+		// Re-enqueued 3x while in flight: collapses to one dirty entry,
+		// so exactly one more Execute after the gate opens.
+		for range 3 {
+			Expect(mgr.Enqueue(testOperand{ID: "a"})).To(Succeed())
+		}
+		close(gate)
+
+		Eventually(calls.Load).Should(BeEquivalentTo(2))
+		Consistently(calls.Load, 200*time.Millisecond).Should(BeEquivalentTo(2))
+	})
+
+	It("processes distinct operands concurrently but never the same operand twice at once", func() {
+		var (
+			mu       sync.Mutex
+			inFlight = map[workerlib.Operand]int{}
+			peak     int
+			overlap  bool
+			done     atomic.Int32
+		)
+		w := newTestWorker(func(ctx context.Context, operand workerlib.Operand) (workerlib.Result, *errors.ServiceError) {
+			mu.Lock()
+			inFlight[operand]++
+			if inFlight[operand] > 1 {
+				overlap = true
+			}
+			total := 0
+			for _, n := range inFlight {
+				total += n
+			}
+			if total > peak {
+				peak = total
+			}
+			mu.Unlock()
+
+			time.Sleep(50 * time.Millisecond)
+
+			mu.Lock()
+			inFlight[operand]--
+			mu.Unlock()
+			done.Add(1)
+			return workerlib.Result{}, nil
+		})
+		startManager(w)
+		defer mgr.Stop(false)
+
+		for _, id := range []string{"a", "b", "c", "d", "e", "f"} {
+			Expect(mgr.Enqueue(testOperand{ID: id})).To(Succeed())
+			// Same key again while (likely) in flight: must not run in parallel
+			// with itself.
+			Expect(mgr.Enqueue(testOperand{ID: id})).To(Succeed())
+		}
+
+		Eventually(done.Load, 5*time.Second).Should(BeNumerically(">=", 6))
+
+		mu.Lock()
+		defer mu.Unlock()
+		Expect(overlap).To(BeFalse(), "same operand ran concurrently with itself")
+		Expect(peak).To(BeNumerically(">", 1), "expected concurrent processing of distinct operands")
+	})
+})


### PR DESCRIPTION
## 📝 What this does
Fixes the production slowdown where stack creation stalled for minutes: workqueue operands were allocated pointers, so the queue's dedup never matched and every periodic tick added a duplicate requeue chain for each still-active release/preview. One stuck preview was reconciling 1,200×/min and the single release-worker goroutine spent its capacity on zombies. This makes dedup real, bounds how long a release can stay active, and drains each queue with multiple goroutines.

## 🔀 Changes
- Replaced all pointer operands with comparable values (`models.*Operand{ID}`, value `ReleaseGCRequest`, singleton `InviteCleanupRequest`) so workqueue dedup and per-key rate limiting key on content, not allocation address
- Added a startup guard: registering a worker with a pointer or non-comparable operand prototype panics, and enqueue routes by the same type, so the regression can't silently return
- Added a release deadline sub-reconciler: a release still InProgress 45 minutes after creation is marked Failed, so crashlooping workloads stop feeding the queue forever
- Raised worker throughput: each worker's queue is drained by 6 goroutines (the workqueue guarantees a key is never processed by two goroutines at once, which value operands make sound)
- Moved the invite-cleanup expired query from GetInput into Execute, removing stale snapshot batches from the queue

## 🧪 How to test
- [ ] Run `mage test:unit` — includes new workermanager specs (in-flight re-enqueue collapses to one extra execution; distinct operands run concurrently with zero same-key overlap) and deadline reconciler specs
- [ ] Deploy a stack whose container can never become ready; confirm the release fails with "release did not converge within 45 minutes" instead of polling forever
- [ ] While that release is active, watch logs: its processing rate stays ~4/min instead of growing every 30s