### PR TITLE
Add self-host installer release channel

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -4,9 +4,16 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to rebuild and repair
+        required: true
+        type: string
 
 env:
   IMAGE_REPO: ${{ vars.IMAGE_REPO || 'quay.io/stackdome/stackdome' }}
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 jobs:
   build-and-push:
@@ -14,35 +21,51 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Validate existing release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          printf '%s\n' "$RELEASE_TAG" | grep -Eq '^v[A-Za-z0-9._-]+$' || {
+            echo "invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          }
+          gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" >/dev/null
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
 
-      - name: Configure private module access
-        run: git config --global url."https://${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
-
       - name: Download dependencies
-        run: go mod download
         env:
+          GH_PAT: ${{ secrets.GH_PAT }}
           GOPRIVATE: github.com/ashishmax31/*,stackdome.io/*,github.com/Stackdome/*
+        run: |
+          credential_config=$(mktemp)
+          trap 'rm -f "$credential_config"' EXIT
+          git config --file "$credential_config" credential.helper \
+            '!f() { if [ "$1" = get ]; then printf "%s\n" "username=x-access-token" "password=$GH_PAT"; fi; }; f'
+          GIT_CONFIG_GLOBAL="$credential_config" GIT_TERMINAL_PROMPT=0 go mod download
+
+      - name: Test installer
+        run: |
+          sh -n install/bootstrap.sh
+          go test ./cmd/installer ./install
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           version: 10
-
-      - name: Extract tag
-        id: tag
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Build frontend
         run: make frontend
@@ -53,32 +76,64 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/linux_arm64/stackdome-server cmd/main.go
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Quay.io
-        run: echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u "${{ secrets.QUAY_USER }}" --password-stdin
+        env:
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+        run: printf '%s\n' "$QUAY_TOKEN" | docker login quay.io -u "$QUAY_USER" --password-stdin
 
       - name: Build and push image
         env:
-          VERSION: ${{ steps.tag.outputs.version }}
+          VERSION: ${{ env.RELEASE_TAG }}
         run: |
+          image_tags=(--tag "${{ env.IMAGE_REPO }}:${VERSION}")
+          if [ "$GITHUB_EVENT_NAME" = push ]; then
+            image_tags+=(--tag "${{ env.IMAGE_REPO }}:latest")
+          fi
           docker buildx build --platform linux/amd64,linux/arm64 \
-            -t ${{ env.IMAGE_REPO }}:${VERSION} \
-            -t ${{ env.IMAGE_REPO }}:latest \
+            "${image_tags[@]}" \
             --push .
+
+      - name: Remove registry credentials
+        if: always()
+        run: docker logout quay.io
 
       - name: Build installer binaries
         run: |
-          make installer-linux-amd64
-          make installer-linux-arm64
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o bin/stackdome-install-linux-amd64 ./cmd/installer
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -o bin/stackdome-install-linux-arm64 ./cmd/installer
+          (cd bin && sha256sum stackdome-install-linux-amd64 stackdome-install-linux-arm64 > checksums.txt)
+          (cd bin && sha256sum --check checksums.txt)
+          file bin/stackdome-install-linux-amd64 | grep -q 'ELF 64-bit.*x86-64'
+          file bin/stackdome-install-linux-arm64 | grep -q 'ELF 64-bit.*ARM aarch64'
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           files: |
             bin/stackdome-install-linux-amd64
             bin/stackdome-install-linux-arm64
+            bin/checksums.txt
+          fail_on_unmatched_files: true
           generate_release_notes: true
+
+      - name: Smoke released assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          smoke_dir=$(mktemp -d)
+          trap 'rm -rf "$smoke_dir"' EXIT
+          gh release download "$RELEASE_TAG" --dir "$smoke_dir" \
+            --pattern stackdome-install-linux-amd64 \
+            --pattern stackdome-install-linux-arm64 \
+            --pattern checksums.txt \
+            --clobber
+          (cd "$smoke_dir" && sha256sum --check checksums.txt)
+          file "$smoke_dir/stackdome-install-linux-amd64" | grep -q 'ELF 64-bit.*x86-64'
+          file "$smoke_dir/stackdome-install-linux-arm64" | grep -q 'ELF 64-bit.*ARM aarch64'

--- a/.github/workflows/publish-self-host-installer.yaml
+++ b/.github/workflows/publish-self-host-installer.yaml
@@ -1,0 +1,105 @@
+name: Publish Self-host Installer
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing GitHub Release tag to publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  RELEASE_TAG: ${{ inputs.tag }}
+  R2_BUCKET: ${{ vars.R2_BUCKET }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: installer-production
+    steps:
+      - name: Validate existing GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          printf '%s\n' "$RELEASE_TAG" | grep -Eq '^v[A-Za-z0-9._-]+$' || {
+            echo "invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          }
+          test -n "$R2_BUCKET"
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+
+      - name: Checkout selected tag
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Download and verify release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p release-assets
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --dir release-assets \
+            --pattern stackdome-install-linux-amd64 \
+            --pattern stackdome-install-linux-arm64 \
+            --pattern checksums.txt
+          test "$(find release-assets -type f | wc -l | tr -d ' ')" -eq 3
+          test "$(awk 'NF { count++ } END { print count + 0 }' release-assets/checksums.txt)" -eq 2
+          for asset in stackdome-install-linux-amd64 stackdome-install-linux-arm64; do
+            count=$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset { count++ } END { print count + 0 }' release-assets/checksums.txt)
+            test "$count" -eq 1
+          done
+          (cd release-assets && sha256sum --check checksums.txt)
+          file release-assets/stackdome-install-linux-amd64 | grep -q 'ELF 64-bit.*x86-64'
+          file release-assets/stackdome-install-linux-arm64 | grep -q 'ELF 64-bit.*ARM aarch64'
+
+      - name: Render versioned install script
+        run: |
+          mkdir -p dist
+          sed "s/@STACKDOME_VERSION@/$RELEASE_TAG/g" install/bootstrap.sh > dist/install.sh
+          sh -n dist/install.sh
+          placeholder_count=$(grep -c '@STACKDOME_VERSION@' dist/install.sh || true)
+          test "$placeholder_count" -eq 0
+
+      - name: Upload immutable install script
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@4.33.1 r2 object put "${R2_BUCKET}/releases/${RELEASE_TAG}/install.sh" \
+            --file dist/install.sh \
+            --content-type 'text/x-shellscript; charset=utf-8' \
+            --cache-control 'public, max-age=31536000, immutable' \
+            --remote
+
+      - name: Smoke immutable install script
+        run: |
+          immutable_script=$(mktemp)
+          trap 'rm -f "$immutable_script"' EXIT
+          curl -fsS "https://get.stackdome.com/releases/${RELEASE_TAG}/install.sh" -o "$immutable_script"
+          sh -n "$immutable_script"
+          sudo env STACKDOME_DOWNLOAD_ONLY=1 STACKDOME_VERSION="$RELEASE_TAG" sh "$immutable_script"
+
+      - name: Promote live install script
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@4.33.1 r2 object put "${R2_BUCKET}/install.sh" \
+            --file dist/install.sh \
+            --content-type 'text/x-shellscript; charset=utf-8' \
+            --cache-control 'public, max-age=300' \
+            --remote
+
+      - name: Smoke live install script
+        run: |
+          live_script=$(mktemp)
+          trap 'rm -f "$live_script"' EXIT
+          curl -fsSI https://get.stackdome.com/install.sh
+          curl -fsS https://get.stackdome.com/install.sh -o "$live_script"
+          sh -n "$live_script"
+          sudo env STACKDOME_DOWNLOAD_ONLY=1 sh "$live_script"

--- a/cmd/installer/bootstrap.go
+++ b/cmd/installer/bootstrap.go
@@ -17,7 +17,6 @@ const nameField = "name"
 var apiBaseURL string
 
 type bootstrapResult struct {
-	Token     string
 	OrgID     string
 	ClusterID string
 }
@@ -52,7 +51,7 @@ func runAPIBootstrap(vals install.TemplateValues, secrets *BootstrapSecrets) (*b
 	stepLog(fmt.Sprintf("Cluster registered -- ID: %s", clusterID))
 
 	successLog("API bootstrap complete")
-	return &bootstrapResult{Token: token, OrgID: orgID, ClusterID: clusterID}, nil
+	return &bootstrapResult{OrgID: orgID, ClusterID: clusterID}, nil
 }
 
 func authenticate(email, password string) (token, orgID string, err error) {
@@ -118,7 +117,7 @@ func signup(email, password string) (string, string, error) {
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusCreated {
-		return "", "", fmt.Errorf("signup returned %d: %s", resp.StatusCode, string(body))
+		return "", "", fmt.Errorf("signup returned %d", resp.StatusCode)
 	}
 
 	token := parseJSONField(body, "jwt_token")
@@ -156,8 +155,7 @@ func configureDomain(token, orgID, domain string) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("domain config returned %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("domain config returned %d", resp.StatusCode)
 	}
 	return nil
 }
@@ -298,7 +296,7 @@ func registerCluster(token, orgID, clusterURL, caData, saToken string) (string, 
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("cluster registration returned %d: %s", resp.StatusCode, string(body))
+		return "", fmt.Errorf("cluster registration returned %d", resp.StatusCode)
 	}
 
 	clusterID := parseJSONField(body, "id")

--- a/cmd/installer/exec.go
+++ b/cmd/installer/exec.go
@@ -10,22 +10,22 @@ import (
 
 func run(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = installerOutput.stderr
+	cmd.Stderr = installerOutput.stderr
 	cmd.Stdin = os.Stdin
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("command %q failed: %w", name+" "+strings.Join(args, " "), err)
+		return fmt.Errorf("%s failed: %w", commandLabel(name, args), err)
 	}
 	return nil
 }
 
 func output(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = installerOutput.stderr
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("command %q failed: %w", name+" "+strings.Join(args, " "), err)
+		return "", fmt.Errorf("%s failed: %w", commandLabel(name, args), err)
 	}
 	return strings.TrimSpace(out.String()), nil
 }
@@ -44,8 +44,8 @@ func outputQuiet(name string, args ...string) (string, error) {
 
 func runShell(command string) error {
 	cmd := exec.Command("sh", "-c", command)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = installerOutput.stderr
+	cmd.Stderr = installerOutput.stderr
 	cmd.Stdin = os.Stdin
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("shell command failed: %w", err)
@@ -61,10 +61,17 @@ func commandExists(name string) bool {
 func kubectlApply(manifest []byte) error {
 	cmd := exec.Command("kubectl", "apply", "-f", "-")
 	cmd.Stdin = bytes.NewReader(manifest)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = installerOutput.stderr
+	cmd.Stderr = installerOutput.stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("kubectl apply failed: %w", err)
 	}
 	return nil
+}
+
+func commandLabel(name string, args []string) string {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return name
+	}
+	return name + " " + args[0]
 }

--- a/cmd/installer/log.go
+++ b/cmd/installer/log.go
@@ -1,7 +1,5 @@
 package main
 
-import "fmt"
-
 const (
 	colorReset  = "\033[0m"
 	colorRed    = "\033[0;31m"
@@ -13,21 +11,28 @@ const (
 var totalPhases = 6
 
 func phaseLog(phase int, msg string) {
-	fmt.Printf("%s[%d/%d]%s %s\n", colorGreen, phase, totalPhases, colorReset, msg)
+	installerOutput.diagnosticf("%s[%d/%d]%s %s\n", color(colorGreen), phase, totalPhases, color(colorReset), msg)
 }
 
 func stepLog(msg string) {
-	fmt.Printf("  %s->%s %s\n", colorBlue, colorReset, msg)
+	installerOutput.diagnosticf("  %s->%s %s\n", color(colorBlue), color(colorReset), msg)
 }
 
 func warnLog(msg string) {
-	fmt.Printf("%s[!]%s %s\n", colorYellow, colorReset, msg)
+	installerOutput.diagnosticf("%s[!]%s %s\n", color(colorYellow), color(colorReset), msg)
 }
 
 func errLog(msg string) {
-	fmt.Printf("%s[ERROR]%s %s\n", colorRed, colorReset, msg)
+	installerOutput.diagnosticf("%s[ERROR]%s %s\n", color(colorRed), color(colorReset), msg)
 }
 
 func successLog(msg string) {
-	fmt.Printf("%s[ok]%s %s\n", colorGreen, colorReset, msg)
+	installerOutput.diagnosticf("%s[ok]%s %s\n", color(colorGreen), color(colorReset), msg)
+}
+
+func color(code string) string {
+	if !installerOutput.color {
+		return ""
+	}
+	return code
 }

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -12,87 +14,148 @@ import (
 
 const defaultAPIServerImage = "quay.io/stackdome/stackdome:latest"
 
+var errEmailRequired = errors.New("--email is required")
+
+type installOptions struct {
+	email           string
+	domain          string
+	image           string
+	chartVersion    string
+	credentialsFile string
+	github          *githubFlags
+	platform        *platformFlags
+}
+
 func main() {
-	args := os.Args[1:]
+	os.Exit(runMain(os.Args[1:]))
+}
+
+func runMain(args []string) int {
+	return runMainWithIO(args, os.Stdout, os.Stderr, stderrIsTerminal())
+}
+
+func runMainWithIO(args []string, stdout, stderr io.Writer, terminal bool) int {
+	mode := string(outputHuman)
+	if argumentsRequestJSON(args) {
+		mode = string(outputJSON)
+	}
+	_ = configureOutput(mode, argumentsRequestNoColor(args), terminal, stdout, stderr)
+
 	command := "install"
+	commandArgs := args
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
-		command, args = args[0], args[1:]
+		command, commandArgs = args[0], args[1:]
 	}
 
+	var err error
 	switch command {
 	case "install":
-		runInstall(args)
+		err = runInstall(commandArgs)
 	case "upgrade":
-		runUpgrade(args)
+		err = runUpgrade(commandArgs)
 	default:
 		usage()
-		os.Exit(1)
+		err = installationError("arguments", "unknown installer command", fmt.Errorf("unknown command %q", command))
 	}
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		emitFailure(err)
+		return 1
+	}
+	return 0
 }
 
 func usage() {
-	fmt.Println("Usage:")
-	fmt.Println("  stackdome-install install --email you@company.com [--domain stackdome.example.com]")
-	fmt.Println("                            [--image IMAGE] [--chart-version VERSION]")
-	fmt.Println("                            [GitHub flags] [platform flags]")
-	fmt.Println("  stackdome-install upgrade [--image IMAGE] [--chart-version VERSION]")
-	fmt.Println("                              [GitHub flags] [platform flags]")
-	fmt.Println()
-	fmt.Println("GitHub flags (all optional, stored in the bootstrap secret and reused by")
-	fmt.Println("later upgrades unless given again):")
-	fmt.Println("  --github-client-id ID --github-client-secret SECRET   'Sign in with GitHub'")
-	fmt.Println("  --github-app-id ID --github-app-slug SLUG             platform GitHub App")
-	fmt.Println("  --github-app-key-file PATH --github-app-webhook-secret SECRET")
-	fmt.Println()
-	fmt.Println("Platform flags (optional; configure wildcard hostnames and TLS):")
-	fmt.Println("  --platform-base-domain DOMAIN")
-	fmt.Println("  --platform-cloudflare-token-file PATH")
-	fmt.Println("  --platform-acme-environment production|staging")
-	fmt.Println("Only the Cloudflare token may be changed after initial configuration.")
-	fmt.Println()
-	fmt.Println("upgrade reuses the email, domain and secrets of the existing install,")
-	fmt.Println("and keeps the deployed image unless --image is given.")
+	installerOutput.diagnosticf("Usage:\n")
+	installerOutput.diagnosticf("  stackdome-install install --email you@company.com [--domain stackdome.example.com]\n")
+	installerOutput.diagnosticf("                            [--image IMAGE] [--chart-version VERSION]\n")
+	installerOutput.diagnosticf("                            [--output human|json] [--no-color]\n")
+	installerOutput.diagnosticf("                            [--credentials-file PATH] [GitHub flags] [platform flags]\n")
+	installerOutput.diagnosticf("  stackdome-install upgrade [--image IMAGE] [--chart-version VERSION]\n")
+	installerOutput.diagnosticf("                              [--output human|json] [--no-color]\n")
+	installerOutput.diagnosticf("                              [GitHub flags] [platform flags]\n\n")
+	installerOutput.diagnosticf("GitHub flags (all optional, stored in the bootstrap secret and reused by\n")
+	installerOutput.diagnosticf("later upgrades unless given again):\n")
+	installerOutput.diagnosticf("  --github-client-id ID --github-client-secret SECRET   'Sign in with GitHub'\n")
+	installerOutput.diagnosticf("  --github-app-id ID --github-app-slug SLUG             platform GitHub App\n")
+	installerOutput.diagnosticf("  --github-app-key-file PATH --github-app-webhook-secret SECRET\n\n")
+	installerOutput.diagnosticf("Platform flags (optional; configure wildcard hostnames and TLS):\n")
+	installerOutput.diagnosticf("  --platform-base-domain DOMAIN\n")
+	installerOutput.diagnosticf("  --platform-cloudflare-token-file PATH\n")
+	installerOutput.diagnosticf("  --platform-acme-environment production|staging\n")
+	installerOutput.diagnosticf("Only the Cloudflare token may be changed after initial configuration.\n\n")
+	installerOutput.diagnosticf("upgrade reuses the email, domain and secrets of the existing install,\n")
+	installerOutput.diagnosticf("and keeps the deployed image unless --image is given.\n")
 }
 
-func runInstall(args []string) {
-	fs := flag.NewFlagSet("install", flag.ExitOnError)
+func parseInstallOptions(args []string) (*installOptions, error) {
+	fs := flag.NewFlagSet("install", flag.ContinueOnError)
+	fs.SetOutput(installerOutput.stderr)
 	email := fs.String("email", "", "Admin user email (required)")
 	domain := fs.String("domain", "", "Dashboard domain (default: stackdome.<PUBLIC_IP>.nip.io)")
 	image := fs.String("image", defaultAPIServerImage, "API server container image")
 	chartVersion := fs.String("chart-version", defaultChartVersion, "stackdome-agent Helm chart version")
+	credentialsFile := fs.String("credentials-file", "", "Secure file for generated admin credentials")
+	output := registerOutputFlags(fs)
 	github := registerGitHubFlags(fs)
 	platform := registerPlatformFlags(fs)
-	_ = fs.Parse(args)
-
-	if *email == "" {
-		usage()
-		fmt.Println()
-		fmt.Println("Error: --email is required")
-		os.Exit(1)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
 	}
+	if fs.NArg() != 0 {
+		return nil, fmt.Errorf("unexpected positional arguments")
+	}
+	if err := output.apply(); err != nil {
+		return nil, err
+	}
+	if *email == "" {
+		return nil, errEmailRequired
+	}
+	return &installOptions{
+		email:           *email,
+		domain:          *domain,
+		image:           *image,
+		chartVersion:    *chartVersion,
+		credentialsFile: credentialsPath(*credentialsFile),
+		github:          github,
+		platform:        platform,
+	}, nil
+}
 
+func runInstall(args []string) error {
+	opts, err := parseInstallOptions(args)
+	if err != nil {
+		if errors.Is(err, errEmailRequired) {
+			usage()
+			return installationError("arguments", err.Error(), err)
+		}
+		return installationError("arguments", "invalid installer arguments", err)
+	}
+	totalPhases = 6
 	banner("StackDome VPS Installer")
 
-	preflight, err := runPreflight(*email, *domain)
+	preflight, err := runPreflight(opts.email, opts.domain)
 	if err != nil {
-		exitErr("Preflight failed", err)
+		return installationError("preflight", err.Error(), err)
 	}
 
 	if err := installK3s(); err != nil {
-		exitErr("k3s installation failed", err)
+		return installationError("k3s", "k3s installation failed", err)
 	}
 
-	if err := installStackdomeAgent(*chartVersion); err != nil {
-		exitErr("stackdome-agent installation failed", err)
+	if err := installStackdomeAgent(opts.chartVersion); err != nil {
+		return installationError("agent", "stackdome-agent installation failed", err)
 	}
 	if err := applyAPIServerRBAC(); err != nil {
-		exitErr("API server RBAC installation failed", err)
+		return installationError("agent", "API server RBAC installation failed", err)
 	}
 
 	vals := install.TemplateValues{
-		AdminEmail:     *email,
+		AdminEmail:     opts.email,
 		Domain:         preflight.Domain,
-		APIServerImage: *image,
+		APIServerImage: opts.image,
 		DBWorkloadType: string(models.WorkloadTypeStatefulService),
 		TLSEnabled:     isTLSDomain(preflight.Domain),
 	}
@@ -100,76 +163,95 @@ func runInstall(args []string) {
 	if existingSecrets, readErr := readExistingSecrets(); readErr == nil {
 		storedPlatform = existingSecrets.Platform
 	}
-	vals.Platform, err = platform.resolvePlatformConfig(storedPlatform)
+	vals.Platform, err = opts.platform.resolvePlatformConfig(storedPlatform)
 	if err != nil {
-		exitErr("Reading platform configuration failed", err)
+		return installationError("configuration", "reading platform configuration failed", err)
 	}
 	if err := ensurePlatformClusterCredentials(&vals.Platform); err != nil {
-		exitErr("Reading platform cluster credentials failed", err)
+		return installationError("configuration", "reading platform cluster credentials failed", err)
 	}
-	if err := github.applyTo(&vals); err != nil {
-		exitErr("Reading GitHub credentials failed", err)
+	if err := opts.github.applyTo(&vals); err != nil {
+		return installationError("configuration", "reading GitHub credentials failed", err)
 	}
 
 	secrets, err := loadOrCreateSecrets(&vals)
 	if err != nil {
-		exitErr("Secret generation failed", err)
+		return installationError("configuration", "secret generation failed", err)
 	}
 
 	if err := configureTLS(vals); err != nil {
-		exitErr("TLS configuration failed", err)
+		return installationError("configuration", "TLS configuration failed", err)
 	}
 
 	if err := applyCRs(vals, preflight.Domain); err != nil {
-		exitErr("CR application failed", err)
+		return installationError("configuration", "custom resource application failed", err)
 	}
 
 	result, err := runAPIBootstrap(vals, secrets)
 	if err != nil {
-		exitErr("API bootstrap failed", err)
+		return installationError("bootstrap", "API bootstrap failed", err)
 	}
 
-	printSummary(preflight.Domain, *email, secrets.AdminPassword, externallyReachable, result)
+	return finishInstall(preflight.Domain, opts.email, secrets.AdminPassword, opts.credentialsFile, externallyReachable, result)
 }
 
 func banner(title string) {
-	fmt.Println()
-	fmt.Println("================================================================")
-	fmt.Printf("  %s\n", title)
-	fmt.Println("================================================================")
-	fmt.Println()
+	installerOutput.diagnosticf("\n================================================================\n")
+	installerOutput.diagnosticf("  %s\n", title)
+	installerOutput.diagnosticf("================================================================\n\n")
 }
 
-func exitErr(msg string, err error) {
-	errLog(fmt.Sprintf("%s: %v", msg, err))
-	os.Exit(1)
-}
-
-func printSummary(domain, email, password string, externallyReachable bool, result *bootstrapResult) {
-	successLog("Installation complete!")
-	fmt.Println()
-	fmt.Println("================================================================")
-	fmt.Println("  StackDome installed successfully!")
-	fmt.Println("================================================================")
-	fmt.Println()
-	fmt.Printf("  URL:            https://%s\n", domain)
-	fmt.Printf("  Email:          %s\n", email)
-	fmt.Printf("  Password:       %s\n", password)
-	fmt.Println()
-	fmt.Println("  What's ready:")
-	fmt.Printf("    - Organization \"Default\" with domain %s\n", domain)
-	fmt.Println("    - Cluster \"local\" registered and connected")
-	fmt.Println("    - In-cluster image registry (50Gi)")
-	fmt.Println("    - PostgreSQL database (10Gi persistent volume)")
-	fmt.Println()
-	if !externallyReachable {
-		fmt.Println("  WARNING: Dashboard is NOT reachable from the internet.")
-		fmt.Println("  Ensure ports 80 and 443 are open in your firewall/security group.")
-		fmt.Println()
+func finishInstall(domain, email, password, credentialsFile string, reachable bool, result *bootstrapResult) error {
+	url := "https://" + domain
+	if credentialsFile != "" {
+		credentials := bootstrapCredentials{URL: url, AdminEmail: email, AdminPassword: password}
+		if err := writeCredentials(credentialsFile, credentials); err != nil {
+			return installationError("configuration", "writing credentials file failed", err)
+		}
 	}
-	fmt.Println("  Save these credentials -- they won't be shown again.")
-	fmt.Println()
-	fmt.Println("  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml")
-	fmt.Println()
-	fmt.Println("================================================================")
+
+	successLog("Installation complete!")
+	if installerOutput.isJSON() {
+		response := installSuccessResult{
+			Status:          "installed",
+			URL:             url,
+			AdminEmail:      email,
+			CredentialsFile: credentialsFile,
+			Organization:    namedResult{Name: "Default", ID: result.OrgID},
+			Cluster:         namedResult{Name: "local", ID: result.ClusterID},
+		}
+		if err := emitJSON(response); err != nil {
+			return installationError("output", "writing JSON result failed", err)
+		}
+		return nil
+	}
+
+	printSummary(domain, email, password, credentialsFile, reachable)
+	return nil
+}
+
+func printSummary(domain, email, password, credentialsFile string, externallyReachable bool) {
+	installerOutput.finalf("\n================================================================\n")
+	installerOutput.finalf("  StackDome installed successfully!\n")
+	installerOutput.finalf("================================================================\n\n")
+	installerOutput.finalf("  URL:            https://%s\n", domain)
+	installerOutput.finalf("  Email:          %s\n", email)
+	installerOutput.finalf("  Password:       %s\n", password)
+	if credentialsFile != "" {
+		installerOutput.finalf("  Credentials:    %s\n", credentialsFile)
+	}
+	installerOutput.finalf("\n  What's ready:\n")
+	installerOutput.finalf("    - Organization \"Default\" with domain %s\n", domain)
+	installerOutput.finalf("    - Cluster \"local\" registered and connected\n")
+	installerOutput.finalf("    - In-cluster image registry (50Gi)\n")
+	installerOutput.finalf("    - PostgreSQL database (10Gi persistent volume)\n\n")
+	if !externallyReachable {
+		installerOutput.finalf("  WARNING: Dashboard is NOT reachable from the internet.\n")
+		installerOutput.finalf("  Ensure ports 80 and 443 are open in your firewall/security group.\n\n")
+	}
+	installerOutput.finalf("  WARNING: Human-mode stdout contains the generated password.\n")
+	installerOutput.finalf("  Do not redirect it to an insecure file.\n\n")
+	installerOutput.finalf("  Save these credentials -- they won't be shown again.\n\n")
+	installerOutput.finalf("  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml\n\n")
+	installerOutput.finalf("================================================================\n")
 }

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -12,7 +12,10 @@ import (
 	"github.com/Stackdome/stackdome/pkg/models"
 )
 
-const defaultAPIServerImage = "quay.io/stackdome/stackdome:latest"
+const (
+	defaultAPIServerImage = "quay.io/stackdome/stackdome:latest"
+	installCommand        = "install"
+)
 
 var errEmailRequired = errors.New("--email is required")
 
@@ -41,7 +44,7 @@ func runMainWithIO(args []string, stdout, stderr io.Writer, terminal bool) int {
 	}
 	_ = configureOutput(mode, argumentsRequestNoColor(args), terminal, stdout, stderr)
 
-	command := "install"
+	command := installCommand
 	commandArgs := args
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		command, commandArgs = args[0], args[1:]
@@ -49,7 +52,7 @@ func runMainWithIO(args []string, stdout, stderr io.Writer, terminal bool) int {
 
 	var err error
 	switch command {
-	case "install":
+	case installCommand:
 		err = runInstall(commandArgs)
 	case "upgrade":
 		err = runUpgrade(commandArgs)
@@ -91,7 +94,7 @@ func usage() {
 }
 
 func parseInstallOptions(args []string) (*installOptions, error) {
-	fs := flag.NewFlagSet("install", flag.ContinueOnError)
+	fs := flag.NewFlagSet(installCommand, flag.ContinueOnError)
 	fs.SetOutput(installerOutput.stderr)
 	email := fs.String("email", "", "Admin user email (required)")
 	domain := fs.String("domain", "", "Dashboard domain (default: stackdome.<PUBLIC_IP>.nip.io)")

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -205,7 +205,7 @@ func banner(title string) {
 }
 
 func finishInstall(domain, email, password, credentialsFile string, reachable bool, result *bootstrapResult) error {
-	url := "https://" + domain
+	url := installationURL(domain)
 	if credentialsFile != "" {
 		credentials := bootstrapCredentials{URL: url, AdminEmail: email, AdminPassword: password}
 		if err := writeCredentials(credentialsFile, credentials); err != nil {
@@ -237,7 +237,7 @@ func printSummary(domain, email, password, credentialsFile string, externallyRea
 	installerOutput.finalf("\n================================================================\n")
 	installerOutput.finalf("  StackDome installed successfully!\n")
 	installerOutput.finalf("================================================================\n\n")
-	installerOutput.finalf("  URL:            https://%s\n", domain)
+	installerOutput.finalf("  URL:            %s\n", installationURL(domain))
 	installerOutput.finalf("  Email:          %s\n", email)
 	installerOutput.finalf("  Password:       %s\n", password)
 	if credentialsFile != "" {
@@ -257,4 +257,12 @@ func printSummary(domain, email, password, credentialsFile string, externallyRea
 	installerOutput.finalf("  Save these credentials -- they won't be shown again.\n\n")
 	installerOutput.finalf("  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml\n\n")
 	installerOutput.finalf("================================================================\n")
+}
+
+func installationURL(domain string) string {
+	scheme := "http"
+	if isTLSDomain(domain) {
+		scheme = "https"
+	}
+	return scheme + "://" + domain
 }

--- a/cmd/installer/output.go
+++ b/cmd/installer/output.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/term"
+)
+
+type outputMode string
+
+const (
+	outputHuman outputMode = "human"
+	outputJSON  outputMode = "json"
+
+	defaultCredentialsFile = "/root/.config/stackdome/bootstrap.json"
+)
+
+type outputRuntime struct {
+	mode     outputMode
+	stdout   io.Writer
+	stderr   io.Writer
+	color    bool
+	terminal bool
+}
+
+var installerOutput = outputRuntime{
+	mode:     outputHuman,
+	stdout:   os.Stdout,
+	stderr:   os.Stderr,
+	color:    term.IsTerminal(int(os.Stderr.Fd())),
+	terminal: term.IsTerminal(int(os.Stderr.Fd())),
+}
+
+func stderrIsTerminal() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+func configureOutput(mode string, noColor, terminal bool, stdout, stderr io.Writer) error {
+	parsed := outputMode(mode)
+	if parsed != outputHuman && parsed != outputJSON {
+		return fmt.Errorf("--output must be human or json")
+	}
+	installerOutput = outputRuntime{
+		mode:     parsed,
+		stdout:   stdout,
+		stderr:   stderr,
+		color:    parsed == outputHuman && terminal && !noColor,
+		terminal: terminal,
+	}
+	return nil
+}
+
+func (o outputRuntime) isJSON() bool {
+	return o.mode == outputJSON
+}
+
+func (o outputRuntime) diagnosticf(format string, args ...interface{}) {
+	_, _ = fmt.Fprintf(o.stderr, format, args...)
+}
+
+func (o outputRuntime) finalf(format string, args ...interface{}) {
+	_, _ = fmt.Fprintf(o.stdout, format, args...)
+}
+
+type outputFlags struct {
+	mode    *string
+	noColor *bool
+}
+
+func registerOutputFlags(fs *flag.FlagSet) *outputFlags {
+	return &outputFlags{
+		mode:    fs.String("output", string(outputHuman), "Output format: human or json"),
+		noColor: fs.Bool("no-color", false, "Disable ANSI color output"),
+	}
+}
+
+func (f *outputFlags) apply() error {
+	return configureOutput(*f.mode, *f.noColor, installerOutput.terminal, installerOutput.stdout, installerOutput.stderr)
+}
+
+func argumentsRequestJSON(args []string) bool {
+	outputValue := ""
+	wantValue := false
+	for _, arg := range args {
+		if wantValue {
+			outputValue = arg
+			wantValue = false
+			continue
+		}
+		switch arg {
+		case "--output":
+			wantValue = true
+		case "--output=json":
+			outputValue = string(outputJSON)
+		case "--output=human":
+			outputValue = string(outputHuman)
+		}
+	}
+	return outputValue == string(outputJSON)
+}
+
+func argumentsRequestNoColor(args []string) bool {
+	for _, arg := range args {
+		if arg == "--no-color" {
+			return true
+		}
+	}
+	return false
+}
+
+type installerError struct {
+	Phase  string
+	Public string
+	Err    error
+}
+
+func (e *installerError) Error() string {
+	if e.Err == nil || e.Public == e.Err.Error() {
+		return e.Public
+	}
+	return fmt.Sprintf("%s: %v", e.Public, e.Err)
+}
+
+func (e *installerError) Unwrap() error {
+	return e.Err
+}
+
+func installationError(phase, public string, err error) error {
+	return &installerError{Phase: phase, Public: public, Err: err}
+}
+
+type namedResult struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
+
+type installSuccessResult struct {
+	Status          string      `json:"status"`
+	URL             string      `json:"url"`
+	AdminEmail      string      `json:"admin_email"`
+	CredentialsFile string      `json:"credentials_file"`
+	Organization    namedResult `json:"organization"`
+	Cluster         namedResult `json:"cluster"`
+}
+
+type upgradeSuccessResult struct {
+	Status            string `json:"status"`
+	URL               string `json:"url"`
+	APIServerImage    string `json:"api_server_image"`
+	AgentChartVersion string `json:"agent_chart_version"`
+}
+
+type errorResult struct {
+	Status  string `json:"status"`
+	Phase   string `json:"phase"`
+	Message string `json:"message"`
+}
+
+type bootstrapCredentials struct {
+	URL           string `json:"url"`
+	AdminEmail    string `json:"admin_email"`
+	AdminPassword string `json:"admin_password"`
+}
+
+func emitJSON(value interface{}) error {
+	return json.NewEncoder(installerOutput.stdout).Encode(value)
+}
+
+func emitFailure(err error) {
+	phase := "unknown"
+	public := "installer failed"
+	var installErr *installerError
+	if errors.As(err, &installErr) {
+		phase = installErr.Phase
+		public = installErr.Public
+	}
+	errLog(err.Error())
+	if installerOutput.isJSON() {
+		if encodeErr := emitJSON(errorResult{Status: "error", Phase: phase, Message: public}); encodeErr != nil {
+			installerOutput.diagnosticf("failed to encode JSON error: %v\n", encodeErr)
+		}
+	}
+}
+
+func credentialsPath(requested string) string {
+	if requested == "" && installerOutput.isJSON() {
+		return defaultCredentialsFile
+	}
+	return requested
+}
+
+func writeCredentials(path string, credentials bootstrapCredentials) error {
+	if path == "" {
+		return fmt.Errorf("credentials path is empty")
+	}
+	parent := filepath.Dir(path)
+	parentInfo, err := os.Lstat(parent)
+	switch {
+	case err == nil:
+		if parentInfo.Mode()&os.ModeSymlink != 0 || !parentInfo.IsDir() {
+			return fmt.Errorf("credentials parent %s is not a directory", parent)
+		}
+		if parentInfo.Mode().Perm()&0o077 != 0 {
+			return fmt.Errorf("credentials parent %s must not be accessible by group or other users", parent)
+		}
+	case os.IsNotExist(err):
+		if err := os.MkdirAll(parent, 0o700); err != nil {
+			return fmt.Errorf("creating credentials directory: %w", err)
+		}
+		if err := os.Chmod(parent, 0o700); err != nil {
+			return fmt.Errorf("securing credentials directory: %w", err)
+		}
+	case err != nil:
+		return fmt.Errorf("inspecting credentials directory: %w", err)
+	}
+
+	if existing, err := os.Lstat(path); err == nil {
+		if existing.Mode()&os.ModeSymlink != 0 || !existing.Mode().IsRegular() {
+			return fmt.Errorf("credentials destination must be a regular file")
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspecting credentials destination: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(parent, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temporary credentials file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("securing temporary credentials file: %w", err)
+	}
+	if err := json.NewEncoder(tmp).Encode(credentials); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("encoding credentials: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("syncing credentials: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing credentials: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("installing credentials file: %w", err)
+	}
+	removeTemp = false
+	return nil
+}

--- a/cmd/installer/output_test.go
+++ b/cmd/installer/output_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestJSONArgumentFailureSeparatesOutput(t *testing.T) {
+	previous := installerOutput
+	t.Cleanup(func() { installerOutput = previous })
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	const secretFixture = "fixture-super-secret"
+	code := runMainWithIO(
+		[]string{"install", "--output", "json", "--", "--github-client-secret", secretFixture},
+		&stdout,
+		&stderr,
+		true,
+	)
+	if code == 0 {
+		t.Fatal("runMainWithIO returned success for invalid arguments")
+	}
+	if strings.Count(stdout.String(), "\n") != 1 || !strings.HasSuffix(stdout.String(), "\n") {
+		t.Fatalf("JSON stdout = %q, want exactly one newline-terminated object", stdout.String())
+	}
+	var result errorResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("JSON stdout is not parseable: %v", err)
+	}
+	if result.Status != "error" || result.Phase != "arguments" {
+		t.Fatalf("JSON error = %#v, want arguments error", result)
+	}
+	if strings.Contains(stdout.String(), "\x1b[") {
+		t.Fatalf("JSON stdout contains ANSI escapes: %q", stdout.String())
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("diagnostic stderr is empty")
+	}
+	if strings.Contains(stdout.String(), secretFixture) || strings.Contains(stderr.String(), secretFixture) {
+		t.Fatal("secret-like positional argument leaked to installer output")
+	}
+}
+
+func TestWriteCredentialsEnforcesFilesystemBoundary(t *testing.T) {
+	credentials := bootstrapCredentials{
+		URL:           "https://stackdome.example.com",
+		AdminEmail:    "installer@example.com",
+		AdminPassword: "fixture-password",
+	}
+	privateDir := filepath.Join(t.TempDir(), "stackdome")
+	path := filepath.Join(privateDir, "bootstrap.json")
+	if err := writeCredentials(path, credentials); err != nil {
+		t.Fatalf("writeCredentials() error = %v", err)
+	}
+
+	dirInfo, err := os.Stat(privateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("credentials directory mode = %o, want 700", got)
+	}
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("credentials file mode = %o, want 600", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got bootstrapCredentials
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, credentials) {
+		t.Fatalf("credentials = %#v, want %#v", got, credentials)
+	}
+
+	replacement := credentials
+	replacement.AdminPassword = "replacement-password"
+	if err := writeCredentials(path, replacement); err != nil {
+		t.Fatalf("replacing regular credentials file: %v", err)
+	}
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), credentials.AdminPassword) || !strings.Contains(string(data), replacement.AdminPassword) {
+		t.Fatalf("credential replacement did not atomically install new content: %s", data)
+	}
+
+	target := filepath.Join(privateDir, "target.json")
+	if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	symlink := filepath.Join(privateDir, "symlink.json")
+	if err := os.Symlink(target, symlink); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCredentials(symlink, credentials); err == nil {
+		t.Fatal("writeCredentials() accepted a symlink destination")
+	}
+
+	directoryDestination := filepath.Join(privateDir, "directory.json")
+	if err := os.Mkdir(directoryDestination, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCredentials(directoryDestination, credentials); err == nil {
+		t.Fatal("writeCredentials() accepted a directory destination")
+	}
+}
+
+func TestCommandLabelDoesNotIncludeTrailingArguments(t *testing.T) {
+	label := commandLabel("helm", []string{"upgrade", "--set", "password=fixture-secret"})
+	if label != "helm upgrade" {
+		t.Fatalf("commandLabel() = %q, want %q", label, "helm upgrade")
+	}
+	if strings.Contains(label, "fixture-secret") {
+		t.Fatalf("commandLabel() leaked trailing argument: %q", label)
+	}
+}

--- a/cmd/installer/output_test.go
+++ b/cmd/installer/output_test.go
@@ -128,3 +128,15 @@ func TestCommandLabelDoesNotIncludeTrailingArguments(t *testing.T) {
 		t.Fatalf("commandLabel() leaked trailing argument: %q", label)
 	}
 }
+
+func TestInstallationURLMatchesTLSMode(t *testing.T) {
+	tests := map[string]string{
+		"stackdome.192.0.2.1.nip.io": "http://stackdome.192.0.2.1.nip.io",
+		"stackdome.example.com":      "https://stackdome.example.com",
+	}
+	for domain, want := range tests {
+		if got := installationURL(domain); got != want {
+			t.Errorf("installationURL(%q) = %q, want %q", domain, got, want)
+		}
+	}
+}

--- a/cmd/installer/preflight.go
+++ b/cmd/installer/preflight.go
@@ -89,7 +89,7 @@ func detectPublicIP() (string, error) {
 	}
 	ip = strings.TrimSpace(ip)
 	if net.ParseIP(ip) == nil {
-		return "", fmt.Errorf("invalid public IP received: %q", ip)
+		return "", fmt.Errorf("invalid public IP response")
 	}
 	return ip, nil
 }

--- a/cmd/installer/upgrade.go
+++ b/cmd/installer/upgrade.go
@@ -3,55 +3,82 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/Stackdome/stackdome/install"
 )
 
-func runUpgrade(args []string) {
-	fs := flag.NewFlagSet("upgrade", flag.ExitOnError)
+type upgradeOptions struct {
+	image        string
+	chartVersion string
+	github       *githubFlags
+	platform     *platformFlags
+}
+
+func parseUpgradeOptions(args []string) (*upgradeOptions, error) {
+	fs := flag.NewFlagSet("upgrade", flag.ContinueOnError)
+	fs.SetOutput(installerOutput.stderr)
 	image := fs.String("image", "", "API server container image (default: keep the currently deployed one)")
 	chartVersion := fs.String("chart-version", defaultChartVersion, "stackdome-agent Helm chart version")
+	output := registerOutputFlags(fs)
 	github := registerGitHubFlags(fs)
 	platform := registerPlatformFlags(fs)
-	_ = fs.Parse(args)
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if fs.NArg() != 0 {
+		return nil, fmt.Errorf("unexpected positional arguments")
+	}
+	if err := output.apply(); err != nil {
+		return nil, err
+	}
+	return &upgradeOptions{
+		image:        *image,
+		chartVersion: *chartVersion,
+		github:       github,
+		platform:     platform,
+	}, nil
+}
+
+func runUpgrade(args []string) error {
+	opts, err := parseUpgradeOptions(args)
+	if err != nil {
+		return installationError("arguments", "invalid installer arguments", err)
+	}
 
 	totalPhases = 4
 	banner("StackDome Upgrade")
 
 	phaseLog(1, "Checking existing install...")
 	if err := requireRoot(); err != nil {
-		exitErr("Preflight failed", err)
+		return installationError("preflight", err.Error(), err)
 	}
 	if err := requireExistingInstall(); err != nil {
-		errLog(fmt.Sprintf("Nothing to upgrade: %v", err))
-		fmt.Println()
-		fmt.Println("Run the installer first:")
-		fmt.Println("  sudo ./stackdome-install install --email you@company.com")
-		os.Exit(1)
+		installerOutput.diagnosticf("\nRun the installer first:\n")
+		installerOutput.diagnosticf("  sudo ./stackdome-install install --email you@company.com\n")
+		return installationError("preflight", "no existing installation found", err)
 	}
 
 	domain, err := existingDomain()
 	if err != nil {
-		exitErr("Reading existing configuration failed", err)
+		return installationError("configuration", "reading existing configuration failed", err)
 	}
 	stepLog(fmt.Sprintf("Domain: %s", domain))
 
-	if *image == "" {
+	if opts.image == "" {
 		current, err := existingImage()
 		if err != nil {
-			exitErr("Reading existing configuration failed", err)
+			return installationError("configuration", "reading existing configuration failed", err)
 		}
-		*image = current
+		opts.image = current
 		stepLog(fmt.Sprintf("Image: %s (unchanged)", current))
 	} else {
-		stepLog(fmt.Sprintf("Image: %s", *image))
+		stepLog(fmt.Sprintf("Image: %s", opts.image))
 	}
 
 	phaseLog(2, "Loading existing secrets...")
 	secrets, err := readExistingSecrets()
 	if err != nil {
-		exitErr("Reading bootstrap secrets failed", err)
+		return installationError("configuration", "reading bootstrap secrets failed", err)
 	}
 	successLog("Secrets loaded")
 
@@ -59,13 +86,13 @@ func runUpgrade(args []string) {
 	// live Postgres between Deployment and StatefulSet is not this command's job.
 	dbWorkloadType, err := existingDBWorkloadType()
 	if err != nil {
-		exitErr("Reading existing configuration failed", err)
+		return installationError("configuration", "reading existing configuration failed", err)
 	}
 	stepLog(fmt.Sprintf("Database workload type: %s", dbWorkloadType))
 
 	vals := install.TemplateValues{
 		Domain:         domain,
-		APIServerImage: *image,
+		APIServerImage: opts.image,
 		DBWorkloadType: dbWorkloadType,
 		TLSEnabled:     isTLSDomain(domain),
 		DBPassword:     secrets.DBPassword,
@@ -73,37 +100,47 @@ func runUpgrade(args []string) {
 		EncryptionKey:  secrets.EncryptionKey,
 		AdminPassword:  secrets.AdminPassword,
 	}
-	vals.Platform, err = platform.resolvePlatformConfig(secrets.Platform)
+	vals.Platform, err = opts.platform.resolvePlatformConfig(secrets.Platform)
 	if err != nil {
-		exitErr("Reading platform configuration failed", err)
+		return installationError("configuration", "reading platform configuration failed", err)
 	}
-	if err := github.applyTo(&vals); err != nil {
-		exitErr("Reading GitHub credentials failed", err)
+	if err := opts.github.applyTo(&vals); err != nil {
+		return installationError("configuration", "reading GitHub credentials failed", err)
 	}
 
-	if err := installStackdomeAgent(*chartVersion); err != nil {
-		exitErr("stackdome-agent upgrade failed", err)
+	if err := installStackdomeAgent(opts.chartVersion); err != nil {
+		return installationError("agent", "stackdome-agent upgrade failed", err)
 	}
 	if err := applyAPIServerRBAC(); err != nil {
-		exitErr("API server RBAC upgrade failed", err)
+		return installationError("agent", "API server RBAC upgrade failed", err)
 	}
 	if err := ensurePlatformClusterCredentials(&vals.Platform); err != nil {
-		exitErr("Reading platform cluster credentials failed", err)
+		return installationError("configuration", "reading platform cluster credentials failed", err)
 	}
 	if err := mergeBootstrapConfig(&vals, secrets); err != nil {
-		exitErr("Storing bootstrap configuration failed", err)
+		return installationError("configuration", "storing bootstrap configuration failed", err)
 	}
 
 	if err := applyCRs(vals, domain); err != nil {
-		exitErr("CR application failed", err)
+		return installationError("configuration", "custom resource application failed", err)
 	}
 
 	successLog("Upgrade complete!")
-	fmt.Println()
-	fmt.Printf("  URL:            https://%s\n", domain)
-	fmt.Printf("  API server:     %s\n", *image)
-	fmt.Printf("  Agent chart:    v%s\n", *chartVersion)
-	fmt.Println()
+	if installerOutput.isJSON() {
+		if err := emitJSON(upgradeSuccessResult{
+			Status:            "upgraded",
+			URL:               "https://" + domain,
+			APIServerImage:    opts.image,
+			AgentChartVersion: opts.chartVersion,
+		}); err != nil {
+			return installationError("output", "writing JSON result failed", err)
+		}
+		return nil
+	}
+	installerOutput.finalf("\n  URL:            https://%s\n", domain)
+	installerOutput.finalf("  API server:     %s\n", opts.image)
+	installerOutput.finalf("  Agent chart:    v%s\n\n", opts.chartVersion)
+	return nil
 }
 
 func requireExistingInstall() error {

--- a/cmd/installer/upgrade.go
+++ b/cmd/installer/upgrade.go
@@ -129,7 +129,7 @@ func runUpgrade(args []string) error {
 	if installerOutput.isJSON() {
 		if err := emitJSON(upgradeSuccessResult{
 			Status:            "upgraded",
-			URL:               "https://" + domain,
+			URL:               installationURL(domain),
 			APIServerImage:    opts.image,
 			AgentChartVersion: opts.chartVersion,
 		}); err != nil {
@@ -137,7 +137,7 @@ func runUpgrade(args []string) error {
 		}
 		return nil
 	}
-	installerOutput.finalf("\n  URL:            https://%s\n", domain)
+	installerOutput.finalf("\n  URL:            %s\n", installationURL(domain))
 	installerOutput.finalf("  API server:     %s\n", opts.image)
 	installerOutput.finalf("  Agent chart:    v%s\n\n", opts.chartVersion)
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	golang.org/x/crypto v0.53.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
+	golang.org/x/term v0.44.0
 	golang.org/x/time v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/postgres v1.5.9
@@ -181,7 +182,6 @@ require (
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/tools v0.46.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect

--- a/install/bootstrap.sh
+++ b/install/bootstrap.sh
@@ -4,8 +4,29 @@ set -eu
 
 readonly canonical_command='curl -fsSL https://get.stackdome.com/install.sh | sudo sh'
 
+output_value=
+expect_output_value=0
+for arg in "$@"; do
+    if [ "$expect_output_value" -eq 1 ]; then
+        output_value=$arg
+        expect_output_value=0
+        continue
+    fi
+    case "$arg" in
+        --output) expect_output_value=1 ;;
+        --output=*) output_value=${arg#--output=} ;;
+    esac
+done
+json_output=0
+[ "$output_value" = json ] && json_output=1
+
 fail() {
-    printf '%s\n' "stackdome installer: $*" >&2
+    detail=$1
+    public=${2:-transport failed}
+    printf '%s\n' "stackdome installer: $detail" >&2
+    if [ "$json_output" -eq 1 ]; then
+        printf '{"status":"error","phase":"transport","message":"%s"}\n' "$public"
+    fi
     exit 1
 }
 
@@ -16,13 +37,13 @@ cleanup() {
 }
 
 if [ "$(id -u)" -ne 0 ]; then
-    fail "root access required; run: $canonical_command"
+    fail "root access required; run: $canonical_command" 'root access required'
 fi
 
-os=$(uname -s 2>/dev/null) || fail 'unable to determine operating system'
-[ "$os" = Linux ] || fail "unsupported operating system: $os (Linux required)"
+os=$(uname -s 2>/dev/null) || fail 'unable to determine operating system' 'unsupported platform'
+[ "$os" = Linux ] || fail "unsupported operating system: $os (Linux required)" 'unsupported platform'
 
-machine=$(uname -m 2>/dev/null) || fail 'unable to determine CPU architecture'
+machine=$(uname -m 2>/dev/null) || fail 'unable to determine CPU architecture' 'unsupported platform'
 case "$machine" in
     x86_64|amd64)
         asset=stackdome-install-linux-amd64
@@ -31,7 +52,7 @@ case "$machine" in
         asset=stackdome-install-linux-arm64
         ;;
     *)
-        fail "unsupported CPU architecture: $machine"
+        fail "unsupported CPU architecture: $machine" 'unsupported platform'
         ;;
 esac
 
@@ -44,7 +65,7 @@ elif command -v wget >/dev/null 2>&1; then
         wget -q -O "$1" "$2"
     }
 else
-    fail 'curl or wget is required'
+    fail 'curl or wget is required' 'download tool unavailable'
 fi
 
 if command -v sha256sum >/dev/null 2>&1; then
@@ -56,17 +77,17 @@ elif command -v shasum >/dev/null 2>&1; then
         shasum -a 256 "$1"
     }
 else
-    fail 'sha256sum or shasum is required'
+    fail 'sha256sum or shasum is required' 'checksum tool unavailable'
 fi
 
 release_tag=${STACKDOME_VERSION:-@STACKDOME_VERSION@}
-[ -n "$release_tag" ] || fail 'STACKDOME_VERSION is required'
-[ "$release_tag" != '@STACKDOME_VERSION@' ] || fail 'STACKDOME_VERSION is required'
+[ -n "$release_tag" ] || fail 'STACKDOME_VERSION is required' 'release version unavailable'
+[ "$release_tag" != '@STACKDOME_VERSION@' ] || fail 'STACKDOME_VERSION is required' 'release version unavailable'
 
 release_base_url=${STACKDOME_RELEASE_BASE_URL:-https://github.com/Stackdome/stackdome/releases/download}
 
 umask 077
-tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/stackdome-install.XXXXXX") || fail 'unable to create temporary directory'
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/stackdome-install.XXXXXX") || fail 'unable to create temporary directory' 'temporary directory creation failed'
 trap cleanup 0
 trap 'cleanup; exit 129' HUP
 trap 'cleanup; exit 130' INT
@@ -76,24 +97,28 @@ checksums_file="$tmp_dir/checksums.txt"
 installer_file="$tmp_dir/$asset"
 release_url="$release_base_url/$release_tag"
 
-download "$checksums_file" "$release_url/checksums.txt" || fail 'failed to download checksums.txt'
+download "$checksums_file" "$release_url/checksums.txt" || fail 'failed to download checksums.txt' 'checksum manifest download failed'
 
 match_count=$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset { count++ } END { print count + 0 }' "$checksums_file")
-[ "$match_count" -eq 1 ] || fail "checksums.txt must contain exactly one entry for $asset"
+[ "$match_count" -eq 1 ] || fail "checksums.txt must contain exactly one entry for $asset" 'checksum manifest invalid'
 
 expected=$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset { print $1 }' "$checksums_file" | tr '[:upper:]' '[:lower:]')
 case "$expected" in
-    *[!0-9a-f]*|'') fail "invalid SHA-256 checksum for $asset" ;;
+    *[!0-9a-f]*|'') fail "invalid SHA-256 checksum for $asset" 'checksum manifest invalid' ;;
 esac
-[ "${#expected}" -eq 64 ] || fail "invalid SHA-256 checksum for $asset"
+[ "${#expected}" -eq 64 ] || fail "invalid SHA-256 checksum for $asset" 'checksum manifest invalid'
 
-download "$installer_file" "$release_url/$asset" || fail "failed to download $asset"
-checksum_line=$(checksum "$installer_file") || fail "failed to calculate checksum for $asset"
+download "$installer_file" "$release_url/$asset" || fail "failed to download $asset" 'installer download failed'
+checksum_line=$(checksum "$installer_file") || fail "failed to calculate checksum for $asset" 'installer checksum verification failed'
 actual=$(printf '%s\n' "$checksum_line" | awk '{ print $1 }' | tr '[:upper:]' '[:lower:]')
-[ "$actual" = "$expected" ] || fail "checksum mismatch for $asset"
+[ "$actual" = "$expected" ] || fail "checksum mismatch for $asset" 'installer checksum verification failed'
 
 if [ "${STACKDOME_DOWNLOAD_ONLY:-0}" = 1 ]; then
-    printf '%s\n' "Verified $asset for $release_tag"
+    if [ "$json_output" -eq 1 ]; then
+        printf '{"status":"verified"}\n'
+    else
+        printf '%s\n' "Verified $asset for $release_tag"
+    fi
     exit 0
 fi
 
@@ -108,15 +133,30 @@ for arg in "$@"; do
 done
 
 if [ "$needs_email" -eq 1 ]; then
-    if [ -r /dev/tty ] && [ -w /dev/tty ] && (: </dev/tty) 2>/dev/null; then
+    if [ "$json_output" -eq 1 ]; then
+        fail 'JSON install requires --email' 'non-interactive install requires --email'
+    elif [ -r /dev/tty ] && [ -w /dev/tty ] && (: </dev/tty) 2>/dev/null; then
         printf 'Admin email: ' >/dev/tty
-        IFS= read -r admin_email </dev/tty || fail 'unable to read admin email'
-        [ -n "$admin_email" ] || fail 'admin email cannot be empty'
+        IFS= read -r admin_email </dev/tty || fail 'unable to read admin email' 'admin email is required'
+        [ -n "$admin_email" ] || fail 'admin email cannot be empty' 'admin email is required'
         set -- "$@" --email "$admin_email"
     else
-        fail 'non-interactive install requires --email'
+        fail 'non-interactive install requires --email' 'non-interactive install requires --email'
     fi
 fi
 
-chmod 0700 "$installer_file" || fail "failed to make $asset executable"
-"$installer_file" "$@" || fail 'installer execution failed'
+chmod 0700 "$installer_file" || fail "failed to make $asset executable" 'installer preparation failed'
+installer_stdout="$tmp_dir/installer.stdout"
+installer_status=0
+"$installer_file" "$@" >"$installer_stdout" || installer_status=$?
+if ! cat "$installer_stdout"; then
+    printf '%s\n' 'stackdome installer: failed to forward installer output' >&2
+    exit 1
+fi
+if [ "$installer_status" -ne 0 ]; then
+    if [ "$json_output" -eq 1 ] && [ ! -s "$installer_stdout" ]; then
+        printf '{"status":"error","phase":"transport","message":"installer execution failed"}\n'
+    fi
+    printf '%s\n' 'stackdome installer: installer execution failed' >&2
+    exit "$installer_status"
+fi

--- a/install/bootstrap.sh
+++ b/install/bootstrap.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+
+set -eu
+
+readonly canonical_command='curl -fsSL https://get.stackdome.com/install.sh | sudo sh'
+
+fail() {
+    printf '%s\n' "stackdome installer: $*" >&2
+    exit 1
+}
+
+cleanup() {
+    if [ -n "${tmp_dir:-}" ] && [ -d "$tmp_dir" ]; then
+        rm -rf "$tmp_dir"
+    fi
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    fail "root access required; run: $canonical_command"
+fi
+
+os=$(uname -s 2>/dev/null) || fail 'unable to determine operating system'
+[ "$os" = Linux ] || fail "unsupported operating system: $os (Linux required)"
+
+machine=$(uname -m 2>/dev/null) || fail 'unable to determine CPU architecture'
+case "$machine" in
+    x86_64|amd64)
+        asset=stackdome-install-linux-amd64
+        ;;
+    aarch64|arm64)
+        asset=stackdome-install-linux-arm64
+        ;;
+    *)
+        fail "unsupported CPU architecture: $machine"
+        ;;
+esac
+
+if command -v curl >/dev/null 2>&1; then
+    download() {
+        curl --fail --location --silent --show-error --output "$1" "$2"
+    }
+elif command -v wget >/dev/null 2>&1; then
+    download() {
+        wget -q -O "$1" "$2"
+    }
+else
+    fail 'curl or wget is required'
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    checksum() {
+        sha256sum "$1"
+    }
+elif command -v shasum >/dev/null 2>&1; then
+    checksum() {
+        shasum -a 256 "$1"
+    }
+else
+    fail 'sha256sum or shasum is required'
+fi
+
+release_tag=${STACKDOME_VERSION:-@STACKDOME_VERSION@}
+[ -n "$release_tag" ] || fail 'STACKDOME_VERSION is required'
+[ "$release_tag" != '@STACKDOME_VERSION@' ] || fail 'STACKDOME_VERSION is required'
+
+release_base_url=${STACKDOME_RELEASE_BASE_URL:-https://github.com/Stackdome/stackdome/releases/download}
+
+umask 077
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/stackdome-install.XXXXXX") || fail 'unable to create temporary directory'
+trap cleanup 0
+trap 'cleanup; exit 129' HUP
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+checksums_file="$tmp_dir/checksums.txt"
+installer_file="$tmp_dir/$asset"
+release_url="$release_base_url/$release_tag"
+
+download "$checksums_file" "$release_url/checksums.txt" || fail 'failed to download checksums.txt'
+
+match_count=$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset { count++ } END { print count + 0 }' "$checksums_file")
+[ "$match_count" -eq 1 ] || fail "checksums.txt must contain exactly one entry for $asset"
+
+expected=$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset { print $1 }' "$checksums_file" | tr '[:upper:]' '[:lower:]')
+case "$expected" in
+    *[!0-9a-f]*|'') fail "invalid SHA-256 checksum for $asset" ;;
+esac
+[ "${#expected}" -eq 64 ] || fail "invalid SHA-256 checksum for $asset"
+
+download "$installer_file" "$release_url/$asset" || fail "failed to download $asset"
+checksum_line=$(checksum "$installer_file") || fail "failed to calculate checksum for $asset"
+actual=$(printf '%s\n' "$checksum_line" | awk '{ print $1 }' | tr '[:upper:]' '[:lower:]')
+[ "$actual" = "$expected" ] || fail "checksum mismatch for $asset"
+
+if [ "${STACKDOME_DOWNLOAD_ONLY:-0}" = 1 ]; then
+    printf '%s\n' "Verified $asset for $release_tag"
+    exit 0
+fi
+
+needs_email=1
+if [ "${1:-}" = upgrade ]; then
+    needs_email=0
+fi
+for arg in "$@"; do
+    case "$arg" in
+        --email|--email=*) needs_email=0 ;;
+    esac
+done
+
+if [ "$needs_email" -eq 1 ]; then
+    if [ -r /dev/tty ] && [ -w /dev/tty ] && (: </dev/tty) 2>/dev/null; then
+        printf 'Admin email: ' >/dev/tty
+        IFS= read -r admin_email </dev/tty || fail 'unable to read admin email'
+        [ -n "$admin_email" ] || fail 'admin email cannot be empty'
+        set -- "$@" --email "$admin_email"
+    else
+        fail 'non-interactive install requires --email'
+    fi
+fi
+
+chmod 0700 "$installer_file" || fail "failed to make $asset executable"
+"$installer_file" "$@" || fail 'installer execution failed'

--- a/install/bootstrap_script_test.go
+++ b/install/bootstrap_script_test.go
@@ -1,0 +1,64 @@
+package install
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBootstrapRootFailureOutputModes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bootstrap.sh requires POSIX sh")
+	}
+	fakeBin := t.TempDir()
+	fakeID := filepath.Join(fakeBin, "id")
+	if err := os.WriteFile(fakeID, []byte("#!/bin/sh\nprintf '501\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(args ...string) (string, string, int) {
+		t.Helper()
+		cmd := exec.Command("sh", append([]string{"bootstrap.sh"}, args...)...)
+		cmd.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if err == nil {
+			return stdout.String(), stderr.String(), 0
+		}
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("bootstrap execution error = %v", err)
+		}
+		return stdout.String(), stderr.String(), exitErr.ExitCode()
+	}
+
+	jsonStdout, jsonStderr, jsonCode := run("--output", "json")
+	if jsonCode == 0 {
+		t.Fatal("JSON root failure exited zero")
+	}
+	wantJSON := "{\"status\":\"error\",\"phase\":\"transport\",\"message\":\"root access required\"}\n"
+	if jsonStdout != wantJSON {
+		t.Fatalf("JSON stdout = %q, want %q", jsonStdout, wantJSON)
+	}
+	if !strings.Contains(jsonStderr, "root access required") {
+		t.Fatalf("JSON stderr = %q, want root diagnostic", jsonStderr)
+	}
+
+	humanStdout, humanStderr, humanCode := run()
+	if humanCode == 0 {
+		t.Fatal("human root failure exited zero")
+	}
+	if humanStdout != "" {
+		t.Fatalf("human stdout = %q, want empty", humanStdout)
+	}
+	if !strings.Contains(humanStderr, "curl -fsSL https://get.stackdome.com/install.sh | sudo sh") {
+		t.Fatalf("human stderr = %q, want canonical command", humanStderr)
+	}
+}

--- a/install/bootstrap_script_test.go
+++ b/install/bootstrap_script_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,8 +33,8 @@ func TestBootstrapRootFailureOutputModes(t *testing.T) {
 		if err == nil {
 			return stdout.String(), stderr.String(), 0
 		}
-		exitErr, ok := err.(*exec.ExitError)
-		if !ok {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
 			t.Fatalf("bootstrap execution error = %v", err)
 		}
 		return stdout.String(), stderr.String(), exitErr.ExitCode()

--- a/install/embed_test.go
+++ b/install/embed_test.go
@@ -17,6 +17,15 @@ func TestInstall(t *testing.T) {
 }
 
 var _ = Describe("RenderManifest", func() {
+	It("labels StackResources for the Stack controller", func() {
+		for _, name := range []string{"db-resource-cr.yaml", "api-server-resource-cr.yaml"} {
+			out, err := install.RenderManifest(name, install.TemplateValues{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(out)).To(ContainSubstring("core.stackdome.io/stack-name: stackdome-platform"))
+			Expect(string(out)).NotTo(ContainSubstring("\n    stackdome.io/stack-name:"))
+		}
+	})
+
 	Describe("db-resource-cr.yaml", func() {
 		It("renders the requested workload type", func() {
 			out, err := install.RenderManifest("db-resource-cr.yaml", install.TemplateValues{

--- a/install/manifests/api-server-resource-cr.yaml
+++ b/install/manifests/api-server-resource-cr.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: stackdome-platform
     app.kubernetes.io/managed-by: stackdome-installer
     stackdome.io/bootstrap: "true"
-    stackdome.io/stack-name: stackdome-platform
+    core.stackdome.io/stack-name: stackdome-platform
   ownerReferences:
     - apiVersion: core.stackdome.io/v1alpha1
       kind: Stack

--- a/install/manifests/db-resource-cr.yaml
+++ b/install/manifests/db-resource-cr.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: stackdome-platform
     app.kubernetes.io/managed-by: stackdome-installer
     stackdome.io/bootstrap: "true"
-    stackdome.io/stack-name: stackdome-platform
+    core.stackdome.io/stack-name: stackdome-platform
   ownerReferences:
     - apiVersion: core.stackdome.io/v1alpha1
       kind: Stack


### PR DESCRIPTION
## Summary

- add a POSIX self-host bootstrap that selects Linux amd64/arm64 release assets and verifies exact SHA-256 entries before execution
- add explicit agent output with --output json; human output remains the default and no-TTY execution only disables color
- keep progress, warnings, subprocess output, and diagnostics on stderr while stdout contains one final human summary or JSON object
- write JSON-mode admin credentials atomically to a secure 0600 file under a 0700 directory, rejecting symlinks and non-regular destinations
- return stable install, upgrade, transport, and error JSON without passwords, JWTs, response bodies, full command arguments, or service-account tokens
- make tag releases repairable while preventing manual historical repairs from retagging latest
- add a protected R2 workflow that verifies both architectures, publishes the immutable versioned script, smokes it, then promotes the live key
- move GitHub and Quay credentials out of secret-bearing command interpolation and clean up temporary credentials

## Agent invocation

    curl -fsSL https://get.stackdome.com/install.sh |
      sudo sh -s -- --email installer@example.com --output json

JSON install mode defaults credentials to /root/.config/stackdome/bootstrap.json. Agents may override it with --credentials-file PATH. Explicit JSON mode never prompts, even if the calling harness allocates a pseudo-terminal.

## Verification

- shell syntax validation for install/bootstrap.sh
- actionlint v1.7.7 on both workflows
- go test ./cmd/installer ./install
- go test -race ./cmd/installer ./install
- go vet ./cmd/installer
- focused tests for JSON stream separation, secret-like argument redaction, credential permissions/symlink rejection, and wrapper transport errors
- Linux amd64 and arm64 cross-builds
- SHA-256 verification and ELF architecture inspection
- independent code review: no critical or important findings

## Release gates

This PR does not tag, publish a GitHub Release, upload to R2, change DNS, or advertise the command. Protected publication and clean-server acceptance on both architectures remain required before launch.