### PR TITLE
Treat the OAuth callback page as an auth page in the API client

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -110,9 +110,11 @@ export interface AuthErrorDeps {
   isAuthPage?: () => boolean;
 }
 
-function isOnAuthPage(): boolean {
+// Includes the OAuth callback: a stale session's failed refresh must not
+// navigate away and abort the in-flight code exchange.
+export function isOnAuthPage(): boolean {
   const path = window.location.pathname;
-  return path === '/sign-in' || path === '/sign-up';
+  return path === '/sign-in' || path === '/sign-up' || path === '/auth/github/callback';
 }
 
 // Expired/invalid access tokens return 403 here (not 401); match the token reason

--- a/frontend/src/api/tests/client-auth.test.ts
+++ b/frontend/src/api/tests/client-auth.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { handleResponseError, type AuthErrorDeps } from "@/api/client";
+import { handleResponseError, isOnAuthPage, type AuthErrorDeps } from "@/api/client";
 
 function mkDeps(over: Partial<AuthErrorDeps> = {}): AuthErrorDeps {
   return {
@@ -97,5 +97,20 @@ describe("handleResponseError", () => {
     const deps = mkDeps({ isAuthPage: () => true });
     await expect(handleResponseError(err(403, "token is expired by 1h"), deps)).rejects.toBeDefined();
     expect(deps.refresh).not.toHaveBeenCalled();
+  });
+});
+
+describe("isOnAuthPage", () => {
+  // The callback page must count as an auth page: with a stale expired session,
+  // a failed refresh would otherwise redirect to /sign-in and abort the
+  // in-flight OAuth code exchange.
+  it.each(["/sign-in", "/sign-up", "/auth/github/callback"])("is true on %s", (path) => {
+    window.history.replaceState(null, "", path);
+    expect(isOnAuthPage()).toBe(true);
+  });
+
+  it("is false on app pages", () => {
+    window.history.replaceState(null, "", "/dashboard");
+    expect(isOnAuthPage()).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

GitHub OAuth login loops back to `/sign-in` forever when the browser holds a stale expired session (Jam: https://jam.dev/c/1064a77a-be99-47e4-86a6-3176274bf598).

Chain:
1. `/auth/github/callback` page mounts and starts the code exchange.
2. The current-user probe fires with the stale token and gets a 403 (`token parse error: token is expired`).
3. The interceptor tries a refresh, which fails, and the auth-failure handler hard-navigates to `/sign-in`.
4. That navigation aborts the in-flight `/api/v1/auth/github/callback` exchange (`net::ERR_ABORTED`), so new tokens are never stored.

## Fix

`isOnAuthPage()` now includes `/auth/github/callback`, so a failed refresh cannot navigate away while the callback page is establishing the new session. Only browsers with old expired tokens ever hit this; fresh browsers were unaffected.

## Testing

- New `isOnAuthPage` unit tests (all three auth paths + an app path).
- Full frontend suite: 1591 tests pass, lint clean.