### PR TITLE
Fix: release deadline no longer cancels slow builds mid-flight

### DIFF
--- a/pkg/db/migrations/202608090001_add_release_worker_status.go
+++ b/pkg/db/migrations/202608090001_add_release_worker_status.go
@@ -1,0 +1,26 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func addReleaseWorkerStatus() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202608090001",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.Exec(`ALTER TABLE stack_releases ADD COLUMN worker_status JSONB`).Error; err != nil {
+				return fmt.Errorf("failed to add stack_releases.worker_status: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			if err := tx.Exec(`ALTER TABLE stack_releases DROP COLUMN worker_status`).Error; err != nil {
+				return fmt.Errorf("failed to drop stack_releases.worker_status: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -81,4 +81,5 @@ var MigrationList = []*gormigrate.Migration{
 	deleteOrphanPlatformOrg(),
 	addClusterInfo(),
 	deleteSeededPlatformDomains(),
+	addReleaseWorkerStatus(),
 }

--- a/pkg/mocks/mock_stack_release_store.go
+++ b/pkg/mocks/mock_stack_release_store.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	errors "github.com/Stackdome/stackdome/pkg/errors"
 	models "github.com/Stackdome/stackdome/pkg/models"
@@ -339,6 +340,20 @@ func (m_2 *MockStackReleaseStore) SaveManifest(ctx context.Context, id string, m
 func (mr *MockStackReleaseStoreMockRecorder) SaveManifest(ctx, id, m, rev, pins, rendererVersion any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveManifest", reflect.TypeOf((*MockStackReleaseStore)(nil).SaveManifest), ctx, id, m, rev, pins, rendererVersion)
+}
+
+// SetConvergeClockStartedAt mocks base method.
+func (m *MockStackReleaseStore) SetConvergeClockStartedAt(ctx context.Context, id string, startedAt *time.Time) *errors.ServiceError {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetConvergeClockStartedAt", ctx, id, startedAt)
+	ret0, _ := ret[0].(*errors.ServiceError)
+	return ret0
+}
+
+// SetConvergeClockStartedAt indicates an expected call of SetConvergeClockStartedAt.
+func (mr *MockStackReleaseStoreMockRecorder) SetConvergeClockStartedAt(ctx, id, startedAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConvergeClockStartedAt", reflect.TypeOf((*MockStackReleaseStore)(nil).SetConvergeClockStartedAt), ctx, id, startedAt)
 }
 
 // WithTransaction mocks base method.

--- a/pkg/models/stack_release.go
+++ b/pkg/models/stack_release.go
@@ -81,6 +81,7 @@ type StackRelease struct {
 	RendererVersion  string
 	Outcome          *ReleaseOutcome         `gorm:"type:jsonb"`
 	ValidationErrors ReleaseValidationErrors `gorm:"type:jsonb"`
+	WorkerStatus     *ReleaseWorkerStatus    `gorm:"type:jsonb"`
 	CreatedBy        string
 	CreatedAt        time.Time
 	UpdatedAt        time.Time
@@ -122,6 +123,43 @@ func (c *ReleaseCause) Scan(value interface{}) error {
 		return errors.New("type assertion to []byte failed for ReleaseCause")
 	}
 	return json.Unmarshal(b, c)
+}
+
+// --- ReleaseWorkerStatus ---
+
+// ReleaseWorkerStatus is bookkeeping the release worker persists while a
+// release is in flight. It is not part of the user-facing release contract.
+type ReleaseWorkerStatus struct {
+	// ConvergeClockStartedAt is when the convergence timeout clock started.
+	// The deadline reconciler stamps it once the release has no builds left
+	// to wait for, and clears it again if a build shows up running. Nil means
+	// the clock has not started and the release cannot converge-timeout.
+	ConvergeClockStartedAt *time.Time `json:"converge_clock_started_at,omitempty"`
+}
+
+func (w ReleaseWorkerStatus) Value() (driver.Value, error) {
+	return json.Marshal(w)
+}
+
+func (w *ReleaseWorkerStatus) Scan(value interface{}) error {
+	if value == nil {
+		*w = ReleaseWorkerStatus{}
+		return nil
+	}
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed for ReleaseWorkerStatus")
+	}
+	return json.Unmarshal(b, w)
+}
+
+// ConvergeClockStartedAt returns the stamped clock start, or nil when the
+// worker status block is absent entirely.
+func (r *StackRelease) ConvergeClockStartedAt() *time.Time {
+	if r.WorkerStatus == nil {
+		return nil
+	}
+	return r.WorkerStatus.ConvergeClockStartedAt
 }
 
 // --- StackSnapshot ---

--- a/pkg/services/stack_release_service.go
+++ b/pkg/services/stack_release_service.go
@@ -54,6 +54,7 @@ type StackReleaseService interface {
 	MarkCancelled(ctx context.Context, id string, reasons string) (bool, *errors.ServiceError)
 	MarkSuperseded(ctx context.Context, id string, reason string) (bool, *errors.ServiceError)
 	MarkFailed(ctx context.Context, id string, message string, outcome *models.ReleaseOutcome) (bool, *errors.ServiceError)
+	SetConvergeClockStartedAt(ctx context.Context, id string, startedAt *time.Time) *errors.ServiceError
 	MarkFailedWithValidationErrors(ctx context.Context, id, message string, verrs models.ReleaseValidationErrors) (bool, *errors.ServiceError)
 	AppendImageDigests(ctx context.Context, id string, digests map[string]string) *errors.ServiceError
 
@@ -555,6 +556,10 @@ func (s *stackReleaseService) MarkFailed(ctx context.Context, id string, message
 	}
 	s.recordTerminalEvent(ctx, id, models.ReleaseStateFailed, message)
 	return true, nil
+}
+
+func (s *stackReleaseService) SetConvergeClockStartedAt(ctx context.Context, id string, startedAt *time.Time) *errors.ServiceError {
+	return s.store.SetConvergeClockStartedAt(ctx, id, startedAt)
 }
 
 func (s *stackReleaseService) MarkFailedWithValidationErrors(ctx context.Context, id, message string, verrs models.ReleaseValidationErrors) (bool, *errors.ServiceError) {

--- a/pkg/stores/pgstore/stack_release.go
+++ b/pkg/stores/pgstore/stack_release.go
@@ -179,6 +179,27 @@ func (s *stackReleaseStore) SaveManifest(ctx context.Context, id string, m *mode
 	return result.RowsAffected > 0, nil
 }
 
+// SetConvergeClockStartedAt stamps (or, with nil, clears) the convergence
+// timeout clock in worker_status. Only InProgress releases are touched — the
+// clock is meaningless on a terminal release.
+func (s *stackReleaseStore) SetConvergeClockStartedAt(ctx context.Context, id string, startedAt *time.Time) *errors.ServiceError {
+	var status *models.ReleaseWorkerStatus
+	if startedAt != nil {
+		status = &models.ReleaseWorkerStatus{ConvergeClockStartedAt: startedAt}
+	}
+	result := s.sessionFactory.New(ctx).
+		Model(&models.StackRelease{}).
+		Where("id = ? AND state = ?", id, models.ReleaseStateInProgress).
+		Updates(map[string]interface{}{
+			"worker_status": status,
+			colUpdatedAt:    time.Now().UTC(),
+		})
+	if result.Error != nil {
+		return errors.GeneralError("failed to set converge clock: %s", result.Error.Error())
+	}
+	return nil
+}
+
 func (s *stackReleaseStore) MarkCancelled(ctx context.Context, id string, reason string) (bool, *errors.ServiceError) {
 	result := s.sessionFactory.New(ctx).
 		Model(&models.StackRelease{}).

--- a/pkg/stores/stack_release_store.go
+++ b/pkg/stores/stack_release_store.go
@@ -2,6 +2,7 @@ package stores
 
 import (
 	"context"
+	"time"
 
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/models"
@@ -48,6 +49,10 @@ type StackReleaseStore interface {
 
 	// AppendImageDigests merges image digests into the release pins.
 	AppendImageDigests(ctx context.Context, id string, digests map[string]string) *errors.ServiceError
+
+	// SetConvergeClockStartedAt stamps (nil: clears) the convergence timeout
+	// clock on an InProgress release. See models.ReleaseWorkerStatus.
+	SetConvergeClockStartedAt(ctx context.Context, id string, startedAt *time.Time) *errors.ServiceError
 
 	// ListTerminalSummariesByStackID returns lightweight release summaries for GC decisions.
 	// Only terminal-state releases are returned — active releases are never GC candidates.

--- a/pkg/worker/release/converge.go
+++ b/pkg/worker/release/converge.go
@@ -76,11 +76,12 @@ func (r *convergeReconciler) Reconcile(ctx context.Context, release *models.Stac
 	return resultRequeueAfter(convergencePollInterval), nil
 }
 
-// failedReleaseBuild returns a terminally failed build that this release
-// triggered — Status.ReleaseID carries the release-id annotation the agent
-// copies onto the ImageBuild at creation. Such a release can never converge:
-// this is the fail-fast that replaced the deploy timeout. A prior release's
-// failed build carries that release's ID, so it can never kill this one.
+// failedReleaseBuild returns a terminally failed or cancelled build that this
+// release triggered — Status.ReleaseID carries the release-id annotation the
+// agent copies onto the ImageBuild at creation. Such a release can never
+// converge: this is the fail-fast that replaced the deploy timeout. A prior
+// release's failed build carries that release's ID, so it can never kill
+// this one.
 //
 // ponytail: a release that reuses a prior release's already-failed build
 // (identical revision and build config) matches nothing here and polls
@@ -91,7 +92,12 @@ func (r *convergeReconciler) failedReleaseBuild(ctx context.Context, release *mo
 		return nil, serr
 	}
 	for _, b := range builds {
-		if b.Status == nil || b.Status.State != string(buildsv1alpha1.BuildPhaseFailed) {
+		if b.Status == nil {
+			continue
+		}
+		switch b.Status.State {
+		case string(buildsv1alpha1.BuildPhaseFailed), string(buildsv1alpha1.BuildPhaseCancelled):
+		default:
 			continue
 		}
 		if b.Status.ReleaseID != "" && b.Status.ReleaseID == release.ID {
@@ -102,6 +108,9 @@ func (r *convergeReconciler) failedReleaseBuild(ctx context.Context, release *mo
 }
 
 func buildFailedMessage(b *models.ImageBuild) string {
+	if b.Status.State == string(buildsv1alpha1.BuildPhaseCancelled) {
+		return fmt.Sprintf("build cancelled for %s", b.StackResourceName)
+	}
 	msg := fmt.Sprintf("build failed for %s", b.StackResourceName)
 	if f := b.Status.LastBuildFailureDetail; f != nil {
 		detail := f.Message

--- a/pkg/worker/release/deadline_reconciler.go
+++ b/pkg/worker/release/deadline_reconciler.go
@@ -5,39 +5,161 @@ import (
 	"fmt"
 	"time"
 
+	buildsv1alpha1 "stackdome.io/cluster-agent/api/builds/v1alpha1"
+
 	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/models"
 )
 
 type deadlineReconciler struct {
-	releaseService releaseService
-	logger         logger.Logger
+	releaseService    releaseService
+	imageBuildService imageBuildService
+	logger            logger.Logger
 }
 
 func newDeadlineReconciler(spec ReleaseWorkerSpec) *deadlineReconciler {
 	return &deadlineReconciler{
-		releaseService: spec.ReleaseService,
-		logger:         logger.NewLoggerWithPrefix(context.Background(), "release-deadline"),
+		releaseService:    spec.ReleaseService,
+		imageBuildService: spec.ImageBuildService,
+		logger:            logger.NewLoggerWithPrefix(context.Background(), "release-deadline"),
 	}
 }
 
 func (r *deadlineReconciler) Name() string { return "deadline" }
 
-// Fails a release still in progress convergenceTimeout after creation.
-// Runs after the gatekeeper so supersede/CAS decisions happen first; covers
-// every later phase (render, apply, converge), not just convergence polling.
+// Times out a release that is stuck. Two separate clocks:
+//
+//   - Lifetime cap (releaseLifetimeCap, from CreatedAt): absolute ceiling.
+//     Catches everything the converge clock cannot see — a build stuck
+//     Pending forever, a build CR that never appears, a dead agent.
+//
+//   - Converge clock (convergenceTimeout, from WorkerStatus stamp): the
+//     deploy/converge phase only. The clock is stamped when the release has
+//     no builds left to wait for, and cleared again while a build is
+//     running, so a slow build never eats the deploy phase's window.
+//
+// Build failures are NOT handled here: a Failed or Cancelled build fails the
+// release immediately via the converge reconciler's fail-fast.
+//
+// Runs after the gatekeeper so supersede/CAS decisions happen first.
 func (r *deadlineReconciler) Reconcile(ctx context.Context, release *models.StackRelease) (subReconcilerResult, error) {
 	if release.State != models.ReleaseStateInProgress {
 		return resultNil, nil
 	}
-	if time.Since(release.CreatedAt) <= convergenceTimeout {
-		return resultNil, nil
+
+	if time.Since(release.CreatedAt) > releaseLifetimeCap {
+		return r.fail(ctx, release,
+			fmt.Sprintf("release exceeded maximum lifetime of %d hours", int(releaseLifetimeCap.Hours())))
 	}
 
-	msg := fmt.Sprintf("release did not converge within %d minutes", int(convergenceTimeout.Minutes()))
-	if _, err := r.releaseService.MarkFailed(ctx, release.ID, msg, nil); err != nil {
-		return resultNil, fmt.Errorf("failed to mark release failed on deadline: %w", err)
+	phase, err := r.buildPhase(ctx, release)
+	if err != nil {
+		return resultNil, fmt.Errorf("failed to check builds for deadline: %w", err)
+	}
+
+	switch phase {
+	case buildsRunning:
+		// Can't converge-timeout mid-build. Clear a stale stamp so the
+		// deploy phase gets a fresh window once the build finishes.
+		if release.ConvergeClockStartedAt() != nil {
+			if serr := r.releaseService.SetConvergeClockStartedAt(ctx, release.ID, nil); serr != nil {
+				return resultNil, fmt.Errorf("failed to clear converge clock: %w", serr)
+			}
+		}
+		return resultNil, nil
+
+	case buildsNotAppearedYet:
+		// The stack builds from source but the agent has not created the
+		// build CR yet. Starting the clock now would count build time
+		// against the deploy window. The lifetime cap covers a build that
+		// never appears.
+		return resultNil, nil
+
+	case buildsDone:
+		startedAt := release.ConvergeClockStartedAt()
+		if startedAt == nil {
+			now := time.Now().UTC()
+			if serr := r.releaseService.SetConvergeClockStartedAt(ctx, release.ID, &now); serr != nil {
+				return resultNil, fmt.Errorf("failed to start converge clock: %w", serr)
+			}
+			return resultNil, nil
+		}
+		if time.Since(*startedAt) <= convergenceTimeout {
+			return resultNil, nil
+		}
+		msg := fmt.Sprintf("release did not converge within %d minutes", int(convergenceTimeout.Minutes()))
+		if releaseExpectsBuilds(release) {
+			msg += " of build completion"
+		}
+		return r.fail(ctx, release, msg)
+	}
+	return resultNil, nil
+}
+
+func (r *deadlineReconciler) fail(ctx context.Context, release *models.StackRelease, msg string) (subReconcilerResult, error) {
+	if _, serr := r.releaseService.MarkFailed(ctx, release.ID, msg, nil); serr != nil {
+		return resultNil, fmt.Errorf("failed to mark release failed on deadline: %w", serr)
 	}
 	r.logger.Info(ctx, "release %s: %s", release.ID, msg)
 	return resultStop, nil
+}
+
+// releaseBuildPhase summarises where this release's builds are, as far as the
+// deadline clocks care.
+type releaseBuildPhase int
+
+const (
+	// buildsDone: nothing to wait for — no builds expected, or every build
+	// attributed to this release is terminal. The converge clock may run.
+	buildsDone releaseBuildPhase = iota
+	// buildsRunning: at least one attributed build is not terminal yet.
+	buildsRunning
+	// buildsNotAppearedYet: the snapshot says the stack builds from source,
+	// but no build attributed to this release exists yet.
+	buildsNotAppearedYet
+)
+
+// buildPhase classifies this release's builds. Attribution is by
+// Status.ReleaseID, same as the converge reconciler's fail-fast. A build in
+// an unknown state counts as running: better to wait than to cancel a
+// release mid-build.
+func (r *deadlineReconciler) buildPhase(ctx context.Context, release *models.StackRelease) (releaseBuildPhase, error) {
+	if !releaseExpectsBuilds(release) {
+		return buildsDone, nil
+	}
+
+	builds, serr := r.imageBuildService.ListByStackID(ctx, release.StackID)
+	if serr != nil {
+		return buildsDone, serr
+	}
+
+	seen := false
+	for _, b := range builds {
+		if b.Status == nil || b.Status.ReleaseID != release.ID {
+			continue
+		}
+		seen = true
+		switch b.Status.State {
+		case string(buildsv1alpha1.BuildPhaseSuccess),
+			string(buildsv1alpha1.BuildPhaseFailed),
+			string(buildsv1alpha1.BuildPhaseCancelled):
+			continue
+		}
+		return buildsRunning, nil
+	}
+	if !seen {
+		return buildsNotAppearedYet, nil
+	}
+	return buildsDone, nil
+}
+
+// releaseExpectsBuilds reports whether any resource in the release snapshot
+// builds from source (and therefore produces an ImageBuild).
+func releaseExpectsBuilds(release *models.StackRelease) bool {
+	for _, res := range release.Snapshot.Resources {
+		if res.BuildConfig != nil {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/worker/release/deadline_reconciler_test.go
+++ b/pkg/worker/release/deadline_reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	buildsv1alpha1 "stackdome.io/cluster-agent/api/builds/v1alpha1"
 
 	"github.com/Stackdome/stackdome/pkg/models"
 )
@@ -15,6 +16,7 @@ var _ = Describe("deadlineReconciler", func() {
 	var (
 		ctrl       *gomock.Controller
 		releaseSvc *MockreleaseService
+		buildSvc   *MockimageBuildService
 		r          *deadlineReconciler
 		ctx        context.Context
 	)
@@ -22,7 +24,8 @@ var _ = Describe("deadlineReconciler", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		releaseSvc = NewMockreleaseService(ctrl)
-		r = newDeadlineReconciler(ReleaseWorkerSpec{ReleaseService: releaseSvc})
+		buildSvc = NewMockimageBuildService(ctrl)
+		r = newDeadlineReconciler(ReleaseWorkerSpec{ReleaseService: releaseSvc, ImageBuildService: buildSvc})
 		ctx = context.Background()
 	})
 
@@ -30,14 +33,49 @@ var _ = Describe("deadlineReconciler", func() {
 		ctrl.Finish()
 	})
 
-	It("fails an InProgress release older than the convergence timeout", func() {
+	// inProgressRelease returns a release created `age` ago. With
+	// withBuild=true the snapshot contains one build-from-source resource,
+	// so the release expects an ImageBuild before its converge clock starts.
+	inProgressRelease := func(age time.Duration, withBuild bool) *models.StackRelease {
 		release := &models.StackRelease{
 			ID:        "rel-1",
+			StackID:   "stack-1",
 			State:     models.ReleaseStateInProgress,
-			CreatedAt: time.Now().Add(-convergenceTimeout - time.Minute),
+			CreatedAt: time.Now().Add(-age),
 		}
+		if withBuild {
+			release.Snapshot.Resources = []*models.StackResource{
+				{BuildConfig: &models.BuildConfigSpec{}},
+			}
+		}
+		return release
+	}
+
+	withConvergeClock := func(release *models.StackRelease, startedAgo time.Duration) *models.StackRelease {
+		startedAt := time.Now().Add(-startedAgo)
+		release.WorkerStatus = &models.ReleaseWorkerStatus{ConvergeClockStartedAt: &startedAt}
+		return release
+	}
+
+	buildWithState := func(releaseID string, state buildsv1alpha1.BuildPhase) *models.ImageBuild {
+		return &models.ImageBuild{
+			Status: &models.ImageBuildStatus{ReleaseID: releaseID, State: string(state)},
+		}
+	}
+
+	It("ignores releases that are not InProgress", func() {
+		release := inProgressRelease(10*time.Hour, false)
+		release.State = models.ReleaseStatePending
+
+		result, err := r.Reconcile(ctx, release)
+		Expect(err).To(BeNil())
+		Expect(result.resultNil).To(BeTrue())
+	})
+
+	It("fails a release past the absolute lifetime cap regardless of builds", func() {
+		release := inProgressRelease(releaseLifetimeCap+time.Minute, true)
 		releaseSvc.EXPECT().
-			MarkFailed(ctx, "rel-1", "release did not converge within 45 minutes", nil).
+			MarkFailed(ctx, "rel-1", "release exceeded maximum lifetime of 6 hours", nil).
 			Return(true, nil)
 
 		result, err := r.Reconcile(ctx, release)
@@ -45,27 +83,113 @@ var _ = Describe("deadlineReconciler", func() {
 		Expect(result.resultStop).To(BeTrue())
 	})
 
-	It("leaves an InProgress release inside the timeout alone", func() {
-		release := &models.StackRelease{
-			ID:        "rel-1",
-			State:     models.ReleaseStateInProgress,
-			CreatedAt: time.Now().Add(-time.Minute),
-		}
+	Context("stack without builds", func() {
+		It("starts the converge clock on the first tick", func() {
+			release := inProgressRelease(time.Minute, false)
+			releaseSvc.EXPECT().
+				SetConvergeClockStartedAt(ctx, "rel-1", gomock.Not(gomock.Nil())).
+				Return(nil)
 
-		result, err := r.Reconcile(ctx, release)
-		Expect(err).To(BeNil())
-		Expect(result.resultNil).To(BeTrue())
+			result, err := r.Reconcile(ctx, release)
+			Expect(err).To(BeNil())
+			Expect(result.resultNil).To(BeTrue())
+		})
+
+		It("leaves a release alone while the converge clock is inside the window", func() {
+			release := withConvergeClock(inProgressRelease(time.Hour, false), time.Minute)
+
+			result, err := r.Reconcile(ctx, release)
+			Expect(err).To(BeNil())
+			Expect(result.resultNil).To(BeTrue())
+		})
+
+		It("fails a release whose converge clock has expired", func() {
+			release := withConvergeClock(inProgressRelease(time.Hour, false), convergenceTimeout+time.Minute)
+			releaseSvc.EXPECT().
+				MarkFailed(ctx, "rel-1", "release did not converge within 45 minutes", nil).
+				Return(true, nil)
+
+			result, err := r.Reconcile(ctx, release)
+			Expect(err).To(BeNil())
+			Expect(result.resultStop).To(BeTrue())
+		})
 	})
 
-	It("ignores releases not yet InProgress even when old", func() {
-		release := &models.StackRelease{
-			ID:        "rel-1",
-			State:     models.ReleaseStatePending,
-			CreatedAt: time.Now().Add(-convergenceTimeout - time.Hour),
-		}
+	Context("stack with builds", func() {
+		It("does nothing while the build has not appeared yet", func() {
+			release := inProgressRelease(time.Hour, true)
+			buildSvc.EXPECT().ListByStackID(ctx, "stack-1").Return(nil, nil)
 
-		result, err := r.Reconcile(ctx, release)
-		Expect(err).To(BeNil())
-		Expect(result.resultNil).To(BeTrue())
+			result, err := r.Reconcile(ctx, release)
+			Expect(err).To(BeNil())
+			Expect(result.resultNil).To(BeTrue())
+		})
+
+		It("treats another release's build as not appeared for this release", func() {
+			release := inProgressRelease(time.Hour, true)
+			buildSvc.EXPECT().ListByStackID(ctx, "stack-1").
+				Return([]*models.ImageBuild{buildWithState("rel-other", buildsv1alpha1.BuildPhasePending)}, nil)
+
+			result, err := r.Reconcile(ctx, release)
+			Expect(err).To(BeNil())
+			Expect(result.resultNil).To(BeTrue())
+		})
+
+		It("does nothing while its build is running and the clock never started", func() {
+			release := inProgressRelease(time.Hour, true)
+			buildSvc.EXPECT().ListByStackID(ctx, "stack-1").
+				Return([]*models.ImageBuild{buildWithState("rel-1", buildsv1alpha1.BuildPhasePending)}, nil)
+
+			result, err := r.Reconcile(ctx, release)
+			Expect(err).To(BeNil())
+			Expect(result.resultNil).To(BeTrue())
+		})
+
+		It("clears a stale converge clock when a build shows up running", func() {
+			release := withConvergeClock(inProgressRelease(time.Hour, true), convergenceTimeout+time.Minute)
+			buildSvc.EXPECT().ListByStackID(ctx, "stack-1").
+				Return([]*models.ImageBuild{buildWithState("rel-1", buildsv1alpha1.BuildPhasePending)}, nil)
+			releaseSvc.EXPECT().SetConvergeClockStartedAt(ctx, "rel-1", gomock.Nil()).Return(nil)
+
+			result, err := r.Reconcile(ctx, release)
+			Expect(err).To(BeNil())
+			Expect(result.resultNil).To(BeTrue())
+		})
+
+		It("treats a build in an unknown state as still running", func() {
+			release := inProgressRelease(time.Hour, true)
+			buildSvc.EXPECT().ListByStackID(ctx, "stack-1").
+				Return([]*models.ImageBuild{buildWithState("rel-1", buildsv1alpha1.BuildPhase("Building"))}, nil)
+
+			result, err := r.Reconcile(ctx, release)
+			Expect(err).To(BeNil())
+			Expect(result.resultNil).To(BeTrue())
+		})
+
+		It("starts the converge clock once the build succeeds", func() {
+			release := inProgressRelease(time.Hour, true)
+			buildSvc.EXPECT().ListByStackID(ctx, "stack-1").
+				Return([]*models.ImageBuild{buildWithState("rel-1", buildsv1alpha1.BuildPhaseSuccess)}, nil)
+			releaseSvc.EXPECT().
+				SetConvergeClockStartedAt(ctx, "rel-1", gomock.Not(gomock.Nil())).
+				Return(nil)
+
+			result, err := r.Reconcile(ctx, release)
+			Expect(err).To(BeNil())
+			Expect(result.resultNil).To(BeTrue())
+		})
+
+		It("fails a release whose post-build converge clock has expired", func() {
+			release := withConvergeClock(inProgressRelease(2*time.Hour, true), convergenceTimeout+time.Minute)
+			buildSvc.EXPECT().ListByStackID(ctx, "stack-1").
+				Return([]*models.ImageBuild{buildWithState("rel-1", buildsv1alpha1.BuildPhaseSuccess)}, nil)
+			releaseSvc.EXPECT().
+				MarkFailed(ctx, "rel-1", "release did not converge within 45 minutes of build completion", nil).
+				Return(true, nil)
+
+			result, err := r.Reconcile(ctx, release)
+			Expect(err).To(BeNil())
+			Expect(result.resultStop).To(BeTrue())
+		})
 	})
 })

--- a/pkg/worker/release/release_worker.go
+++ b/pkg/worker/release/release_worker.go
@@ -19,10 +19,16 @@ import (
 const (
 	ReleaseWorkerName       = "release-worker"
 	convergencePollInterval = 15 * time.Second
-	// A release that hasn't reached a terminal state within this window is
-	// failed by the deadline reconciler — bounds background load from
-	// workloads that will never become ready (e.g. crashlooping apps).
+	// A release whose deploy/converge phase runs longer than this is failed
+	// by the deadline reconciler — bounds background load from workloads
+	// that will never become ready (e.g. crashlooping apps). The clock
+	// starts after builds finish, not at release creation; see
+	// deadlineReconciler.
 	convergenceTimeout = 45 * time.Minute
+	// Absolute ceiling on a release's lifetime, measured from creation.
+	// Catches releases the converge clock never sees: a build stuck Pending
+	// forever, a build CR that never appears, a dead agent.
+	releaseLifetimeCap = 6 * time.Hour
 )
 
 type ReleaseWorkerSpec struct {

--- a/pkg/worker/release/release_worker_test.go
+++ b/pkg/worker/release/release_worker_test.go
@@ -294,6 +294,44 @@ var _ = Describe("ConvergeReconciler", func() {
 		Expect(result.resultStop).To(BeTrue())
 	})
 
+	It("marks failed and stops when this release's build is cancelled", func() {
+		release := &models.StackRelease{
+			ID:               "rel-1",
+			StackID:          "stack-1",
+			ManifestRevision: "rev-1",
+			Manifest:         &models.ReleaseManifest{},
+		}
+
+		stackSvc := NewMockstackService(ctrl)
+		stackSvc.EXPECT().InternalGetStack(gomock.Any(), "stack-1").
+			Return(&models.Stack{ID: "stack-1"}, nil)
+
+		buildSvc := NewMockimageBuildService(ctrl)
+		buildSvc.EXPECT().ListByStackID(gomock.Any(), "stack-1").Return([]*models.ImageBuild{{
+			StackResourceName: "web",
+			Status: &models.ImageBuildStatus{
+				State:     string(buildsv1alpha1.BuildPhaseCancelled),
+				ReleaseID: "rel-1",
+			},
+		}}, nil)
+
+		relSvc := NewMockreleaseService(ctrl)
+		relSvc.EXPECT().
+			MarkFailed(gomock.Any(), "rel-1", "build cancelled for web", gomock.Any()).
+			Return(true, nil)
+
+		r := &convergeReconciler{
+			releaseService:    relSvc,
+			stackService:      stackSvc,
+			imageBuildService: buildSvc,
+			logger:            testLogger(),
+		}
+
+		result, err := r.Reconcile(context.Background(), release)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.resultStop).To(BeTrue())
+	})
+
 	// Another release's failed build — or one from an agent that predates the
 	// release-id annotation — says nothing about this release: keep polling.
 	DescribeTable("keeps polling on a failed build that is not this release's",

--- a/pkg/worker/release/types.go
+++ b/pkg/worker/release/types.go
@@ -41,6 +41,7 @@ type releaseService interface {
 	MarkFailed(ctx context.Context, id string, message string, outcome *models.ReleaseOutcome) (bool, *errors.ServiceError)
 	MarkFailedWithValidationErrors(ctx context.Context, id, message string, verrs models.ReleaseValidationErrors) (bool, *errors.ServiceError)
 	AppendImageDigests(ctx context.Context, id string, digests map[string]string) *errors.ServiceError
+	SetConvergeClockStartedAt(ctx context.Context, id string, startedAt *time.Time) *errors.ServiceError
 }
 
 type eventRecorder interface {

--- a/pkg/worker/release/types_mock.go
+++ b/pkg/worker/release/types_mock.go
@@ -12,6 +12,7 @@ package release
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	errors "github.com/Stackdome/stackdome/pkg/errors"
 	models "github.com/Stackdome/stackdome/pkg/models"
@@ -242,6 +243,20 @@ func (m_2 *MockreleaseService) SaveManifest(ctx context.Context, id string, m *m
 func (mr *MockreleaseServiceMockRecorder) SaveManifest(ctx, id, m, rev, pins, rendererVersion any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveManifest", reflect.TypeOf((*MockreleaseService)(nil).SaveManifest), ctx, id, m, rev, pins, rendererVersion)
+}
+
+// SetConvergeClockStartedAt mocks base method.
+func (m *MockreleaseService) SetConvergeClockStartedAt(ctx context.Context, id string, startedAt *time.Time) *errors.ServiceError {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetConvergeClockStartedAt", ctx, id, startedAt)
+	ret0, _ := ret[0].(*errors.ServiceError)
+	return ret0
+}
+
+// SetConvergeClockStartedAt indicates an expected call of SetConvergeClockStartedAt.
+func (mr *MockreleaseServiceMockRecorder) SetConvergeClockStartedAt(ctx, id, startedAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConvergeClockStartedAt", reflect.TypeOf((*MockreleaseService)(nil).SetConvergeClockStartedAt), ctx, id, startedAt)
 }
 
 // MockeventRecorder is a mock of eventRecorder interface.


### PR DESCRIPTION
## 📝 What this does
A release with a slow image build was cancelled by the 45-minute convergence deadline even though nothing was stuck — the build simply ate the window (follow-up to the review note on #236). The deadline now understands builds: the convergence clock starts only after the release's builds finish, and a separate 6-hour lifetime cap catches genuinely stuck releases.

Relates to: #236

## 🏗️ Architecture
### Flow
Two independent clocks in the deadline reconciler, for a release in progress:

1. **Lifetime cap** — 6 hours from creation, unconditional. Catches a build stuck `Pending` forever, a build CR that never appears, a dead agent.
2. **Converge clock** — 45 minutes, stamped into a new `worker_status` JSONB block on the release once there are no builds left to wait for; cleared again if a build is observed running. For stacks that build from source, the clock does not start until a build attributed to the release appears and finishes, so the gap before the agent creates the build CR cannot leak build time into the deploy window.

Build failures stay out of the deadline path: a `Failed` build already fail-fasts the release via the converge reconciler, and a `Cancelled` build now does the same ("build cancelled for <resource>") instead of dying later with a misleading timeout message.

## 🔀 Changes
- Started the convergence timeout after builds complete, tracked via a persisted `converge_clock_started_at` stamp that survives worker restarts (migration adds `stack_releases.worker_status`)
- Added a 6-hour absolute lifetime cap with its own failure message so timeout causes are distinguishable
- Failed releases immediately on cancelled builds in the converge fail-fast
- Timeout messages now name their window ("within 45 minutes of build completion" vs "exceeded maximum lifetime of 6 hours")

## 🧪 How to test
- [ ] Deploy a stack whose build takes longer than 45 minutes; the release survives the build and gets a fresh 45-minute deploy window
- [ ] Cancel a build mid-release; the release fails immediately with "build cancelled"
- [ ] Deploy an image-only stack that never becomes ready; it still fails at 45 minutes
- [ ] `go test ./pkg/worker/release/ -count=1` — deadline reconciler specs cover every build-phase transition