### PR TITLE
fix: preserve installer version sentinel

### DIFF
--- a/.github/workflows/publish-self-host-installer.yaml
+++ b/.github/workflows/publish-self-host-installer.yaml
@@ -62,10 +62,10 @@ jobs:
       - name: Render versioned install script
         run: |
           mkdir -p dist
-          sed "s/@STACKDOME_VERSION@/$RELEASE_TAG/g" install/bootstrap.sh > dist/install.sh
+          sed "/^release_tag=/s/@STACKDOME_VERSION@/$RELEASE_TAG/" install/bootstrap.sh > dist/install.sh
           sh -n dist/install.sh
           placeholder_count=$(grep -c '@STACKDOME_VERSION@' dist/install.sh || true)
-          test "$placeholder_count" -eq 0
+          test "$placeholder_count" -eq 1
 
       - name: Upload immutable install script
         env:


### PR DESCRIPTION
## Summary
- replace the release placeholder only in the `release_tag` default assignment
- preserve the runtime sentinel used to detect an unrendered installer
- allow the `v0.0.2-alpha` immutable installer smoke check to accept its rendered version

## Verification
- rendered `v0.0.2-alpha` default and sentinel assertions
- `sh -n` on the rendered installer
- `actionlint .github/workflows/publish-self-host-installer.yaml`
- `go test ./cmd/installer ./install`

## Note
A local `go test ./...` run passed unit packages but the integration suite could not create its Kind worker because `kubeadm join` was killed with exit code 137. GitHub CI will run the repository integration checks.