### PR TITLE
Add Stackdome Cloud compute policy and lazy registries

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     services:
       postgres:
@@ -60,10 +60,21 @@ jobs:
           DB_USERNAME: postgres
           DB_PASSWORD: testpassword
 
+      - name: Run Stackdome Cloud e2e tests
+        run: make test-cloud-integration
+        env:
+          GOPRIVATE: github.com/ashishmax31/*,stackdome.io/*,github.com/Stackdome/*
+          DB_HOST: localhost
+          DB_PORT: "5432"
+          DB_USERNAME: postgres
+          DB_PASSWORD: testpassword
+
       - name: Upload test log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-test-log
-          path: test/int/last-run.log
+          path: |
+            test/int/last-run.log
+            test/cloudint/last-run.log
           retention-days: 2

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node-compile-cache/
 
 # Integration test cache (clusters, kubeconfigs, CI logs — never commit)
 test/int/.cache/
+test/cloudint/.cache/
 cluster_config.yaml
 database.yaml
 bin/
@@ -40,4 +41,5 @@ pkg/web/dist/*
 
 # Integration test output (Makefile tees here)
 test/int/last-run.log
+test/cloudint/last-run.log
 .pnpm-store

--- a/Makefile
+++ b/Makefile
@@ -184,3 +184,10 @@ test-integration: ensure-postgres ## Run integration tests. Optional: FOCUS="My 
 		$(if $(FOCUS),-ginkgo.focus="$(FOCUS)") \
 		2>&1 | tee last-run.log; \
 		EXIT_CODE=$$?; rm -f integration.test; exit $$EXIT_CODE
+
+.PHONY: test-cloud-integration
+test-cloud-integration: ensure-postgres ## Run the focused Stackdome Cloud/shared integration suite.
+	@go test -tags=cloud_e2e -c -o test/cloudint/cloud-integration.test ./test/cloudint
+	@cd test/cloudint && set -o pipefail && ./cloud-integration.test -test.v -ginkgo.v -test.timeout 1h -test.count 1 \
+		2>&1 | tee last-run.log; \
+		EXIT_CODE=$$?; rm -f cloud-integration.test; exit $$EXIT_CODE

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ test-integration: ensure-postgres ## Run integration tests. Optional: FOCUS="My 
 		EXIT_CODE=$$?; rm -f integration.test; exit $$EXIT_CODE
 
 .PHONY: test-cloud-integration
+test-cloud-integration: SHELL := /usr/bin/env bash
 test-cloud-integration: ensure-postgres ## Run the focused Stackdome Cloud/shared integration suite.
 	@go test -tags=cloud_e2e -c -o test/cloudint/cloud-integration.test ./test/cloudint
 	@cd test/cloudint && set -o pipefail && ./cloud-integration.test -test.v -ginkgo.v -test.timeout 1h -test.count 1 \

--- a/cmd/environment/env.go
+++ b/cmd/environment/env.go
@@ -855,6 +855,14 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 
 	e.WorkerManager.RegisterWorker(stackWorker, models.StackOperand{})
 
+	clusterImageRegistryStore := pgstore.NewClusterImageRegistryStore(pgstore.ClusterImageRegistryStoreSpec{
+		SessionFactory: e.DBSession,
+	})
+	clusterImageRegistryResource := clusterresource.NewClusterImageRegistryService(clusterresource.ClusterImageRegistryServiceSpec{
+		ClusterManager: e.ClusterManager,
+		Logger:         e.Logger,
+	})
+
 	releaseWorker := releaseworker.NewReleaseWorker(releaseworker.ReleaseWorkerSpec{
 		ReleaseService:       e.Services.StackReleaseService,
 		EventRecorder:        e.Services.ReleaseEventRecorder,
@@ -881,6 +889,8 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 			SessionFactory: e.DBSession,
 		}),
 		ReleaseWorkerEnqueuer: e.WorkerManager,
+		ImageRegistryStore:    clusterImageRegistryStore,
+		ImageRegistryResource: clusterImageRegistryResource,
 		Env:                   e.Name,
 	})
 	e.WorkerManager.RegisterWorker(releaseWorker, models.StackReleaseOperand{})
@@ -904,20 +914,14 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 	})
 	e.WorkerManager.RegisterWorker(volumeWorker, models.VolumeOperand{})
 
-	clusterImageRegistryResource := clusterresource.NewClusterImageRegistryService(clusterresource.ClusterImageRegistryServiceSpec{
-		ClusterManager: e.ClusterManager,
-		Logger:         e.Logger,
-	})
 	clusterImageRegistryWorker := clusterimageregistryworker.NewClusterImageRegistryWorker(clusterimageregistryworker.ClusterImageRegistryWorkerSpec{
 		ClusterStore: pgstore.NewClusterStore(pgstore.ClusterStoreSpec{
 			SessionFactory: e.DBSession,
 		}),
-		ImageRegistryStore: pgstore.NewClusterImageRegistryStore(pgstore.ClusterImageRegistryStoreSpec{
-			SessionFactory: e.DBSession,
-		}),
-		ClusterManager:  e.ClusterManager,
-		ClusterResource: clusterImageRegistryResource,
-		Env:             e.Name,
+		ImageRegistryStore: clusterImageRegistryStore,
+		ClusterManager:     e.ClusterManager,
+		ClusterResource:    clusterImageRegistryResource,
+		Env:                e.Name,
 	})
 	e.WorkerManager.RegisterWorker(clusterImageRegistryWorker, models.ClusterImageRegistryOperand{})
 

--- a/cmd/environment/env.go
+++ b/cmd/environment/env.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Stackdome/stackdome/pkg/builders"
 	"github.com/Stackdome/stackdome/pkg/clients/githubapp"
 	"github.com/Stackdome/stackdome/pkg/clustermanager"
+	"github.com/Stackdome/stackdome/pkg/computeaccess"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/controllers/clusterimageregistry"
 	clusterinfocontroller "github.com/Stackdome/stackdome/pkg/controllers/clusterinfo"
 	imagebuildcontroller "github.com/Stackdome/stackdome/pkg/controllers/imagebuild"
@@ -117,6 +119,7 @@ func (e *environmentImpl) Init(ctx context.Context) error {
 		e.loadEnvAndConfigs,
 		e.setupLogger,
 		e.setupDatabase,
+		e.initializeComputePolicy,
 		e.auditPersistedComputeTopology,
 		e.setupObservability,
 		e.initializeResourceAccessPolicyManager,
@@ -261,6 +264,32 @@ func (e *environmentImpl) setupDatabase(ctx context.Context) error {
 		return fmt.Errorf("invalid database config: %w", err)
 	}
 	e.DBSession = db.NewSessionFactory(e.Config.Database)
+	return nil
+}
+
+func (e *environmentImpl) initializeComputePolicy(context.Context) error {
+	e.ComputePolicy = computequota.NewSelfHostedPolicy()
+	if !e.Config.IsStackdomeCloud() {
+		return nil
+	}
+
+	cloudConfig := e.Config.StackdomeCloud
+	if cloudConfig == nil {
+		return fmt.Errorf("stackdome Cloud configuration is required")
+	}
+	computeAccess := computeaccess.NewService(computeaccess.ServiceSpec{
+		Store: pgstore.NewComputeAccessStore(pgstore.ComputeAccessStoreSpec{
+			SessionFactory:               e.DBSession,
+			MaxActiveSharedComputeLeases: cloudConfig.Access.MaxActiveSharedComputeLeases,
+		}),
+		DefaultEntitlementSource:   computeaccess.ComputeEntitlementSourceTrial,
+		DefaultEntitlementDuration: cloudConfig.Access.TrialEntitlementDuration.Duration(),
+	})
+	e.ComputePolicy = computequota.NewStackdomeCloudPolicy(computequota.StackdomeCloudPolicySpec{
+		ComputeAccess: computeAccess,
+		ComputeUsage:  pgstore.NewComputeUsageStore(),
+		Limits:        cloudConfig.Limits,
+	})
 	return nil
 }
 
@@ -494,10 +523,18 @@ func (e *environmentImpl) loadServices(ctx context.Context) error {
 		Permissions:    e.PermissionService,
 	})
 
+	orgRegistryDefaults := e.PlatformConfig.OrgRegistry
+	if e.Config.IsStackdomeCloud() {
+		orgRegistryDefaults = models.OrgRegistryDefaults{
+			StorageSize:  e.Config.StackdomeCloud.Registry.StorageSize,
+			StorageClass: e.Config.StackdomeCloud.Registry.StorageClass,
+		}
+	}
+
 	organisationService := services.NewOrganisationService(services.OrganisationServiceSpec{
 		OrganisationDomainService: organisationDomainService,
 		ImageRegistryService:      imageRegistryService,
-		OrgRegistryDefaults:       e.PlatformConfig.OrgRegistry,
+		OrgRegistryDefaults:       orgRegistryDefaults,
 		StackQueryService:         e.Services.StackService,
 		SessionFactory:            e.DBSession,
 		ProjectService:            projectService,
@@ -598,6 +635,7 @@ func (e *environmentImpl) loadServices(ctx context.Context) error {
 		Logger:           e.Logger,
 		Permissions:      e.PermissionService,
 		ReferenceService: referenceService,
+		ComputePolicy:    e.ComputePolicy,
 	})
 
 	resourceValidator := stackresourcevalidator.NewValidator(stackresourcevalidator.ValidatorSpec{
@@ -622,6 +660,7 @@ func (e *environmentImpl) loadServices(ctx context.Context) error {
 		StackDomainService:     stackDomainService,
 		ReferenceService:       referenceService,
 		ResourceValidator:      resourceValidator,
+		ComputePolicy:          e.ComputePolicy,
 	})
 
 	imageBuildService := services.NewImageBuildService(services.ImageBuildServiceSpec{
@@ -672,6 +711,7 @@ func (e *environmentImpl) loadServices(ctx context.Context) error {
 		Permissions:            e.PermissionService,
 		ReferenceService:       referenceService,
 		ExternalImportDisabled: externalPostgresImportDisabled,
+		ComputePolicy:          e.ComputePolicy,
 	})
 
 	stackService := services.NewStackService(services.StackServiceSpec{
@@ -690,6 +730,7 @@ func (e *environmentImpl) loadServices(ctx context.Context) error {
 		CredentialResolver:    credentialResolver,
 		GitIntegrationService: gitIntegrationService,
 		PlatformBaseDomain:    e.PlatformConfig.BaseDomain,
+		ComputePolicy:         e.ComputePolicy,
 	})
 
 	metricsService := services.NewMetricsService(services.MetricsServiceSpec{
@@ -754,6 +795,7 @@ func (e *environmentImpl) loadServices(ctx context.Context) error {
 		ReferenceService:   referenceService,
 		EventStore:         releaseEventStore,
 		EventRecorder:      releaseEventRecorder,
+		ComputePolicy:      e.ComputePolicy,
 	})
 
 	stackService.SetReleaseService(stackReleaseService)

--- a/cmd/environment/environment.go
+++ b/cmd/environment/environment.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Stackdome/stackdome/config"
 	"github.com/Stackdome/stackdome/pkg/auth"
 	"github.com/Stackdome/stackdome/pkg/clustermanager"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/db"
 	emailpkg "github.com/Stackdome/stackdome/pkg/email"
 	applogger "github.com/Stackdome/stackdome/pkg/logger"
@@ -41,6 +42,7 @@ type Env struct {
 	EmailService                emailpkg.EmailService
 	LeadershipFlag              *leadership.Flag
 	EncryptionService           services.EncryptionService
+	ComputePolicy               computequota.Policy
 	Logger                      applogger.Logger
 	Observability               *observability.Metrics
 }

--- a/config/application_config_test.go
+++ b/config/application_config_test.go
@@ -63,6 +63,10 @@ limits:
   maxPostgresAddonsPerOrganization: 1
   postgresInstances: 1
   maxPostgresStorageSize: 2Gi
+  postgresCPURequest: 50m
+  postgresCPULimit: 500m
+  postgresMemoryRequest: 128Mi
+  postgresMemoryLimit: 1Gi
   concurrentBuilds: 1
 registry:
   maxActiveRegistries: 200
@@ -375,6 +379,10 @@ func validStackdomeCloudConfigForTest() StackdomeCloudConfig {
 			MaxPostgresAddonsPerOrganization: 1,
 			PostgresInstances:                1,
 			MaxPostgresStorageSize:           "2Gi",
+			PostgresCPURequest:               "50m",
+			PostgresCPULimit:                 "500m",
+			PostgresMemoryRequest:            "128Mi",
+			PostgresMemoryLimit:              "1Gi",
 			ConcurrentBuilds:                 1,
 		},
 		Registry: StackdomeCloudRegistryConfig{

--- a/config/application_config_test.go
+++ b/config/application_config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -49,18 +50,24 @@ var _ = Describe("Runtime mode configuration", func() {
 	It("loads and validates the typed Stackdome Cloud YAML", func() {
 		path := filepath.Join(GinkgoT().TempDir(), "cloud.yaml")
 		Expect(os.WriteFile(path, []byte(`
-capacity:
-  maxActiveTrialAllocations: 200
-  allocationTTL: 6h
+access:
+  maxActiveSharedComputeLeases: 200
+  trialEntitlementDuration: 6h
 limits:
   maxStacksPerOrganization: 2
   maxStackResourcesPerOrganization: 6
   replicasPerStackResource: 1
+  maxVolumesPerOrganization: 2
+  maxVolumeSize: 2Gi
+  volumeStorageClass: longhorn
+  maxPostgresAddonsPerOrganization: 1
+  postgresInstances: 1
+  maxPostgresStorageSize: 2Gi
   concurrentBuilds: 1
 registry:
   maxActiveRegistries: 200
   storageClass: longhorn
-  storageSize: 10Gi
+  storageSize: 2Gi
 features:
   customDomains: false
   externalPostgresImport: false
@@ -92,12 +99,12 @@ signup:
 		Expect(cfg.LoadStackdomeCloudConfig()).To(Succeed())
 
 		Expect(cfg.IsStackdomeCloud()).To(BeTrue())
-		Expect(cfg.StackdomeCloud.Capacity.MaxActiveTrialAllocations).To(Equal(200))
-		Expect(cfg.StackdomeCloud.Capacity.AllocationTTL.Duration()).To(Equal(6 * time.Hour))
+		Expect(cfg.StackdomeCloud.Access.MaxActiveSharedComputeLeases).To(Equal(200))
+		Expect(cfg.StackdomeCloud.Access.TrialEntitlementDuration.Duration()).To(Equal(6 * time.Hour))
 		Expect(cfg.StackdomeCloud.Limits.MaxStackResourcesPerOrganization).To(Equal(int64(6)))
 		Expect(cfg.StackdomeCloud.Registry.MaxActiveRegistries).To(Equal(200))
 		Expect(cfg.StackdomeCloud.Registry.StorageClass).To(Equal("longhorn"))
-		Expect(cfg.StackdomeCloud.Registry.StorageSize).To(Equal("10Gi"))
+		Expect(cfg.StackdomeCloud.Registry.StorageSize).To(Equal("2Gi"))
 		Expect(cfg.StackdomeCloud.Features.WorkspaceUsers).To(BeFalse())
 	})
 
@@ -122,7 +129,7 @@ signup:
 	It("parses the checked-in Stackdome Cloud example", func() {
 		cloudConfig, err := LoadStackdomeCloudConfig("stackdome_cloud.example.yaml")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(cloudConfig.Capacity.MaxActiveTrialAllocations).To(Equal(200))
+		Expect(cloudConfig.Access.MaxActiveSharedComputeLeases).To(Equal(200))
 		Expect(cloudConfig.Registry.MaxActiveRegistries).To(Equal(200))
 		Expect(cloudConfig.Signup.ClientIPSource).To(Equal(StackdomeCloudClientIPSourceCloudflare))
 		Expect(cloudConfig.Signup.Throttle.IP.MaxTrackedClients).To(Equal(10_000))
@@ -321,7 +328,7 @@ var _ = Describe("Compute mode configuration", func() {
 		cfg.StackdomeCloud = &StackdomeCloudConfig{}
 
 		Expect(cfg.Validate()).To(MatchError(
-			"validate Stackdome Cloud config: capacity.maxActiveTrialAllocations must be greater than zero",
+			"validate Stackdome Cloud config: access.maxActiveSharedComputeLeases must be greater than zero",
 		))
 	})
 })
@@ -354,20 +361,26 @@ var _ = Describe("Shared compute environment", func() {
 
 func validStackdomeCloudConfigForTest() StackdomeCloudConfig {
 	return StackdomeCloudConfig{
-		Capacity: StackdomeCloudCapacityConfig{
-			MaxActiveTrialAllocations: 200,
-			AllocationTTL:             ConfigDuration(6 * time.Hour),
+		Access: StackdomeCloudComputeAccessConfig{
+			MaxActiveSharedComputeLeases: 200,
+			TrialEntitlementDuration:     ConfigDuration(6 * time.Hour),
 		},
-		Limits: StackdomeCloudLimitsConfig{
+		Limits: computequota.ComputeLimits{
 			MaxStacksPerOrganization:         2,
 			MaxStackResourcesPerOrganization: 6,
 			ReplicasPerStackResource:         1,
+			MaxVolumesPerOrganization:        2,
+			MaxVolumeSize:                    "2Gi",
+			VolumeStorageClass:               "longhorn",
+			MaxPostgresAddonsPerOrganization: 1,
+			PostgresInstances:                1,
+			MaxPostgresStorageSize:           "2Gi",
 			ConcurrentBuilds:                 1,
 		},
 		Registry: StackdomeCloudRegistryConfig{
 			MaxActiveRegistries: 200,
 			StorageClass:        "longhorn",
-			StorageSize:         "10Gi",
+			StorageSize:         "2Gi",
 		},
 		Signup: StackdomeCloudSignupConfig{
 			ClientIPSource: StackdomeCloudClientIPSourceCloudflare,

--- a/config/cloud_config.go
+++ b/config/cloud_config.go
@@ -140,6 +140,18 @@ func (c *StackdomeCloudConfig) Validate() error {
 	if err := validatePositiveQuantity("limits.maxPostgresStorageSize", c.Limits.MaxPostgresStorageSize); err != nil {
 		return err
 	}
+	if err := validateResourceRequestAndLimit(
+		"limits.postgresCPURequest", c.Limits.PostgresCPURequest,
+		"limits.postgresCPULimit", c.Limits.PostgresCPULimit,
+	); err != nil {
+		return err
+	}
+	if err := validateResourceRequestAndLimit(
+		"limits.postgresMemoryRequest", c.Limits.PostgresMemoryRequest,
+		"limits.postgresMemoryLimit", c.Limits.PostgresMemoryLimit,
+	); err != nil {
+		return err
+	}
 	if c.Limits.ConcurrentBuilds <= 0 {
 		return fmt.Errorf("limits.concurrentBuilds must be greater than zero")
 	}
@@ -209,6 +221,21 @@ func validatePositiveQuantity(field, value string) error {
 	}
 	if quantity.Sign() <= 0 {
 		return fmt.Errorf("%s must be greater than zero", field)
+	}
+	return nil
+}
+
+func validateResourceRequestAndLimit(requestField, requestValue, limitField, limitValue string) error {
+	if err := validatePositiveQuantity(requestField, requestValue); err != nil {
+		return err
+	}
+	if err := validatePositiveQuantity(limitField, limitValue); err != nil {
+		return err
+	}
+	request := resource.MustParse(requestValue)
+	limit := resource.MustParse(limitValue)
+	if request.Cmp(limit) > 0 {
+		return fmt.Errorf("%s must not exceed %s", requestField, limitField)
 	}
 	return nil
 }

--- a/config/cloud_config.go
+++ b/config/cloud_config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -36,23 +37,18 @@ func (d ConfigDuration) Duration() time.Duration {
 }
 
 type StackdomeCloudConfig struct {
-	Capacity StackdomeCloudCapacityConfig `yaml:"capacity" json:"capacity"`
-	Limits   StackdomeCloudLimitsConfig   `yaml:"limits" json:"limits"`
-	Registry StackdomeCloudRegistryConfig `yaml:"registry" json:"registry"`
-	Features StackdomeCloudFeaturesConfig `yaml:"features" json:"features"`
-	Signup   StackdomeCloudSignupConfig   `yaml:"signup" json:"signup"`
+	Access   StackdomeCloudComputeAccessConfig `yaml:"access" json:"access"`
+	Limits   computequota.ComputeLimits        `yaml:"limits" json:"limits"`
+	Registry StackdomeCloudRegistryConfig      `yaml:"registry" json:"registry"`
+	Features StackdomeCloudFeaturesConfig      `yaml:"features" json:"features"`
+	Signup   StackdomeCloudSignupConfig        `yaml:"signup" json:"signup"`
 }
 
-type StackdomeCloudCapacityConfig struct {
-	MaxActiveTrialAllocations int            `yaml:"maxActiveTrialAllocations" json:"max_active_trial_allocations"`
-	AllocationTTL             ConfigDuration `yaml:"allocationTTL" json:"allocation_ttl"`
-}
-
-type StackdomeCloudLimitsConfig struct {
-	MaxStacksPerOrganization         int64 `yaml:"maxStacksPerOrganization" json:"max_stacks_per_organization"`
-	MaxStackResourcesPerOrganization int64 `yaml:"maxStackResourcesPerOrganization" json:"max_stack_resources_per_organization"`
-	ReplicasPerStackResource         int32 `yaml:"replicasPerStackResource" json:"replicas_per_stack_resource"`
-	ConcurrentBuilds                 int   `yaml:"concurrentBuilds" json:"concurrent_builds"`
+// StackdomeCloudComputeAccessConfig configures the default trial grant and the
+// platform ceiling enforced when reserving shared compute.
+type StackdomeCloudComputeAccessConfig struct {
+	MaxActiveSharedComputeLeases int            `yaml:"maxActiveSharedComputeLeases" json:"max_active_shared_compute_leases"`
+	TrialEntitlementDuration     ConfigDuration `yaml:"trialEntitlementDuration" json:"trial_entitlement_duration"`
 }
 
 type StackdomeCloudRegistryConfig struct {
@@ -108,11 +104,11 @@ type StackdomeCloudEmailThrottleConfig struct {
 }
 
 func (c *StackdomeCloudConfig) Validate() error {
-	if c.Capacity.MaxActiveTrialAllocations <= 0 {
-		return fmt.Errorf("capacity.maxActiveTrialAllocations must be greater than zero")
+	if c.Access.MaxActiveSharedComputeLeases <= 0 {
+		return fmt.Errorf("access.maxActiveSharedComputeLeases must be greater than zero")
 	}
-	if c.Capacity.AllocationTTL.Duration() <= 0 {
-		return fmt.Errorf("capacity.allocationTTL must be greater than zero")
+	if c.Access.TrialEntitlementDuration.Duration() <= 0 {
+		return fmt.Errorf("access.trialEntitlementDuration must be greater than zero")
 	}
 	if c.Limits.MaxStacksPerOrganization <= 0 {
 		return fmt.Errorf("limits.maxStacksPerOrganization must be greater than zero")
@@ -122,6 +118,27 @@ func (c *StackdomeCloudConfig) Validate() error {
 	}
 	if c.Limits.ReplicasPerStackResource <= 0 {
 		return fmt.Errorf("limits.replicasPerStackResource must be greater than zero")
+	}
+	if c.Limits.MaxVolumesPerOrganization <= 0 {
+		return fmt.Errorf("limits.maxVolumesPerOrganization must be greater than zero")
+	}
+	if err := validatePositiveQuantity("limits.maxVolumeSize", c.Limits.MaxVolumeSize); err != nil {
+		return err
+	}
+	if c.Limits.VolumeStorageClass == "" {
+		return fmt.Errorf("limits.volumeStorageClass is required")
+	}
+	if problems := validation.IsDNS1123Subdomain(c.Limits.VolumeStorageClass); len(problems) > 0 {
+		return fmt.Errorf("limits.volumeStorageClass must be a valid Kubernetes name: %s", problems[0])
+	}
+	if c.Limits.MaxPostgresAddonsPerOrganization <= 0 {
+		return fmt.Errorf("limits.maxPostgresAddonsPerOrganization must be greater than zero")
+	}
+	if c.Limits.PostgresInstances <= 0 {
+		return fmt.Errorf("limits.postgresInstances must be greater than zero")
+	}
+	if err := validatePositiveQuantity("limits.maxPostgresStorageSize", c.Limits.MaxPostgresStorageSize); err != nil {
+		return err
 	}
 	if c.Limits.ConcurrentBuilds <= 0 {
 		return fmt.Errorf("limits.concurrentBuilds must be greater than zero")
@@ -141,12 +158,8 @@ func (c *StackdomeCloudConfig) Validate() error {
 	if c.Features.WorkspaceUsers {
 		return fmt.Errorf("features.workspaceUsers has been removed and must be false")
 	}
-	storageSize, err := resource.ParseQuantity(c.Registry.StorageSize)
-	if err != nil {
-		return fmt.Errorf("registry.storageSize must be a valid Kubernetes quantity: %w", err)
-	}
-	if storageSize.Sign() <= 0 {
-		return fmt.Errorf("registry.storageSize must be greater than zero")
+	if err := validatePositiveQuantity("registry.storageSize", c.Registry.StorageSize); err != nil {
+		return err
 	}
 	switch c.Signup.ClientIPSource {
 	case StackdomeCloudClientIPSourceCloudflare, StackdomeCloudClientIPSourceRemoteAddr:
@@ -185,6 +198,17 @@ func (c *StackdomeCloudConfig) Validate() error {
 	}
 	if c.Signup.Throttle.Email.Window.Duration() <= 0 {
 		return fmt.Errorf("signup.throttle.email.window must be greater than zero")
+	}
+	return nil
+}
+
+func validatePositiveQuantity(field, value string) error {
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return fmt.Errorf("%s must be a valid Kubernetes quantity: %w", field, err)
+	}
+	if quantity.Sign() <= 0 {
+		return fmt.Errorf("%s must be greater than zero", field)
 	}
 	return nil
 }

--- a/config/openapi/stackdome_api.yaml
+++ b/config/openapi/stackdome_api.yaml
@@ -6337,8 +6337,8 @@ components:
       properties:
         size:
           type: string
-          pattern: '^(|[0-9]+[KMGTP]i?)$'
-          description: Storage size (e.g., 10Gi, 100Gi). An empty value uses the runtime's configured default.
+          pattern: '^[0-9]+[KMGTP]i?$'
+          description: Storage size (e.g., 10Gi, 100Gi)
         storage_class:
           type: string
           description: Kubernetes storage class name. Omit to use the cluster's default storage class.

--- a/config/openapi/stackdome_api.yaml
+++ b/config/openapi/stackdome_api.yaml
@@ -6337,8 +6337,8 @@ components:
       properties:
         size:
           type: string
-          pattern: '^[0-9]+[KMGTP]i?$'
-          description: Storage size (e.g., 10Gi, 100Gi)
+          pattern: '^(|[0-9]+[KMGTP]i?)$'
+          description: Storage size (e.g., 10Gi, 100Gi). An empty value uses the runtime's configured default.
         storage_class:
           type: string
           description: Kubernetes storage class name. Omit to use the cluster's default storage class.

--- a/config/stackdome_cloud.dev.yaml
+++ b/config/stackdome_cloud.dev.yaml
@@ -1,0 +1,48 @@
+# Local Stackdome Cloud policy used by hack/run_local.sh.
+access:
+  maxActiveSharedComputeLeases: 200
+  trialEntitlementDuration: 6h
+
+limits:
+  maxStacksPerOrganization: 2
+  maxStackResourcesPerOrganization: 6
+  replicasPerStackResource: 1
+  maxVolumesPerOrganization: 2
+  maxVolumeSize: 2Gi
+  volumeStorageClass: local-path
+  maxPostgresAddonsPerOrganization: 1
+  postgresInstances: 1
+  maxPostgresStorageSize: 2Gi
+  # Basic plan: small scheduling requests with 0.5 CPU / 1Gi runtime limits.
+  postgresCPURequest: 50m
+  postgresCPULimit: 500m
+  postgresMemoryRequest: 128Mi
+  postgresMemoryLimit: 1Gi
+  concurrentBuilds: 1
+
+registry:
+  maxActiveRegistries: 200
+  storageClass: local-path
+  storageSize: 2Gi
+
+features:
+  customDomains: false
+  externalPostgresImport: false
+
+signup:
+  clientIPSource: remote_addr
+  turnstile:
+    enabled: true
+    siteKey: local-development-site-key
+    expectedHostname: localhost
+    expectedAction: signup
+    verificationTimeout: 5s
+  throttle:
+    ip:
+      maxTrackedClients: 100
+      maxAttempts: 20
+      window: 10m
+    email:
+      maxTrackedAddresses: 100
+      maxAttempts: 20
+      window: 1h

--- a/config/stackdome_cloud.example.yaml
+++ b/config/stackdome_cloud.example.yaml
@@ -1,15 +1,21 @@
 # Stackdome Cloud alpha runtime policy. Set RUNTIME_MODE=stackdome_cloud and
 # STACKDOME_CLOUD_CONFIG to this file's deployed path.
-capacity:
-  # An allocation starts when an organization first deploys, not at signup.
-  # Expired allocations continue consuming capacity until cleanup changes state.
-  maxActiveTrialAllocations: 200
-  allocationTTL: 6h
+access:
+  # A trial entitlement starts when an organization first consumes compute.
+  # Expired entitlements retain their lease until cleanup changes its state.
+  maxActiveSharedComputeLeases: 200
+  trialEntitlementDuration: 6h
 
 limits:
   maxStacksPerOrganization: 2
   maxStackResourcesPerOrganization: 6
   replicasPerStackResource: 1
+  maxVolumesPerOrganization: 2
+  maxVolumeSize: 2Gi
+  volumeStorageClass: longhorn
+  maxPostgresAddonsPerOrganization: 1
+  postgresInstances: 1
+  maxPostgresStorageSize: 2Gi
   # Deployment must set cloud-guard controller.maxConcurrentBuilds from this
   # same value. Hub validates this policy but does not schedule image builds.
   concurrentBuilds: 1
@@ -18,7 +24,7 @@ registry:
   # Registries are created lazily only when an organization starts a build.
   maxActiveRegistries: 200
   storageClass: longhorn
-  storageSize: 10Gi
+  storageSize: 2Gi
 
 features:
   customDomains: false

--- a/config/stackdome_cloud.example.yaml
+++ b/config/stackdome_cloud.example.yaml
@@ -16,6 +16,11 @@ limits:
   maxPostgresAddonsPerOrganization: 1
   postgresInstances: 1
   maxPostgresStorageSize: 2Gi
+  # Basic plan: small scheduling requests with 0.5 CPU / 1Gi runtime limits.
+  postgresCPURequest: 50m
+  postgresCPULimit: 500m
+  postgresMemoryRequest: 128Mi
+  postgresMemoryLimit: 1Gi
   # Deployment must set cloud-guard controller.maxConcurrentBuilds from this
   # same value. Hub validates this policy but does not schedule image builds.
   concurrentBuilds: 1

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -12416,8 +12416,9 @@ components:
         size: size
       properties:
         size:
-          description: "Storage size (e.g., 10Gi, 100Gi)"
-          pattern: "^[0-9]+[KMGTP]i?$"
+          description: "Storage size (e.g., 10Gi, 100Gi). An empty value uses the\
+            \ runtime's configured default."
+          pattern: "^(|[0-9]+[KMGTP]i?)$"
           type: string
         storage_class:
           description: Kubernetes storage class name. Omit to use the cluster's default

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -12416,9 +12416,8 @@ components:
         size: size
       properties:
         size:
-          description: "Storage size (e.g., 10Gi, 100Gi). An empty value uses the\
-            \ runtime's configured default."
-          pattern: "^(|[0-9]+[KMGTP]i?)$"
+          description: "Storage size (e.g., 10Gi, 100Gi)"
+          pattern: "^[0-9]+[KMGTP]i?$"
           type: string
         storage_class:
           description: Kubernetes storage class name. Omit to use the cluster's default

--- a/hack/run_local.sh
+++ b/hack/run_local.sh
@@ -26,6 +26,12 @@
 #   # Start environment only (no stack)
 #   ./hack/run_local.sh
 #
+#   # Start Stackdome Cloud with the local cluster as shared compute
+#   CLOUD_MODE=true ./hack/run_local.sh
+#
+#   # Recreate PostgreSQL when switching between BYOC and shared compute
+#   CLOUD_MODE=true FORCE_PG_RECREATE=true ./hack/run_local.sh
+#
 #   # Deploy a stack
 #   ./hack/run_local.sh samples/tooljet.json
 #
@@ -34,6 +40,7 @@
 #
 # Environment variables (all optional, defaults provided):
 #   API_PORT                   API server port (default: 8000)
+#   CLOUD_MODE                 Set to "true" for stackdome_cloud + shared compute
 #   ORG_DOMAIN                 Organisation domain (default: stackdome.127.0.0.1.nip.io)
 #   ADDON_FILE                 Postgres addon JSON file (creates addon before stack)
 #   SKIP_INFRA                 Set to "true" to skip mage dev:setup (reuse existing)
@@ -53,6 +60,7 @@ ADMIN_EMAIL="admin@stackdome.io"
 ADMIN_PASS="welcome@123"
 K3D_CLUSTER_NAME="${K3D_CLUSTER_NAME:-stackdome-dev}"
 ORG_DOMAIN="${ORG_DOMAIN:-stackdome.127.0.0.1.nip.io}"
+CLOUD_MODE="${CLOUD_MODE:-false}"
 SKIP_INFRA="${SKIP_INFRA:-false}"
 SKIP_API_SERVER="${SKIP_API_SERVER:-false}"
 FORCE_CLUSTER_RECREATE="${FORCE_CLUSTER_RECREATE:-false}"
@@ -98,6 +106,11 @@ trap 'exit 0' INT TERM
 # ============================================================
 check_prerequisites() {
     log "Checking prerequisites..."
+
+    if [[ "$CLOUD_MODE" != "true" && "$CLOUD_MODE" != "false" ]]; then
+        err "CLOUD_MODE must be either 'true' or 'false'"
+    fi
+
     local missing=()
     for cmd in go docker k3d kubectl jq mage helm; do
         if ! command -v "$cmd" &>/dev/null; then
@@ -206,6 +219,29 @@ DB_PASSWORD="${DB_PASSWORD}"
 DB_DEBUG_MODE="false"
 EOF
 
+    if [[ "$CLOUD_MODE" == "true" ]]; then
+        cat >> "$API_SERVER_DIR/.env" <<EOF
+RUNTIME_MODE="stackdome_cloud"
+COMPUTE_MODE="shared"
+SHARED_COMPUTE_CLUSTER_API_URL="${CLUSTER_URL}"
+SHARED_COMPUTE_CLUSTER_CA_DATA="${CLUSTER_CA}"
+SHARED_COMPUTE_CLUSTER_TOKEN="${SA_TOKEN}"
+PLATFORM_BASE_DOMAIN="${ORG_DOMAIN}"
+PLATFORM_TLS_ENABLED="true"
+PLATFORM_EMAIL="local@stackdome.dev"
+PLATFORM_DNS_CLOUDFLARE_API_TOKEN="local-development-token"
+PLATFORM_ACME_ENVIRONMENT="staging"
+PLATFORM_TLS_NAMESPACE="stackdome-control-plane"
+STACKDOME_CLOUD_CONFIG="${API_SERVER_DIR}/config/stackdome_cloud.dev.yaml"
+TURNSTILE_SECRET="local-development-secret"
+EOF
+    else
+        cat >> "$API_SERVER_DIR/.env" <<EOF
+RUNTIME_MODE="self_hosted"
+COMPUTE_MODE="bring_your_own"
+EOF
+    fi
+
     log "Running database migrations..."
     ./bin/stackdome-server migrate
 
@@ -288,6 +324,11 @@ api() {
 # Step 4: Ensure domain on organisation
 # ============================================================
 ensure_org_domain() {
+    if [[ "$CLOUD_MODE" == "true" ]]; then
+        log "Using Cloud platform domain '${ORG_DOMAIN}'."
+        return
+    fi
+
     log "Ensuring domain '${ORG_DOMAIN}' on organisation..."
     local org_response
     org_response=$(api GET "/api/v1/organizations/${ORG_ID}")
@@ -314,6 +355,20 @@ ensure_org_domain() {
 # Step 5: Ensure cluster is registered
 # ============================================================
 ensure_cluster_registered() {
+    if [[ "$CLOUD_MODE" == "true" ]]; then
+        log "Using the shared-compute cluster bootstrapped by the API server..."
+        CLUSTER_ID=$(docker exec -e PGPASSWORD="$DB_PASSWORD" "$PG_CONTAINER_NAME" \
+            psql -U "$DB_USERNAME" -d "$DB_NAME" -tAc \
+            "SELECT id FROM clusters WHERE shared_compute = TRUE ORDER BY id LIMIT 1" \
+            | tr -d '[:space:]')
+        if [[ -z "$CLUSTER_ID" ]]; then
+            err "Failed to find the bootstrapped shared-compute cluster."
+        fi
+        log "Shared-compute cluster ready. ID: ${CLUSTER_ID}"
+        log "The organisation registry remains pending until a build release needs it."
+        return
+    fi
+
     log "Ensuring cluster is registered..."
 
     # Check if a cluster is already registered
@@ -590,6 +645,11 @@ print_stack_info() {
 # ============================================================
 main() {
     log "Starting local Stackdome environment"
+    if [[ "$CLOUD_MODE" == "true" ]]; then
+        info "Mode: stackdome_cloud + shared"
+    else
+        info "Mode: self_hosted + bring_your_own"
+    fi
     if [[ -n "$STACK_FILE" ]]; then
         info "Stack file: ${STACK_FILE}"
     fi

--- a/pkg/api/openapi/api/openapi.yaml
+++ b/pkg/api/openapi/api/openapi.yaml
@@ -12416,8 +12416,9 @@ components:
         size: size
       properties:
         size:
-          description: "Storage size (e.g., 10Gi, 100Gi)"
-          pattern: "^[0-9]+[KMGTP]i?$"
+          description: "Storage size (e.g., 10Gi, 100Gi). An empty value uses the\
+            \ runtime's configured default."
+          pattern: "^(|[0-9]+[KMGTP]i?)$"
           type: string
         storage_class:
           description: Kubernetes storage class name. Omit to use the cluster's default

--- a/pkg/api/openapi/api/openapi.yaml
+++ b/pkg/api/openapi/api/openapi.yaml
@@ -12416,9 +12416,8 @@ components:
         size: size
       properties:
         size:
-          description: "Storage size (e.g., 10Gi, 100Gi). An empty value uses the\
-            \ runtime's configured default."
-          pattern: "^(|[0-9]+[KMGTP]i?)$"
+          description: "Storage size (e.g., 10Gi, 100Gi)"
+          pattern: "^[0-9]+[KMGTP]i?$"
           type: string
         storage_class:
           description: Kubernetes storage class name. Omit to use the cluster's default

--- a/pkg/api/openapi/docs/PostgresStorage.md
+++ b/pkg/api/openapi/docs/PostgresStorage.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Size** | **string** | Storage size (e.g., 10Gi, 100Gi) | 
+**Size** | **string** | Storage size (e.g., 10Gi, 100Gi). An empty value uses the runtime&#39;s configured default. |
 **StorageClass** | Pointer to **string** | Kubernetes storage class name. Omit to use the cluster&#39;s default storage class. | [optional] 
 
 ## Methods
@@ -73,5 +73,4 @@ HasStorageClass returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-
 

--- a/pkg/api/openapi/docs/PostgresStorage.md
+++ b/pkg/api/openapi/docs/PostgresStorage.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Size** | **string** | Storage size (e.g., 10Gi, 100Gi). An empty value uses the runtime&#39;s configured default. |
+**Size** | **string** | Storage size (e.g., 10Gi, 100Gi) |
 **StorageClass** | Pointer to **string** | Kubernetes storage class name. Omit to use the cluster&#39;s default storage class. | [optional] 
 
 ## Methods
@@ -73,4 +73,3 @@ HasStorageClass returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-

--- a/pkg/api/openapi/docs/PostgresStorage.md
+++ b/pkg/api/openapi/docs/PostgresStorage.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Size** | **string** | Storage size (e.g., 10Gi, 100Gi) |
+**Size** | **string** | Storage size (e.g., 10Gi, 100Gi) | 
 **StorageClass** | Pointer to **string** | Kubernetes storage class name. Omit to use the cluster&#39;s default storage class. | [optional] 
 
 ## Methods
@@ -73,3 +73,5 @@ HasStorageClass returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/pkg/api/openapi/model_postgres_storage.go
+++ b/pkg/api/openapi/model_postgres_storage.go
@@ -16,7 +16,7 @@ import (
 
 // PostgresStorage struct for PostgresStorage
 type PostgresStorage struct {
-	// Storage size (e.g., 10Gi, 100Gi)
+	// Storage size (e.g., 10Gi, 100Gi). An empty value uses the runtime's configured default.
 	Size string `json:"size"`
 	// Kubernetes storage class name. Omit to use the cluster's default storage class.
 	StorageClass *string `json:"storage_class,omitempty"`

--- a/pkg/api/openapi/model_postgres_storage.go
+++ b/pkg/api/openapi/model_postgres_storage.go
@@ -16,7 +16,7 @@ import (
 
 // PostgresStorage struct for PostgresStorage
 type PostgresStorage struct {
-	// Storage size (e.g., 10Gi, 100Gi). An empty value uses the runtime's configured default.
+	// Storage size (e.g., 10Gi, 100Gi)
 	Size string `json:"size"`
 	// Kubernetes storage class name. Omit to use the cluster's default storage class.
 	StorageClass *string `json:"storage_class,omitempty"`

--- a/pkg/computeaccess/service.go
+++ b/pkg/computeaccess/service.go
@@ -9,6 +9,9 @@ import (
 
 // Service manages the entitlement and shared-compute lease that back an
 // organisation's use of managed compute.
+// Activate creates the entitlement and shared-compute lease for an organisation on first use.
+// If they already exist, it returns the existing compute access.
+// Policy calls it to ensure access is granted before any compute is used.
 type Service interface {
 	Activate(ctx context.Context, organisationID string) (*ComputeAccess, *errors.ServiceError)
 }

--- a/pkg/computeaccess/service.go
+++ b/pkg/computeaccess/service.go
@@ -1,0 +1,58 @@
+package computeaccess
+
+import (
+	"context"
+	"time"
+
+	"github.com/Stackdome/stackdome/pkg/errors"
+)
+
+// Service manages the entitlement and shared-compute lease that back an
+// organisation's use of managed compute.
+type Service interface {
+	Activate(ctx context.Context, organisationID string) (*ComputeAccess, *errors.ServiceError)
+}
+
+type ServiceSpec struct {
+	Store                      Store
+	DefaultEntitlementSource   ComputeEntitlementSource
+	DefaultEntitlementDuration time.Duration
+	Now                        func() time.Time
+}
+
+type service struct {
+	store                      Store
+	defaultEntitlementSource   ComputeEntitlementSource
+	defaultEntitlementDuration time.Duration
+	now                        func() time.Time
+}
+
+// NewService configures the default entitlement issued when managed compute is
+// activated for the first time.
+func NewService(spec ServiceSpec) Service {
+	now := spec.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &service{
+		store:                      spec.Store,
+		defaultEntitlementSource:   spec.DefaultEntitlementSource,
+		defaultEntitlementDuration: spec.DefaultEntitlementDuration,
+		now:                        now,
+	}
+}
+
+func (s *service) Activate(ctx context.Context, organisationID string) (*ComputeAccess, *errors.ServiceError) {
+	now := s.now()
+	var expiresAt *time.Time
+	if s.defaultEntitlementDuration > 0 {
+		expires := now.Add(s.defaultEntitlementDuration)
+		expiresAt = &expires
+	}
+	return s.store.Activate(ctx, ComputeAccessActivation{
+		OrganisationID:    organisationID,
+		EntitlementSource: s.defaultEntitlementSource,
+		StartsAt:          now,
+		ExpiresAt:         expiresAt,
+	})
+}

--- a/pkg/computeaccess/store.go
+++ b/pkg/computeaccess/store.go
@@ -1,0 +1,23 @@
+package computeaccess
+
+import (
+	"context"
+	"time"
+
+	"github.com/Stackdome/stackdome/pkg/errors"
+)
+
+// ComputeAccessActivation describes the entitlement an organisation receives.
+// Platform capacity is store configuration, not activation input.
+type ComputeAccessActivation struct {
+	OrganisationID    string
+	EntitlementSource ComputeEntitlementSource
+	StartsAt          time.Time
+	ExpiresAt         *time.Time
+}
+
+// Store atomically persists an entitlement and its shared-compute lease with
+// the capacity-consuming resource that first activates them.
+type Store interface {
+	Activate(ctx context.Context, activation ComputeAccessActivation) (*ComputeAccess, *errors.ServiceError)
+}

--- a/pkg/computeaccess/types.go
+++ b/pkg/computeaccess/types.go
@@ -1,0 +1,56 @@
+package computeaccess
+
+import "time"
+
+type ComputeEntitlementSource string
+
+const ComputeEntitlementSourceTrial ComputeEntitlementSource = "trial"
+
+type ComputeEntitlementStatus string
+
+const ComputeEntitlementStatusActive ComputeEntitlementStatus = "active"
+
+// ComputeEntitlement records why an organisation may use compute.
+type ComputeEntitlement struct {
+	ID             string                   `gorm:"primary_key;default:gen_random_uuid()" json:"id"`
+	OrganisationID string                   `gorm:"not null;uniqueIndex:idx_compute_entitlement_org_source" json:"organisation_id"`
+	Source         ComputeEntitlementSource `gorm:"not null;uniqueIndex:idx_compute_entitlement_org_source" json:"source"`
+	Status         ComputeEntitlementStatus `gorm:"not null" json:"status"`
+	StartsAt       time.Time                `gorm:"not null" json:"starts_at"`
+	ExpiresAt      *time.Time               `gorm:"index" json:"expires_at,omitempty"`
+	CreatedAt      time.Time                `json:"created_at"`
+	UpdatedAt      time.Time                `json:"updated_at"`
+}
+
+type SharedComputeLeaseState string
+
+const (
+	SharedComputeLeaseStateActive         SharedComputeLeaseState = "active"
+	SharedComputeLeaseStateCleanupPending SharedComputeLeaseState = "cleanup_pending"
+	SharedComputeLeaseStateCleaning       SharedComputeLeaseState = "cleaning"
+	SharedComputeLeaseStateCleaned        SharedComputeLeaseState = "cleaned"
+	SharedComputeLeaseStateError          SharedComputeLeaseState = "error"
+)
+
+// SharedComputeLease records platform capacity reserved for an organisation.
+// Capacity remains reserved until runtime cleanup reaches the cleaned state.
+type SharedComputeLease struct {
+	ID               string                  `gorm:"primary_key;default:gen_random_uuid()" json:"id"`
+	OrganisationID   string                  `gorm:"not null;index" json:"organisation_id"`
+	EntitlementID    string                  `gorm:"not null;uniqueIndex" json:"entitlement_id"`
+	State            SharedComputeLeaseState `gorm:"not null" json:"state"`
+	ActivatedAt      time.Time               `gorm:"not null" json:"activated_at"`
+	CleanupStartedAt *time.Time              `json:"cleanup_started_at,omitempty"`
+	CleanedUpAt      *time.Time              `json:"cleaned_up_at,omitempty"`
+	ErrorAt          *time.Time              `json:"error_at,omitempty"`
+	ErrorMessage     string                  `json:"error_message,omitempty"`
+	CreatedAt        time.Time               `json:"created_at"`
+	UpdatedAt        time.Time               `json:"updated_at"`
+}
+
+// ComputeAccess groups an entitlement and its shared-capacity lease. It is not
+// persisted as its own record.
+type ComputeAccess struct {
+	Entitlement *ComputeEntitlement
+	Lease       *SharedComputeLease
+}

--- a/pkg/computequota/computequota_suite_test.go
+++ b/pkg/computequota/computequota_suite_test.go
@@ -1,0 +1,13 @@
+package computequota
+
+import (
+	"testing"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+)
+
+func TestComputeQuota(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "ComputeQuota Suite")
+}

--- a/pkg/computequota/limit_changes.go
+++ b/pkg/computequota/limit_changes.go
@@ -1,0 +1,16 @@
+package computequota
+
+import "github.com/Stackdome/stackdome/pkg/models"
+
+// VolumeLimitChange describes a proposed volume creation.
+type VolumeLimitChange struct {
+	OrganisationID string
+	Size           string
+}
+
+// PostgresAddonLimitChange describes a proposed PostgreSQL addon create or update.
+type PostgresAddonLimitChange struct {
+	OrganisationID string
+	CreatesAddon   bool
+	Addon          *models.PostgresAddon
+}

--- a/pkg/computequota/limits.go
+++ b/pkg/computequota/limits.go
@@ -12,6 +12,10 @@ type ComputeLimits struct {
 	MaxPostgresAddonsPerOrganization int64  `yaml:"maxPostgresAddonsPerOrganization" json:"max_postgres_addons_per_organization"`
 	PostgresInstances                int    `yaml:"postgresInstances" json:"postgres_instances"`
 	MaxPostgresStorageSize           string `yaml:"maxPostgresStorageSize" json:"max_postgres_storage_size"`
+	PostgresCPURequest               string `yaml:"postgresCPURequest" json:"postgres_cpu_request"`
+	PostgresCPULimit                 string `yaml:"postgresCPULimit" json:"postgres_cpu_limit"`
+	PostgresMemoryRequest            string `yaml:"postgresMemoryRequest" json:"postgres_memory_request"`
+	PostgresMemoryLimit              string `yaml:"postgresMemoryLimit" json:"postgres_memory_limit"`
 	// ConcurrentBuilds is informational here; request quota policy does not
 	// enforce build scheduling.
 	ConcurrentBuilds int `yaml:"concurrentBuilds" json:"concurrent_builds"`

--- a/pkg/computequota/limits.go
+++ b/pkg/computequota/limits.go
@@ -1,0 +1,18 @@
+package computequota
+
+// ComputeLimits is runtime configuration for an organisation's use of managed
+// compute. It is a value object and is not persisted.
+type ComputeLimits struct {
+	MaxStacksPerOrganization         int64  `yaml:"maxStacksPerOrganization" json:"max_stacks_per_organization"`
+	MaxStackResourcesPerOrganization int64  `yaml:"maxStackResourcesPerOrganization" json:"max_stack_resources_per_organization"`
+	ReplicasPerStackResource         int32  `yaml:"replicasPerStackResource" json:"replicas_per_stack_resource"`
+	MaxVolumesPerOrganization        int64  `yaml:"maxVolumesPerOrganization" json:"max_volumes_per_organization"`
+	MaxVolumeSize                    string `yaml:"maxVolumeSize" json:"max_volume_size"`
+	VolumeStorageClass               string `yaml:"volumeStorageClass" json:"volume_storage_class"`
+	MaxPostgresAddonsPerOrganization int64  `yaml:"maxPostgresAddonsPerOrganization" json:"max_postgres_addons_per_organization"`
+	PostgresInstances                int    `yaml:"postgresInstances" json:"postgres_instances"`
+	MaxPostgresStorageSize           string `yaml:"maxPostgresStorageSize" json:"max_postgres_storage_size"`
+	// ConcurrentBuilds is informational here; request quota policy does not
+	// enforce build scheduling.
+	ConcurrentBuilds int `yaml:"concurrentBuilds" json:"concurrent_builds"`
+}

--- a/pkg/computequota/policy.go
+++ b/pkg/computequota/policy.go
@@ -59,6 +59,10 @@ type stackdomeCloudPolicy struct {
 	limits                 ComputeLimits
 	maxVolumeSize          resource.Quantity
 	maxPostgresStorageSize resource.Quantity
+	postgresCPURequest     resource.Quantity
+	postgresCPULimit       resource.Quantity
+	postgresMemoryRequest  resource.Quantity
+	postgresMemoryLimit    resource.Quantity
 }
 
 type StackdomeCloudPolicySpec struct {
@@ -74,6 +78,10 @@ func NewStackdomeCloudPolicy(spec StackdomeCloudPolicySpec) Policy {
 		limits:                 spec.Limits,
 		maxVolumeSize:          mustParsePolicyQuantity("MaxVolumeSize", spec.Limits.MaxVolumeSize),
 		maxPostgresStorageSize: mustParsePolicyQuantity("MaxPostgresStorageSize", spec.Limits.MaxPostgresStorageSize),
+		postgresCPURequest:     mustParsePolicyQuantity("PostgresCPURequest", spec.Limits.PostgresCPURequest),
+		postgresCPULimit:       mustParsePolicyQuantity("PostgresCPULimit", spec.Limits.PostgresCPULimit),
+		postgresMemoryRequest:  mustParsePolicyQuantity("PostgresMemoryRequest", spec.Limits.PostgresMemoryRequest),
+		postgresMemoryLimit:    mustParsePolicyQuantity("PostgresMemoryLimit", spec.Limits.PostgresMemoryLimit),
 	}
 }
 
@@ -164,6 +172,29 @@ func (p *stackdomeCloudPolicy) ValidatePostgresAddonLimits(ctx context.Context, 
 	if requested.Cmp(p.maxPostgresStorageSize) > 0 {
 		return errors.ComputeQuotaExceeded("Stackdome Cloud allows a maximum PostgreSQL addon storage size of %s", p.limits.MaxPostgresStorageSize)
 	}
+	if serr := requireExactPostgresResource("CPU request", change.Addon.Resources.CPU.Request, p.limits.PostgresCPURequest, p.postgresCPURequest); serr != nil {
+		return serr
+	}
+	if serr := requireExactPostgresResource("CPU limit", change.Addon.Resources.CPU.Limit, p.limits.PostgresCPULimit, p.postgresCPULimit); serr != nil {
+		return serr
+	}
+	if serr := requireExactPostgresResource("memory request", change.Addon.Resources.Memory.Request, p.limits.PostgresMemoryRequest, p.postgresMemoryRequest); serr != nil {
+		return serr
+	}
+	if serr := requireExactPostgresResource("memory limit", change.Addon.Resources.Memory.Limit, p.limits.PostgresMemoryLimit, p.postgresMemoryLimit); serr != nil {
+		return serr
+	}
+	return nil
+}
+
+func requireExactPostgresResource(name, value, configured string, expected resource.Quantity) *errors.ServiceError {
+	actual, err := resource.ParseQuantity(value)
+	if err != nil || actual.Sign() <= 0 {
+		return errors.BadRequest("PostgreSQL addon %s must be a positive Kubernetes quantity", name)
+	}
+	if actual.Cmp(expected) != 0 {
+		return errors.ComputeQuotaExceeded("Stackdome Cloud PostgreSQL addons must use %s %s", configured, name)
+	}
 	return nil
 }
 
@@ -180,4 +211,15 @@ func (p *stackdomeCloudPolicy) ApplyPostgresAddonDefaults(addon *models.Postgres
 	if addon.Instances.Count == 0 {
 		addon.Instances.Count = p.limits.PostgresInstances
 	}
+
+	resourcesUnset := addon.Resources.CPU.Request == "" && addon.Resources.CPU.Limit == "" &&
+		addon.Resources.Memory.Request == "" && addon.Resources.Memory.Limit == ""
+	if resourcesUnset {
+		addon.Resources.CPU.Limit = p.limits.PostgresCPULimit
+		addon.Resources.Memory.Limit = p.limits.PostgresMemoryLimit
+	}
+	// Cloud owns scheduling requests so the advertised Basic limits can share
+	// nodes efficiently without trusting client-selected reservations.
+	addon.Resources.CPU.Request = p.limits.PostgresCPURequest
+	addon.Resources.Memory.Request = p.limits.PostgresMemoryRequest
 }

--- a/pkg/computequota/policy.go
+++ b/pkg/computequota/policy.go
@@ -15,13 +15,15 @@ import (
 type Policy interface {
 	EnsureAccess(ctx context.Context, organisationID string) *errors.ServiceError
 	ValidateStackLimits(ctx context.Context, change StackLimitChange) *errors.ServiceError
-	ValidateVolumeLimits(ctx context.Context, organisationID, size string) *errors.ServiceError
-	ValidatePostgresAddonLimits(ctx context.Context, organisationID, existingAddonID string, addon *models.PostgresAddon) *errors.ServiceError
+	ValidateVolumeLimits(ctx context.Context, change VolumeLimitChange) *errors.ServiceError
+	ValidatePostgresAddonLimits(ctx context.Context, change PostgresAddonLimitChange) *errors.ServiceError
 	ApplyStackResourceDefaults(resource *models.StackResource)
 	ApplyVolumeDefaults(volume *models.Volume)
 	ApplyPostgresAddonDefaults(addon *models.PostgresAddon)
 }
 
+// --------  SELF-HOSTED POLICY  --------
+// Self hosted policy is a no-op policy for self-hosted environments.
 type selfHostedPolicy struct{}
 
 func NewSelfHostedPolicy() Policy {
@@ -36,11 +38,11 @@ func (selfHostedPolicy) ValidateStackLimits(context.Context, StackLimitChange) *
 	return nil
 }
 
-func (selfHostedPolicy) ValidateVolumeLimits(context.Context, string, string) *errors.ServiceError {
+func (selfHostedPolicy) ValidateVolumeLimits(context.Context, VolumeLimitChange) *errors.ServiceError {
 	return nil
 }
 
-func (selfHostedPolicy) ValidatePostgresAddonLimits(context.Context, string, string, *models.PostgresAddon) *errors.ServiceError {
+func (selfHostedPolicy) ValidatePostgresAddonLimits(context.Context, PostgresAddonLimitChange) *errors.ServiceError {
 	return nil
 }
 
@@ -50,6 +52,7 @@ func (selfHostedPolicy) ApplyVolumeDefaults(*models.Volume) {}
 
 func (selfHostedPolicy) ApplyPostgresAddonDefaults(*models.PostgresAddon) {}
 
+// ---  STACKDOME CLOUD POLICY  ---
 type stackdomeCloudPolicy struct {
 	computeAccess          computeaccess.Service
 	computeUsage           UsageStore
@@ -88,12 +91,19 @@ func (p *stackdomeCloudPolicy) EnsureAccess(ctx context.Context, organisationID 
 }
 
 func (p *stackdomeCloudPolicy) ValidateStackLimits(ctx context.Context, change StackLimitChange) *errors.ServiceError {
-	excludeStackID, serr := stackResourceExclusionFor(change)
-	if serr != nil {
-		return serr
+	replacedStackID := ""
+	switch change.Operation {
+	case StackLimitReplaceStack:
+		if change.ReplacedStackID == "" {
+			return errors.GeneralError("replaced stack ID is required for a whole-stack update")
+		}
+		replacedStackID = change.ReplacedStackID
+	case StackLimitCreateStack, StackLimitAddResource, StackLimitUpdateResource:
+	default:
+		return errors.GeneralError("unsupported stack limit operation %q", change.Operation)
 	}
 
-	currentUsage, serr := p.computeUsage.LockOrganisationAndGetUsage(ctx, change.OrganisationID, excludeStackID)
+	currentUsage, serr := p.computeUsage.LockOrganisationAndGetUsage(ctx, change.OrganisationID, replacedStackID)
 	if serr != nil {
 		return serr
 	}
@@ -111,8 +121,8 @@ func (p *stackdomeCloudPolicy) ValidateStackLimits(ctx context.Context, change S
 	return nil
 }
 
-func (p *stackdomeCloudPolicy) ValidateVolumeLimits(ctx context.Context, organisationID, size string) *errors.ServiceError {
-	usage, serr := p.computeUsage.LockOrganisationAndGetUsage(ctx, organisationID, "")
+func (p *stackdomeCloudPolicy) ValidateVolumeLimits(ctx context.Context, change VolumeLimitChange) *errors.ServiceError {
+	usage, serr := p.computeUsage.LockOrganisationAndGetUsage(ctx, change.OrganisationID, "")
 	if serr != nil {
 		return serr
 	}
@@ -120,7 +130,7 @@ func (p *stackdomeCloudPolicy) ValidateVolumeLimits(ctx context.Context, organis
 		return errors.ComputeQuotaExceeded("Stackdome Cloud allows a maximum of %d volumes per organisation", p.limits.MaxVolumesPerOrganization)
 	}
 
-	requested, err := resource.ParseQuantity(size)
+	requested, err := resource.ParseQuantity(change.Size)
 	if err != nil || requested.Sign() <= 0 {
 		return errors.BadRequest("volume size must be a positive Kubernetes quantity")
 	}
@@ -130,24 +140,24 @@ func (p *stackdomeCloudPolicy) ValidateVolumeLimits(ctx context.Context, organis
 	return nil
 }
 
-func (p *stackdomeCloudPolicy) ValidatePostgresAddonLimits(ctx context.Context, organisationID, existingAddonID string, addon *models.PostgresAddon) *errors.ServiceError {
-	usage, serr := p.computeUsage.LockOrganisationAndGetUsage(ctx, organisationID, "")
+func (p *stackdomeCloudPolicy) ValidatePostgresAddonLimits(ctx context.Context, change PostgresAddonLimitChange) *errors.ServiceError {
+	usage, serr := p.computeUsage.LockOrganisationAndGetUsage(ctx, change.OrganisationID, "")
 	if serr != nil {
 		return serr
 	}
 
 	addonCount := usage.PostgresAddonCount
-	if existingAddonID == "" {
+	if change.CreatesAddon {
 		addonCount++
 	}
 	if addonCount > p.limits.MaxPostgresAddonsPerOrganization {
 		return errors.ComputeQuotaExceeded("Stackdome Cloud allows a maximum of %d PostgreSQL addon per organisation", p.limits.MaxPostgresAddonsPerOrganization)
 	}
-	if addon.Instances.Count != p.limits.PostgresInstances {
+	if change.Addon.Instances.Count != p.limits.PostgresInstances {
 		return errors.ComputeQuotaExceeded("Stackdome Cloud PostgreSQL addons must use exactly %d instance", p.limits.PostgresInstances)
 	}
 
-	requested, err := resource.ParseQuantity(addon.Storage.Size)
+	requested, err := resource.ParseQuantity(change.Addon.Storage.Size)
 	if err != nil || requested.Sign() <= 0 {
 		return errors.BadRequest("PostgreSQL addon storage size must be a positive Kubernetes quantity")
 	}
@@ -163,12 +173,7 @@ func (p *stackdomeCloudPolicy) ApplyStackResourceDefaults(stackResource *models.
 }
 
 func (p *stackdomeCloudPolicy) ApplyVolumeDefaults(volume *models.Volume) {
-	if volume.Size == "" {
-		volume.Size = p.limits.MaxVolumeSize
-	}
-	if volume.StorageClass == "" {
-		volume.StorageClass = p.limits.VolumeStorageClass
-	}
+	volume.StorageClass = p.limits.VolumeStorageClass
 }
 
 func (p *stackdomeCloudPolicy) ApplyPostgresAddonDefaults(addon *models.PostgresAddon) {

--- a/pkg/computequota/policy.go
+++ b/pkg/computequota/policy.go
@@ -175,7 +175,4 @@ func (p *stackdomeCloudPolicy) ApplyPostgresAddonDefaults(addon *models.Postgres
 	if addon.Instances.Count == 0 {
 		addon.Instances.Count = p.limits.PostgresInstances
 	}
-	if addon.Storage.Size == "" {
-		addon.Storage.Size = p.limits.MaxPostgresStorageSize
-	}
 }

--- a/pkg/computequota/policy.go
+++ b/pkg/computequota/policy.go
@@ -1,0 +1,181 @@
+package computequota
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Stackdome/stackdome/pkg/computeaccess"
+	"github.com/Stackdome/stackdome/pkg/errors"
+	"github.com/Stackdome/stackdome/pkg/models"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// Policy keeps request-layer access checks, limits, and runtime-owned defaults
+// out of request services.
+type Policy interface {
+	EnsureAccess(ctx context.Context, organisationID string) *errors.ServiceError
+	ValidateStackLimits(ctx context.Context, change StackLimitChange) *errors.ServiceError
+	ValidateVolumeLimits(ctx context.Context, organisationID, size string) *errors.ServiceError
+	ValidatePostgresAddonLimits(ctx context.Context, organisationID, existingAddonID string, addon *models.PostgresAddon) *errors.ServiceError
+	ApplyStackResourceDefaults(resource *models.StackResource)
+	ApplyVolumeDefaults(volume *models.Volume)
+	ApplyPostgresAddonDefaults(addon *models.PostgresAddon)
+}
+
+type selfHostedPolicy struct{}
+
+func NewSelfHostedPolicy() Policy {
+	return selfHostedPolicy{}
+}
+
+func (selfHostedPolicy) EnsureAccess(context.Context, string) *errors.ServiceError {
+	return nil
+}
+
+func (selfHostedPolicy) ValidateStackLimits(context.Context, StackLimitChange) *errors.ServiceError {
+	return nil
+}
+
+func (selfHostedPolicy) ValidateVolumeLimits(context.Context, string, string) *errors.ServiceError {
+	return nil
+}
+
+func (selfHostedPolicy) ValidatePostgresAddonLimits(context.Context, string, string, *models.PostgresAddon) *errors.ServiceError {
+	return nil
+}
+
+func (selfHostedPolicy) ApplyStackResourceDefaults(*models.StackResource) {}
+
+func (selfHostedPolicy) ApplyVolumeDefaults(*models.Volume) {}
+
+func (selfHostedPolicy) ApplyPostgresAddonDefaults(*models.PostgresAddon) {}
+
+type stackdomeCloudPolicy struct {
+	computeAccess          computeaccess.Service
+	computeUsage           UsageStore
+	limits                 ComputeLimits
+	maxVolumeSize          resource.Quantity
+	maxPostgresStorageSize resource.Quantity
+}
+
+type StackdomeCloudPolicySpec struct {
+	ComputeAccess computeaccess.Service
+	ComputeUsage  UsageStore
+	Limits        ComputeLimits
+}
+
+func NewStackdomeCloudPolicy(spec StackdomeCloudPolicySpec) Policy {
+	return &stackdomeCloudPolicy{
+		computeAccess:          spec.ComputeAccess,
+		computeUsage:           spec.ComputeUsage,
+		limits:                 spec.Limits,
+		maxVolumeSize:          mustParsePolicyQuantity("MaxVolumeSize", spec.Limits.MaxVolumeSize),
+		maxPostgresStorageSize: mustParsePolicyQuantity("MaxPostgresStorageSize", spec.Limits.MaxPostgresStorageSize),
+	}
+}
+
+func mustParsePolicyQuantity(name, value string) resource.Quantity {
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil || quantity.Sign() <= 0 {
+		panic(fmt.Sprintf("computequota.NewStackdomeCloudPolicy: %s must be a positive Kubernetes quantity", name))
+	}
+	return quantity
+}
+
+func (p *stackdomeCloudPolicy) EnsureAccess(ctx context.Context, organisationID string) *errors.ServiceError {
+	_, serr := p.computeAccess.Activate(ctx, organisationID)
+	return serr
+}
+
+func (p *stackdomeCloudPolicy) ValidateStackLimits(ctx context.Context, change StackLimitChange) *errors.ServiceError {
+	excludeStackID, serr := stackResourceExclusionFor(change)
+	if serr != nil {
+		return serr
+	}
+
+	currentUsage, serr := p.computeUsage.LockOrganisationAndGetUsage(ctx, change.OrganisationID, excludeStackID)
+	if serr != nil {
+		return serr
+	}
+
+	proposedUsage, serr := stackUsageAfterChange(currentUsage, change)
+	if serr != nil {
+		return serr
+	}
+	if proposedUsage.StackCount > p.limits.MaxStacksPerOrganization {
+		return errors.ComputeQuotaExceeded("Stackdome Cloud allows a maximum of %d stacks per organisation", p.limits.MaxStacksPerOrganization)
+	}
+	if proposedUsage.StackResourceCount > p.limits.MaxStackResourcesPerOrganization {
+		return errors.ComputeQuotaExceeded("Stackdome Cloud allows a maximum of %d stack resources per organisation", p.limits.MaxStackResourcesPerOrganization)
+	}
+	return nil
+}
+
+func (p *stackdomeCloudPolicy) ValidateVolumeLimits(ctx context.Context, organisationID, size string) *errors.ServiceError {
+	usage, serr := p.computeUsage.LockOrganisationAndGetUsage(ctx, organisationID, "")
+	if serr != nil {
+		return serr
+	}
+	if usage.VolumeCount+1 > p.limits.MaxVolumesPerOrganization {
+		return errors.ComputeQuotaExceeded("Stackdome Cloud allows a maximum of %d volumes per organisation", p.limits.MaxVolumesPerOrganization)
+	}
+
+	requested, err := resource.ParseQuantity(size)
+	if err != nil || requested.Sign() <= 0 {
+		return errors.BadRequest("volume size must be a positive Kubernetes quantity")
+	}
+	if requested.Cmp(p.maxVolumeSize) > 0 {
+		return errors.ComputeQuotaExceeded("Stackdome Cloud allows a maximum volume size of %s", p.limits.MaxVolumeSize)
+	}
+	return nil
+}
+
+func (p *stackdomeCloudPolicy) ValidatePostgresAddonLimits(ctx context.Context, organisationID, existingAddonID string, addon *models.PostgresAddon) *errors.ServiceError {
+	usage, serr := p.computeUsage.LockOrganisationAndGetUsage(ctx, organisationID, "")
+	if serr != nil {
+		return serr
+	}
+
+	addonCount := usage.PostgresAddonCount
+	if existingAddonID == "" {
+		addonCount++
+	}
+	if addonCount > p.limits.MaxPostgresAddonsPerOrganization {
+		return errors.ComputeQuotaExceeded("Stackdome Cloud allows a maximum of %d PostgreSQL addon per organisation", p.limits.MaxPostgresAddonsPerOrganization)
+	}
+	if addon.Instances.Count != p.limits.PostgresInstances {
+		return errors.ComputeQuotaExceeded("Stackdome Cloud PostgreSQL addons must use exactly %d instance", p.limits.PostgresInstances)
+	}
+
+	requested, err := resource.ParseQuantity(addon.Storage.Size)
+	if err != nil || requested.Sign() <= 0 {
+		return errors.BadRequest("PostgreSQL addon storage size must be a positive Kubernetes quantity")
+	}
+	if requested.Cmp(p.maxPostgresStorageSize) > 0 {
+		return errors.ComputeQuotaExceeded("Stackdome Cloud allows a maximum PostgreSQL addon storage size of %s", p.limits.MaxPostgresStorageSize)
+	}
+	return nil
+}
+
+func (p *stackdomeCloudPolicy) ApplyStackResourceDefaults(stackResource *models.StackResource) {
+	replicas := p.limits.ReplicasPerStackResource
+	stackResource.Replicas = &replicas
+}
+
+func (p *stackdomeCloudPolicy) ApplyVolumeDefaults(volume *models.Volume) {
+	if volume.Size == "" {
+		volume.Size = p.limits.MaxVolumeSize
+	}
+	if volume.StorageClass == "" {
+		volume.StorageClass = p.limits.VolumeStorageClass
+	}
+}
+
+func (p *stackdomeCloudPolicy) ApplyPostgresAddonDefaults(addon *models.PostgresAddon) {
+	if addon.Instances.Count == 0 {
+		addon.Instances.Count = p.limits.PostgresInstances
+	}
+	if addon.Storage.Size == "" {
+		addon.Storage.Size = p.limits.MaxPostgresStorageSize
+	}
+}

--- a/pkg/computequota/policy_test.go
+++ b/pkg/computequota/policy_test.go
@@ -21,15 +21,15 @@ func (f *fakeComputeAccessService) Activate(_ context.Context, organisationID st
 }
 
 type fakeComputeUsageStore struct {
-	usage          ComputeUsage
-	err            *stackerrors.ServiceError
-	organisationID string
-	excludeStackID string
+	usage           ComputeUsage
+	err             *stackerrors.ServiceError
+	organisationID  string
+	replacedStackID string
 }
 
-func (f *fakeComputeUsageStore) LockOrganisationAndGetUsage(_ context.Context, organisationID, excludeStackID string) (ComputeUsage, *stackerrors.ServiceError) {
+func (f *fakeComputeUsageStore) LockOrganisationAndGetUsage(_ context.Context, organisationID, replacedStackID string) (ComputeUsage, *stackerrors.ServiceError) {
 	f.organisationID = organisationID
-	f.excludeStackID = excludeStackID
+	f.replacedStackID = replacedStackID
 	return f.usage, f.err
 }
 
@@ -47,8 +47,15 @@ var _ = ginkgo.Describe("Compute policy", func() {
 
 			gomega.Expect(policy.EnsureAccess(context.Background(), "org-1")).NotTo(gomega.HaveOccurred())
 			gomega.Expect(policy.ValidateStackLimits(context.Background(), StackLimitChange{Operation: "unknown"})).NotTo(gomega.HaveOccurred())
-			gomega.Expect(policy.ValidateVolumeLimits(context.Background(), "org-1", "not-a-quantity")).NotTo(gomega.HaveOccurred())
-			gomega.Expect(policy.ValidatePostgresAddonLimits(context.Background(), "org-1", "", addon)).NotTo(gomega.HaveOccurred())
+			gomega.Expect(policy.ValidateVolumeLimits(context.Background(), VolumeLimitChange{
+				OrganisationID: "org-1",
+				Size:           "not-a-quantity",
+			})).NotTo(gomega.HaveOccurred())
+			gomega.Expect(policy.ValidatePostgresAddonLimits(context.Background(), PostgresAddonLimitChange{
+				OrganisationID: "org-1",
+				CreatesAddon:   true,
+				Addon:          addon,
+			})).NotTo(gomega.HaveOccurred())
 
 			policy.ApplyStackResourceDefaults(resource)
 			policy.ApplyVolumeDefaults(volume)
@@ -109,25 +116,25 @@ var _ = ginkgo.Describe("Compute policy", func() {
 
 			gomega.Expect(resource.Replicas).NotTo(gomega.BeNil())
 			gomega.Expect(*resource.Replicas).To(gomega.Equal(int32(1)))
-			gomega.Expect(volume.Size).To(gomega.Equal("2Gi"))
+			gomega.Expect(volume.Size).To(gomega.BeEmpty())
 			gomega.Expect(volume.StorageClass).To(gomega.Equal("longhorn"))
 			gomega.Expect(addon.Instances.Count).To(gomega.Equal(1))
 			gomega.Expect(addon.Storage.Size).To(gomega.BeEmpty())
 		})
 
-		ginkgo.It("replaces a stack against usage that excludes its old resources", func() {
+		ginkgo.It("replaces a stack using usage without its old resources", func() {
 			usage.usage = ComputeUsage{StackCount: 2, StackResourceCount: 2}
 
 			err := policy.ValidateStackLimits(context.Background(), StackLimitChange{
 				Operation:            StackLimitReplaceStack,
 				OrganisationID:       "org-1",
-				StackID:              "stack-1",
+				ReplacedStackID:      "stack-1",
 				DesiredResourceCount: 4,
 			})
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(usage.organisationID).To(gomega.Equal("org-1"))
-			gomega.Expect(usage.excludeStackID).To(gomega.Equal("stack-1"))
+			gomega.Expect(usage.replacedStackID).To(gomega.Equal("stack-1"))
 		})
 
 		ginkgo.DescribeTable("rejects stack usage beyond a configured limit",
@@ -153,7 +160,10 @@ var _ = ginkgo.Describe("Compute policy", func() {
 			func(currentVolumeCount int64, size string, expectedCode stackerrors.ServiceErrorCode) {
 				usage.usage = ComputeUsage{VolumeCount: currentVolumeCount}
 
-				err := policy.ValidateVolumeLimits(context.Background(), "org-1", size)
+				err := policy.ValidateVolumeLimits(context.Background(), VolumeLimitChange{
+					OrganisationID: "org-1",
+					Size:           size,
+				})
 
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(err.Code).To(gomega.Equal(expectedCode))
@@ -164,18 +174,22 @@ var _ = ginkgo.Describe("Compute policy", func() {
 		)
 
 		ginkgo.DescribeTable("validates PostgreSQL addon requests",
-			func(currentAddonCount int64, existingAddonID string, addon *models.PostgresAddon, expectedCode stackerrors.ServiceErrorCode) {
+			func(currentAddonCount int64, createsAddon bool, addon *models.PostgresAddon, expectedCode stackerrors.ServiceErrorCode) {
 				usage.usage = ComputeUsage{PostgresAddonCount: currentAddonCount}
 
-				err := policy.ValidatePostgresAddonLimits(context.Background(), "org-1", existingAddonID, addon)
+				err := policy.ValidatePostgresAddonLimits(context.Background(), PostgresAddonLimitChange{
+					OrganisationID: "org-1",
+					CreatesAddon:   createsAddon,
+					Addon:          addon,
+				})
 
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(err.Code).To(gomega.Equal(expectedCode))
 			},
-			ginkgo.Entry("addon count exceeds the limit", int64(1), "", postgresAddon(1, "1Gi"), stackerrors.ErrorComputeQuotaExceeded),
-			ginkgo.Entry("instance count differs from the policy", int64(0), "", postgresAddon(2, "1Gi"), stackerrors.ErrorComputeQuotaExceeded),
-			ginkgo.Entry("storage exceeds the limit", int64(0), "", postgresAddon(1, "3Gi"), stackerrors.ErrorComputeQuotaExceeded),
-			ginkgo.Entry("storage size is malformed", int64(0), "", postgresAddon(1, "invalid"), stackerrors.ErrorBadRequest),
+			ginkgo.Entry("addon count exceeds the limit", int64(1), true, postgresAddon(1, "1Gi"), stackerrors.ErrorComputeQuotaExceeded),
+			ginkgo.Entry("instance count differs from the policy", int64(0), true, postgresAddon(2, "1Gi"), stackerrors.ErrorComputeQuotaExceeded),
+			ginkgo.Entry("storage exceeds the limit", int64(0), true, postgresAddon(1, "3Gi"), stackerrors.ErrorComputeQuotaExceeded),
+			ginkgo.Entry("storage size is malformed", int64(0), true, postgresAddon(1, "invalid"), stackerrors.ErrorBadRequest),
 		)
 	})
 })

--- a/pkg/computequota/policy_test.go
+++ b/pkg/computequota/policy_test.go
@@ -1,0 +1,188 @@
+package computequota
+
+import (
+	"context"
+
+	"github.com/Stackdome/stackdome/pkg/computeaccess"
+	stackerrors "github.com/Stackdome/stackdome/pkg/errors"
+	"github.com/Stackdome/stackdome/pkg/models"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+)
+
+type fakeComputeAccessService struct {
+	organisationID string
+	err            *stackerrors.ServiceError
+}
+
+func (f *fakeComputeAccessService) Activate(_ context.Context, organisationID string) (*computeaccess.ComputeAccess, *stackerrors.ServiceError) {
+	f.organisationID = organisationID
+	return &computeaccess.ComputeAccess{}, f.err
+}
+
+type fakeComputeUsageStore struct {
+	usage          ComputeUsage
+	err            *stackerrors.ServiceError
+	organisationID string
+	excludeStackID string
+}
+
+func (f *fakeComputeUsageStore) LockOrganisationAndGetUsage(_ context.Context, organisationID, excludeStackID string) (ComputeUsage, *stackerrors.ServiceError) {
+	f.organisationID = organisationID
+	f.excludeStackID = excludeStackID
+	return f.usage, f.err
+}
+
+var _ = ginkgo.Describe("Compute policy", func() {
+	ginkgo.Describe("self-hosted", func() {
+		ginkgo.It("does not impose managed-compute defaults or limits", func() {
+			policy := NewSelfHostedPolicy()
+			replicas := int32(3)
+			resource := &models.StackResource{Replicas: &replicas}
+			volume := &models.Volume{Size: "5Gi", StorageClass: "fast"}
+			addon := &models.PostgresAddon{
+				Instances: models.PostgresInstances{Count: 2},
+				Storage:   models.PostgresStorage{Size: "10Gi"},
+			}
+
+			gomega.Expect(policy.EnsureAccess(context.Background(), "org-1")).NotTo(gomega.HaveOccurred())
+			gomega.Expect(policy.ValidateStackLimits(context.Background(), StackLimitChange{Operation: "unknown"})).NotTo(gomega.HaveOccurred())
+			gomega.Expect(policy.ValidateVolumeLimits(context.Background(), "org-1", "not-a-quantity")).NotTo(gomega.HaveOccurred())
+			gomega.Expect(policy.ValidatePostgresAddonLimits(context.Background(), "org-1", "", addon)).NotTo(gomega.HaveOccurred())
+
+			policy.ApplyStackResourceDefaults(resource)
+			policy.ApplyVolumeDefaults(volume)
+			policy.ApplyPostgresAddonDefaults(addon)
+
+			gomega.Expect(*resource.Replicas).To(gomega.Equal(int32(3)))
+			gomega.Expect(volume).To(gomega.Equal(&models.Volume{Size: "5Gi", StorageClass: "fast"}))
+			gomega.Expect(addon.Instances.Count).To(gomega.Equal(2))
+			gomega.Expect(addon.Storage.Size).To(gomega.Equal("10Gi"))
+		})
+	})
+
+	ginkgo.Describe("Stackdome Cloud", func() {
+		var (
+			access *fakeComputeAccessService
+			usage  *fakeComputeUsageStore
+			policy Policy
+		)
+
+		ginkgo.BeforeEach(func() {
+			access = &fakeComputeAccessService{}
+			usage = &fakeComputeUsageStore{}
+			policy = NewStackdomeCloudPolicy(StackdomeCloudPolicySpec{
+				ComputeAccess: access,
+				ComputeUsage:  usage,
+				Limits: ComputeLimits{
+					MaxStacksPerOrganization:         2,
+					MaxStackResourcesPerOrganization: 6,
+					ReplicasPerStackResource:         1,
+					MaxVolumesPerOrganization:        2,
+					MaxVolumeSize:                    "2Gi",
+					VolumeStorageClass:               "longhorn",
+					MaxPostgresAddonsPerOrganization: 1,
+					PostgresInstances:                1,
+					MaxPostgresStorageSize:           "2Gi",
+				},
+			})
+		})
+
+		ginkgo.It("propagates compute access denials", func() {
+			access.err = stackerrors.ComputeAccessInactive()
+
+			err := policy.EnsureAccess(context.Background(), "org-1")
+
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Code).To(gomega.Equal(stackerrors.ErrorComputeAccessInactive))
+			gomega.Expect(access.organisationID).To(gomega.Equal("org-1"))
+		})
+
+		ginkgo.It("applies managed-compute defaults", func() {
+			resource := &models.StackResource{}
+			volume := &models.Volume{}
+			addon := &models.PostgresAddon{}
+
+			policy.ApplyStackResourceDefaults(resource)
+			policy.ApplyVolumeDefaults(volume)
+			policy.ApplyPostgresAddonDefaults(addon)
+
+			gomega.Expect(resource.Replicas).NotTo(gomega.BeNil())
+			gomega.Expect(*resource.Replicas).To(gomega.Equal(int32(1)))
+			gomega.Expect(volume.Size).To(gomega.Equal("2Gi"))
+			gomega.Expect(volume.StorageClass).To(gomega.Equal("longhorn"))
+			gomega.Expect(addon.Instances.Count).To(gomega.Equal(1))
+			gomega.Expect(addon.Storage.Size).To(gomega.Equal("2Gi"))
+		})
+
+		ginkgo.It("replaces a stack against usage that excludes its old resources", func() {
+			usage.usage = ComputeUsage{StackCount: 2, StackResourceCount: 2}
+
+			err := policy.ValidateStackLimits(context.Background(), StackLimitChange{
+				Operation:            StackLimitReplaceStack,
+				OrganisationID:       "org-1",
+				StackID:              "stack-1",
+				DesiredResourceCount: 4,
+			})
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(usage.organisationID).To(gomega.Equal("org-1"))
+			gomega.Expect(usage.excludeStackID).To(gomega.Equal("stack-1"))
+		})
+
+		ginkgo.DescribeTable("rejects stack usage beyond a configured limit",
+			func(current ComputeUsage, change StackLimitChange) {
+				usage.usage = current
+
+				err := policy.ValidateStackLimits(context.Background(), change)
+
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Code).To(gomega.Equal(stackerrors.ErrorComputeQuotaExceeded))
+			},
+			ginkgo.Entry("stack count",
+				ComputeUsage{StackCount: 2},
+				StackLimitChange{Operation: StackLimitCreateStack, OrganisationID: "org-1"},
+			),
+			ginkgo.Entry("resource count",
+				ComputeUsage{StackCount: 1, StackResourceCount: 6},
+				StackLimitChange{Operation: StackLimitAddResource, OrganisationID: "org-1"},
+			),
+		)
+
+		ginkgo.DescribeTable("validates volume requests",
+			func(currentVolumeCount int64, size string, expectedCode stackerrors.ServiceErrorCode) {
+				usage.usage = ComputeUsage{VolumeCount: currentVolumeCount}
+
+				err := policy.ValidateVolumeLimits(context.Background(), "org-1", size)
+
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Code).To(gomega.Equal(expectedCode))
+			},
+			ginkgo.Entry("volume count exceeds the limit", int64(2), "1Gi", stackerrors.ErrorComputeQuotaExceeded),
+			ginkgo.Entry("volume size exceeds the limit", int64(0), "3Gi", stackerrors.ErrorComputeQuotaExceeded),
+			ginkgo.Entry("volume size is malformed", int64(0), "invalid", stackerrors.ErrorBadRequest),
+		)
+
+		ginkgo.DescribeTable("validates PostgreSQL addon requests",
+			func(currentAddonCount int64, existingAddonID string, addon *models.PostgresAddon, expectedCode stackerrors.ServiceErrorCode) {
+				usage.usage = ComputeUsage{PostgresAddonCount: currentAddonCount}
+
+				err := policy.ValidatePostgresAddonLimits(context.Background(), "org-1", existingAddonID, addon)
+
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Code).To(gomega.Equal(expectedCode))
+			},
+			ginkgo.Entry("addon count exceeds the limit", int64(1), "", postgresAddon(1, "1Gi"), stackerrors.ErrorComputeQuotaExceeded),
+			ginkgo.Entry("instance count differs from the policy", int64(0), "", postgresAddon(2, "1Gi"), stackerrors.ErrorComputeQuotaExceeded),
+			ginkgo.Entry("storage exceeds the limit", int64(0), "", postgresAddon(1, "3Gi"), stackerrors.ErrorComputeQuotaExceeded),
+			ginkgo.Entry("storage size is malformed", int64(0), "", postgresAddon(1, "invalid"), stackerrors.ErrorBadRequest),
+		)
+	})
+})
+
+func postgresAddon(instances int, storageSize string) *models.PostgresAddon {
+	return &models.PostgresAddon{
+		Instances: models.PostgresInstances{Count: instances},
+		Storage:   models.PostgresStorage{Size: storageSize},
+	}
+}

--- a/pkg/computequota/policy_test.go
+++ b/pkg/computequota/policy_test.go
@@ -91,6 +91,10 @@ var _ = ginkgo.Describe("Compute policy", func() {
 					MaxPostgresAddonsPerOrganization: 1,
 					PostgresInstances:                1,
 					MaxPostgresStorageSize:           "2Gi",
+					PostgresCPURequest:               "50m",
+					PostgresCPULimit:                 "500m",
+					PostgresMemoryRequest:            "128Mi",
+					PostgresMemoryLimit:              "1Gi",
 				},
 			})
 		})
@@ -120,6 +124,30 @@ var _ = ginkgo.Describe("Compute policy", func() {
 			gomega.Expect(volume.StorageClass).To(gomega.Equal("longhorn"))
 			gomega.Expect(addon.Instances.Count).To(gomega.Equal(1))
 			gomega.Expect(addon.Storage.Size).To(gomega.BeEmpty())
+		})
+
+		ginkgo.It("normalizes the UI Basic PostgreSQL profile for shared compute", func() {
+			addon := &models.PostgresAddon{
+				Instances: models.PostgresInstances{Count: 1},
+				Storage:   models.PostgresStorage{Size: "1Gi"},
+				Resources: models.PostgresResources{
+					CPU:    models.PostgresCPUResource{Request: "250m", Limit: "500m"},
+					Memory: models.PostgresMemoryResource{Request: "1Gi", Limit: "1Gi"},
+				},
+			}
+
+			policy.ApplyPostgresAddonDefaults(addon)
+			err := policy.ValidatePostgresAddonLimits(context.Background(), PostgresAddonLimitChange{
+				OrganisationID: "org-1",
+				CreatesAddon:   true,
+				Addon:          addon,
+			})
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(addon.Resources.CPU.Request).To(gomega.Equal("50m"))
+			gomega.Expect(addon.Resources.CPU.Limit).To(gomega.Equal("500m"))
+			gomega.Expect(addon.Resources.Memory.Request).To(gomega.Equal("128Mi"))
+			gomega.Expect(addon.Resources.Memory.Limit).To(gomega.Equal("1Gi"))
 		})
 
 		ginkgo.It("replaces a stack using usage without its old resources", func() {

--- a/pkg/computequota/policy_test.go
+++ b/pkg/computequota/policy_test.go
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("Compute policy", func() {
 			gomega.Expect(volume.Size).To(gomega.Equal("2Gi"))
 			gomega.Expect(volume.StorageClass).To(gomega.Equal("longhorn"))
 			gomega.Expect(addon.Instances.Count).To(gomega.Equal(1))
-			gomega.Expect(addon.Storage.Size).To(gomega.Equal("2Gi"))
+			gomega.Expect(addon.Storage.Size).To(gomega.BeEmpty())
 		})
 
 		ginkgo.It("replaces a stack against usage that excludes its old resources", func() {

--- a/pkg/computequota/stack_limits.go
+++ b/pkg/computequota/stack_limits.go
@@ -16,35 +16,19 @@ const (
 type StackLimitChange struct {
 	Operation      StackLimitOperation
 	OrganisationID string
-	// StackID is required only for StackLimitReplaceStack, where the desired
-	// resources replace every currently persisted resource in this stack.
-	StackID string
+	// ReplacedStackID identifies the stack whose complete persisted resource
+	// set will be replaced by DesiredResourceCount.
+	ReplacedStackID string
 	// DesiredResourceCount is the complete desired count for a whole-stack
 	// create or replacement. Single-resource operations do not use it.
 	DesiredResourceCount int64
-}
-
-// stackResourceExclusionFor identifies the one operation that replaces all of
-// an existing stack's persisted resources. Other operations count every row.
-func stackResourceExclusionFor(change StackLimitChange) (string, *errors.ServiceError) {
-	switch change.Operation {
-	case StackLimitReplaceStack:
-		if change.StackID == "" {
-			return "", errors.GeneralError("stack ID is required for a whole-stack update")
-		}
-		return change.StackID, nil
-	case StackLimitCreateStack, StackLimitAddResource, StackLimitUpdateResource:
-		return "", nil
-	default:
-		return "", errors.GeneralError("unsupported stack limit operation %q", change.Operation)
-	}
 }
 
 // stackUsageAfterChange turns persisted usage into the totals that would exist
 // after the requested mutation commits.
 func stackUsageAfterChange(current ComputeUsage, change StackLimitChange) (ComputeUsage, *errors.ServiceError) {
 	if (change.Operation == StackLimitCreateStack || change.Operation == StackLimitReplaceStack) && change.DesiredResourceCount < 0 {
-		return ComputeUsage{}, errors.GeneralError("desired resource count must be non-negative")
+		return ComputeUsage{}, errors.UnprocessableEntity("desired resource count must be non-negative")
 	}
 
 	proposed := current
@@ -55,9 +39,9 @@ func stackUsageAfterChange(current ComputeUsage, change StackLimitChange) (Compu
 		proposed.StackCount = current.StackCount + 1
 		proposed.StackResourceCount = current.StackResourceCount + change.DesiredResourceCount
 	case StackLimitReplaceStack:
-		// The query excludes the replaced stack's old resources. If the other
-		// stacks have 2 resources and the replacement has 4, the total is 6;
-		// replacing a stack leaves the stack count unchanged.
+		// Current usage already omits this stack's old resources. If the other
+		// stacks have 2 resources and the replacement has 4, the total is 6.
+		// Replacing a stack leaves the stack count unchanged.
 		proposed.StackCount = current.StackCount
 		proposed.StackResourceCount = current.StackResourceCount + change.DesiredResourceCount
 	case StackLimitAddResource:

--- a/pkg/computequota/stack_limits.go
+++ b/pkg/computequota/stack_limits.go
@@ -1,0 +1,75 @@
+package computequota
+
+import "github.com/Stackdome/stackdome/pkg/errors"
+
+type StackLimitOperation string
+
+const (
+	StackLimitCreateStack    StackLimitOperation = "create_stack"
+	StackLimitReplaceStack   StackLimitOperation = "replace_stack"
+	StackLimitAddResource    StackLimitOperation = "add_resource"
+	StackLimitUpdateResource StackLimitOperation = "update_resource"
+)
+
+// StackLimitChange describes how a proposed draft edit changes counted stack
+// usage. It does not decide compute access or runtime reconciliation.
+type StackLimitChange struct {
+	Operation      StackLimitOperation
+	OrganisationID string
+	// StackID is required only for StackLimitReplaceStack, where the desired
+	// resources replace every currently persisted resource in this stack.
+	StackID string
+	// DesiredResourceCount is the complete desired count for a whole-stack
+	// create or replacement. Single-resource operations do not use it.
+	DesiredResourceCount int64
+}
+
+// stackResourceExclusionFor identifies the one operation that replaces all of
+// an existing stack's persisted resources. Other operations count every row.
+func stackResourceExclusionFor(change StackLimitChange) (string, *errors.ServiceError) {
+	switch change.Operation {
+	case StackLimitReplaceStack:
+		if change.StackID == "" {
+			return "", errors.GeneralError("stack ID is required for a whole-stack update")
+		}
+		return change.StackID, nil
+	case StackLimitCreateStack, StackLimitAddResource, StackLimitUpdateResource:
+		return "", nil
+	default:
+		return "", errors.GeneralError("unsupported stack limit operation %q", change.Operation)
+	}
+}
+
+// stackUsageAfterChange turns persisted usage into the totals that would exist
+// after the requested mutation commits.
+func stackUsageAfterChange(current ComputeUsage, change StackLimitChange) (ComputeUsage, *errors.ServiceError) {
+	if (change.Operation == StackLimitCreateStack || change.Operation == StackLimitReplaceStack) && change.DesiredResourceCount < 0 {
+		return ComputeUsage{}, errors.GeneralError("desired resource count must be non-negative")
+	}
+
+	proposed := current
+	switch change.Operation {
+	case StackLimitCreateStack:
+		// 1 existing stack with 2 resources + a new 3-resource stack =
+		// 2 stacks and 5 resources.
+		proposed.StackCount = current.StackCount + 1
+		proposed.StackResourceCount = current.StackResourceCount + change.DesiredResourceCount
+	case StackLimitReplaceStack:
+		// The query excludes the replaced stack's old resources. If the other
+		// stacks have 2 resources and the replacement has 4, the total is 6;
+		// replacing a stack leaves the stack count unchanged.
+		proposed.StackCount = current.StackCount
+		proposed.StackResourceCount = current.StackResourceCount + change.DesiredResourceCount
+	case StackLimitAddResource:
+		// 5 persisted resources + 1 added resource = 6 resources.
+		proposed.StackCount = current.StackCount
+		proposed.StackResourceCount = current.StackResourceCount + 1
+	case StackLimitUpdateResource:
+		// Updating 1 of 6 persisted resources in place leaves 6 resources.
+		proposed.StackCount = current.StackCount
+		proposed.StackResourceCount = current.StackResourceCount
+	default:
+		return ComputeUsage{}, errors.GeneralError("unsupported stack limit operation %q", change.Operation)
+	}
+	return proposed, nil
+}

--- a/pkg/computequota/stack_limits_test.go
+++ b/pkg/computequota/stack_limits_test.go
@@ -7,44 +7,6 @@ import (
 )
 
 var _ = ginkgo.Describe("Stack limit arithmetic", func() {
-	ginkgo.Describe("stackResourceExclusionFor", func() {
-		ginkgo.It("excludes the replaced stack from persisted resource usage", func() {
-			excludedStackID, err := stackResourceExclusionFor(StackLimitChange{
-				Operation: StackLimitReplaceStack,
-				StackID:   "stack-1",
-			})
-
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(excludedStackID).To(gomega.Equal("stack-1"))
-		})
-
-		ginkgo.DescribeTable("counts every persisted resource for non-replacement operations",
-			func(operation StackLimitOperation) {
-				excludedStackID, err := stackResourceExclusionFor(StackLimitChange{Operation: operation})
-
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(excludedStackID).To(gomega.BeEmpty())
-			},
-			ginkgo.Entry("stack creation", StackLimitCreateStack),
-			ginkgo.Entry("resource creation", StackLimitAddResource),
-			ginkgo.Entry("resource update", StackLimitUpdateResource),
-		)
-
-		ginkgo.It("rejects a replacement without a stack ID", func() {
-			_, err := stackResourceExclusionFor(StackLimitChange{Operation: StackLimitReplaceStack})
-
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Code).To(gomega.Equal(stackerrors.ErrorGeneral))
-		})
-
-		ginkgo.It("rejects an unsupported operation", func() {
-			_, err := stackResourceExclusionFor(StackLimitChange{Operation: "unknown"})
-
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Code).To(gomega.Equal(stackerrors.ErrorGeneral))
-		})
-	})
-
 	ginkgo.Describe("stackUsageAfterChange", func() {
 		current := ComputeUsage{
 			StackCount:         2,
@@ -64,8 +26,8 @@ var _ = ginkgo.Describe("Stack limit arithmetic", func() {
 				StackLimitChange{Operation: StackLimitCreateStack, DesiredResourceCount: 3},
 				ComputeUsage{StackCount: 3, StackResourceCount: 8, VolumeCount: 7, PostgresAddonCount: 11},
 			),
-			ginkgo.Entry("replaces the excluded stack resources without changing the stack count",
-				StackLimitChange{Operation: StackLimitReplaceStack, StackID: "stack-1", DesiredResourceCount: 4},
+			ginkgo.Entry("replaces the old stack resources without changing the stack count",
+				StackLimitChange{Operation: StackLimitReplaceStack, ReplacedStackID: "stack-1", DesiredResourceCount: 4},
 				ComputeUsage{StackCount: 2, StackResourceCount: 9, VolumeCount: 7, PostgresAddonCount: 11},
 			),
 			ginkgo.Entry("adds one resource",
@@ -86,7 +48,7 @@ var _ = ginkgo.Describe("Stack limit arithmetic", func() {
 				})
 
 				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(err.Code).To(gomega.Equal(stackerrors.ErrorGeneral))
+				gomega.Expect(err.Code).To(gomega.Equal(stackerrors.ErrorUnprocessableEntity))
 			},
 			ginkgo.Entry("stack creation", StackLimitCreateStack),
 			ginkgo.Entry("stack replacement", StackLimitReplaceStack),

--- a/pkg/computequota/stack_limits_test.go
+++ b/pkg/computequota/stack_limits_test.go
@@ -1,0 +1,102 @@
+package computequota
+
+import (
+	stackerrors "github.com/Stackdome/stackdome/pkg/errors"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("Stack limit arithmetic", func() {
+	ginkgo.Describe("stackResourceExclusionFor", func() {
+		ginkgo.It("excludes the replaced stack from persisted resource usage", func() {
+			excludedStackID, err := stackResourceExclusionFor(StackLimitChange{
+				Operation: StackLimitReplaceStack,
+				StackID:   "stack-1",
+			})
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(excludedStackID).To(gomega.Equal("stack-1"))
+		})
+
+		ginkgo.DescribeTable("counts every persisted resource for non-replacement operations",
+			func(operation StackLimitOperation) {
+				excludedStackID, err := stackResourceExclusionFor(StackLimitChange{Operation: operation})
+
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(excludedStackID).To(gomega.BeEmpty())
+			},
+			ginkgo.Entry("stack creation", StackLimitCreateStack),
+			ginkgo.Entry("resource creation", StackLimitAddResource),
+			ginkgo.Entry("resource update", StackLimitUpdateResource),
+		)
+
+		ginkgo.It("rejects a replacement without a stack ID", func() {
+			_, err := stackResourceExclusionFor(StackLimitChange{Operation: StackLimitReplaceStack})
+
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Code).To(gomega.Equal(stackerrors.ErrorGeneral))
+		})
+
+		ginkgo.It("rejects an unsupported operation", func() {
+			_, err := stackResourceExclusionFor(StackLimitChange{Operation: "unknown"})
+
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Code).To(gomega.Equal(stackerrors.ErrorGeneral))
+		})
+	})
+
+	ginkgo.Describe("stackUsageAfterChange", func() {
+		current := ComputeUsage{
+			StackCount:         2,
+			StackResourceCount: 5,
+			VolumeCount:        7,
+			PostgresAddonCount: 11,
+		}
+
+		ginkgo.DescribeTable("projects the committed stack usage",
+			func(change StackLimitChange, expected ComputeUsage) {
+				proposed, err := stackUsageAfterChange(current, change)
+
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(proposed).To(gomega.Equal(expected))
+			},
+			ginkgo.Entry("creates a stack and all of its resources",
+				StackLimitChange{Operation: StackLimitCreateStack, DesiredResourceCount: 3},
+				ComputeUsage{StackCount: 3, StackResourceCount: 8, VolumeCount: 7, PostgresAddonCount: 11},
+			),
+			ginkgo.Entry("replaces the excluded stack resources without changing the stack count",
+				StackLimitChange{Operation: StackLimitReplaceStack, StackID: "stack-1", DesiredResourceCount: 4},
+				ComputeUsage{StackCount: 2, StackResourceCount: 9, VolumeCount: 7, PostgresAddonCount: 11},
+			),
+			ginkgo.Entry("adds one resource",
+				StackLimitChange{Operation: StackLimitAddResource},
+				ComputeUsage{StackCount: 2, StackResourceCount: 6, VolumeCount: 7, PostgresAddonCount: 11},
+			),
+			ginkgo.Entry("updates a resource in place",
+				StackLimitChange{Operation: StackLimitUpdateResource},
+				ComputeUsage{StackCount: 2, StackResourceCount: 5, VolumeCount: 7, PostgresAddonCount: 11},
+			),
+		)
+
+		ginkgo.DescribeTable("rejects a negative whole-stack resource count",
+			func(operation StackLimitOperation) {
+				_, err := stackUsageAfterChange(current, StackLimitChange{
+					Operation:            operation,
+					DesiredResourceCount: -1,
+				})
+
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Code).To(gomega.Equal(stackerrors.ErrorGeneral))
+			},
+			ginkgo.Entry("stack creation", StackLimitCreateStack),
+			ginkgo.Entry("stack replacement", StackLimitReplaceStack),
+		)
+
+		ginkgo.It("rejects an unsupported operation", func() {
+			_, err := stackUsageAfterChange(current, StackLimitChange{Operation: "unknown"})
+
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Code).To(gomega.Equal(stackerrors.ErrorGeneral))
+		})
+	})
+})

--- a/pkg/computequota/usage.go
+++ b/pkg/computequota/usage.go
@@ -1,0 +1,22 @@
+package computequota
+
+import (
+	"context"
+
+	"github.com/Stackdome/stackdome/pkg/errors"
+)
+
+type ComputeUsage struct {
+	StackCount         int64
+	StackResourceCount int64
+	VolumeCount        int64
+	PostgresAddonCount int64
+}
+
+// UsageStore serializes capacity-changing mutations for one organisation and
+// returns its persisted usage. Implementations require a transaction in ctx.
+// excludeStackID is used only when replacement of a stack's complete desired
+// state makes its persisted resources irrelevant.
+type UsageStore interface {
+	LockOrganisationAndGetUsage(ctx context.Context, organisationID, excludeStackID string) (ComputeUsage, *errors.ServiceError)
+}

--- a/pkg/computequota/usage.go
+++ b/pkg/computequota/usage.go
@@ -15,8 +15,8 @@ type ComputeUsage struct {
 
 // UsageStore serializes capacity-changing mutations for one organisation and
 // returns its persisted usage. Implementations require a transaction in ctx.
-// excludeStackID is used only when replacement of a stack's complete desired
-// state makes its persisted resources irrelevant.
+// When replacedStackID is set, the replaced stack remains in StackCount while
+// its old resources are omitted from StackResourceCount.
 type UsageStore interface {
-	LockOrganisationAndGetUsage(ctx context.Context, organisationID, excludeStackID string) (ComputeUsage, *errors.ServiceError)
+	LockOrganisationAndGetUsage(ctx context.Context, organisationID, replacedStackID string) (ComputeUsage, *errors.ServiceError)
 }

--- a/pkg/db/migrations/202608100004_create_compute_access.go
+++ b/pkg/db/migrations/202608100004_create_compute_access.go
@@ -1,0 +1,71 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+const createComputeAccessMigrationID = "202608100004_create_compute_access"
+
+// Entitlements model the right to compute independently from leases, which
+// continue tracking shared capacity through runtime cleanup.
+func createComputeAccess() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: createComputeAccessMigrationID,
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.Exec(`
+CREATE TABLE compute_entitlements (
+    id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    organisation_id TEXT NOT NULL REFERENCES organisations(id) ON DELETE CASCADE,
+    source TEXT NOT NULL CHECK (source IN ('trial')),
+    status TEXT NOT NULL CHECK (status IN ('active')),
+    starts_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (organisation_id, source)
+)
+`).Error; err != nil {
+				return fmt.Errorf("failed to create compute entitlements: %w", err)
+			}
+			if err := tx.Exec(`
+CREATE TABLE shared_compute_leases (
+    id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    organisation_id TEXT NOT NULL REFERENCES organisations(id) ON DELETE CASCADE,
+    entitlement_id TEXT NOT NULL UNIQUE REFERENCES compute_entitlements(id) ON DELETE CASCADE,
+    state TEXT NOT NULL CHECK (state IN ('active', 'cleanup_pending', 'cleaning', 'cleaned', 'error')),
+    activated_at TIMESTAMPTZ NOT NULL,
+    cleanup_started_at TIMESTAMPTZ,
+    cleaned_up_at TIMESTAMPTZ,
+    error_at TIMESTAMPTZ,
+    error_message TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)
+`).Error; err != nil {
+				return fmt.Errorf("failed to create shared compute leases: %w", err)
+			}
+			if err := tx.Exec(`CREATE UNIQUE INDEX idx_shared_compute_leases_current_org ON shared_compute_leases (organisation_id) WHERE state <> 'cleaned'`).Error; err != nil {
+				return fmt.Errorf("failed to constrain current shared compute leases: %w", err)
+			}
+			if err := tx.Exec(`CREATE INDEX idx_compute_entitlements_expiry ON compute_entitlements (expires_at) WHERE status = 'active'`).Error; err != nil {
+				return fmt.Errorf("failed to index active compute entitlements: %w", err)
+			}
+			if err := tx.Exec(`CREATE INDEX idx_shared_compute_leases_state ON shared_compute_leases (state)`).Error; err != nil {
+				return fmt.Errorf("failed to index shared compute lease state: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			if err := tx.Exec(`DROP TABLE shared_compute_leases`).Error; err != nil {
+				return fmt.Errorf("failed to drop shared compute leases: %w", err)
+			}
+			if err := tx.Exec(`DROP TABLE compute_entitlements`).Error; err != nil {
+				return fmt.Errorf("failed to drop compute entitlements: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -85,4 +85,5 @@ var MigrationList = []*gormigrate.Migration{
 	renameClusterPlatformToSharedCompute(),
 	addClusterDeletionTimestamp(),
 	dropWorkspaceUserTables(),
+	createComputeAccess(),
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -58,6 +58,15 @@ const (
 
 	// InternalServerError
 	ErrorInternalServerError ServiceErrorCode = 27
+
+	// ComputeAccessInactive occurs when an organisation's compute entitlement or lease is inactive.
+	ErrorComputeAccessInactive ServiceErrorCode = 28
+
+	// SharedComputeCapacityReached occurs when all shared-compute leases are reserved.
+	ErrorSharedComputeCapacityReached ServiceErrorCode = 29
+
+	// ComputeQuotaExceeded occurs when a configured managed-compute limit is exceeded.
+	ErrorComputeQuotaExceeded ServiceErrorCode = 30
 )
 
 type ServiceErrorCode int
@@ -90,6 +99,9 @@ func Errors() ServiceErrors {
 		ServiceError{ErrorTooManyRequests, "Too many requests", http.StatusTooManyRequests, nil},
 		ServiceError{ErrorUnprocessableEntity, "Unable to process request entity", http.StatusUnprocessableEntity, nil},
 		ServiceError{ErrorInternalServerError, "Internal server error", http.StatusInternalServerError, nil},
+		ServiceError{ErrorComputeAccessInactive, "Compute access is inactive", http.StatusGone, nil},
+		ServiceError{ErrorSharedComputeCapacityReached, "Shared compute capacity reached", http.StatusTooManyRequests, nil},
+		ServiceError{ErrorComputeQuotaExceeded, "Compute quota exceeded", http.StatusBadRequest, nil},
 	}
 }
 
@@ -279,6 +291,18 @@ func Gone(reason string, values ...interface{}) *ServiceError {
 
 func TooManyRequests(reason string, values ...interface{}) *ServiceError {
 	return New(ErrorTooManyRequests, reason, values...)
+}
+
+func ComputeAccessInactive() *ServiceError {
+	return New(ErrorComputeAccessInactive, "")
+}
+
+func SharedComputeCapacityReached() *ServiceError {
+	return New(ErrorSharedComputeCapacityReached, "")
+}
+
+func ComputeQuotaExceeded(reason string, values ...interface{}) *ServiceError {
+	return New(ErrorComputeQuotaExceeded, reason, values...)
 }
 
 func UnprocessableEntity(reason string, values ...interface{}) *ServiceError {

--- a/pkg/handlers/stack_handler.go
+++ b/pkg/handlers/stack_handler.go
@@ -128,7 +128,7 @@ func (h *stackHandler) CreateVolume(w http.ResponseWriter, r *http.Request) {
 	var volume openapi.Volume
 	cfg := &handlerConfig{
 		MarshalInto: &volume,
-		Validate:    validation.ValidateVolume(&volume),
+		Validate:    validation.ValidateVolumeWithOptionalSize(&volume),
 		Action: func() (interface{}, *errors.ServiceError) {
 			stackID := mux.Vars(r)["id"]
 			obj, err := h.stackService.CreateStackVolume(r.Context(), stackID, presenters.ConvertVolume(&volume))

--- a/pkg/handlers/validation/volume.go
+++ b/pkg/handlers/validation/volume.go
@@ -7,6 +7,14 @@ import (
 )
 
 func ValidateVolume(in *openapi.Volume) Validate {
+	return validateVolume(in, true)
+}
+
+func ValidateVolumeWithOptionalSize(in *openapi.Volume) Validate {
+	return validateVolume(in, false)
+}
+
+func validateVolume(in *openapi.Volume, sizeRequired bool) Validate {
 	// NOTE: validate only fields that exist on the generated openapi.Volume —
 	// reflect.FieldByName on a missing field yields an invalid Value whose
 	// String() is "<invalid Value>", making validateEmpty fail unconditionally.
@@ -28,11 +36,13 @@ func ValidateVolume(in *openapi.Volume) Validate {
 				return errors.Validation("spec.access_mode is required")
 			}
 
-			if in.Spec.Size == "" {
+			if sizeRequired && in.Spec.Size == "" {
 				return errors.Validation("spec.size is required")
 			}
-			if _, err := k8sresource.ParseQuantity(in.Spec.Size); err != nil {
-				return errors.Validation("spec.size is not a valid quantity")
+			if in.Spec.Size != "" {
+				if _, err := k8sresource.ParseQuantity(in.Spec.Size); err != nil {
+					return errors.Validation("spec.size is not a valid quantity")
+				}
 			}
 			// If source is not nil, validate it
 			if in.Spec.Source != nil {

--- a/pkg/services/image_registry_service.go
+++ b/pkg/services/image_registry_service.go
@@ -154,21 +154,27 @@ func (s *clusterImageRegistryService) Create(ctx context.Context, spec *models.C
 	return s.create(ctx, spec)
 }
 
-// InternalCreateSeedRegistry creates the org's seed registry on a shared-compute
-// cluster. Org-provisioning only — the API Create path requires an
-// org-owned target cluster.
+// InternalCreateSeedRegistry persists the org's pending shared-compute registry
+// in the caller's transaction without enqueueing reconciliation. The
+// organisation service resolves the shared-compute cluster before calling this
+// internal persistence path; the API Create path still requires an org-owned
+// target cluster and keeps its existing eager reconciliation behavior.
 func (s *clusterImageRegistryService) InternalCreateSeedRegistry(ctx context.Context, spec *models.ClusterImageRegistry) (*models.ClusterImageRegistry, *errors.ServiceError) {
 	if err := s.validateSpec(spec); err != nil {
 		return nil, err
 	}
-	cluster, err := s.clusterStore.Get(ctx, spec.ClusterID)
+	spec.Status = &models.ClusterImageRegistryStatus{
+		State:      models.RegistryStatePending,
+		Conditions: []models.Condition{},
+	}
+	s.setDefaultValues(spec)
+
+	createdRegistry, err := s.clusterImageRegistryStore.CreateWithTx(ctx, spec)
 	if err != nil {
+		s.logger.Error(ctx, "failed to create shared-compute seed registry: %v", err)
 		return nil, err
 	}
-	if !cluster.SharedCompute {
-		return nil, errors.NotFound("cluster '%s' is not a shared-compute cluster", spec.ClusterID)
-	}
-	return s.create(ctx, spec)
+	return createdRegistry, nil
 }
 
 func (s *clusterImageRegistryService) validateSpec(spec *models.ClusterImageRegistry) *errors.ServiceError {

--- a/pkg/services/organisation_service.go
+++ b/pkg/services/organisation_service.go
@@ -142,8 +142,8 @@ func (s *organisationService) InternalCreate(ctx context.Context, spec *models.O
 	return s.organisationStore.Get(ctx, org.ID)
 }
 
-// seedSharedComputeRegistry gives a new tenant org a seed registry on the
-// shared-compute cluster. No shared-compute cluster configured → no-op.
+// seedSharedComputeRegistry gives a new tenant org a pending registry row on
+// the shared-compute cluster. No shared-compute cluster configured → no-op.
 func (s *organisationService) seedSharedComputeRegistry(ctx context.Context, orgID, orgName string) *errors.ServiceError {
 	sharedClusters, err := s.clusterStore.ListSharedComputeClusters(ctx)
 	if err != nil {
@@ -155,8 +155,6 @@ func (s *organisationService) seedSharedComputeRegistry(ctx context.Context, org
 	if len(sharedClusters) > 1 {
 		return errors.GeneralError("multiple shared-compute clusters configured")
 	}
-	ctx = auth.SetIdentityInContext(ctx, &auth.Identity{IsSystem: true, OrgID: orgID})
-
 	return s.seedOrgRegistry(ctx, orgID, orgName, sharedClusters[0].ID)
 }
 

--- a/pkg/services/postgres_addon_service.go
+++ b/pkg/services/postgres_addon_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Stackdome/stackdome/pkg/auth"
 	"github.com/Stackdome/stackdome/pkg/clustermanager"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/db"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/logger"
@@ -68,6 +69,7 @@ type PostgresAddonServiceSpec struct {
 	Logger                 logger.Logger
 	Permissions            auth.PermissionService
 	ExternalImportDisabled bool
+	ComputePolicy          computequota.Policy
 }
 
 type postgresAddonService struct {
@@ -85,6 +87,7 @@ type postgresAddonService struct {
 	logger             logger.Logger
 	sessionFactory     db.SessionFactory
 	permissions        auth.PermissionService
+	computePolicy      computequota.Policy
 
 	BackgroundJobEnqueuerDep
 	ClusterResourceServiceDeps
@@ -117,6 +120,7 @@ func NewPostgresAddonService(spec PostgresAddonServiceSpec) PostgresAddonService
 		logger:         spec.Logger,
 		sessionFactory: spec.SessionFactory,
 		permissions:    spec.Permissions,
+		computePolicy:  spec.ComputePolicy,
 	}
 }
 
@@ -129,6 +133,7 @@ func (s *postgresAddonService) CreatePostgresAddon(ctx context.Context, postgres
 		return nil, permErr
 	}
 
+	s.computePolicy.ApplyPostgresAddonDefaults(postgresAddon)
 	if err := s.validator.ValidateForCreate(ctx, postgresAddon); err != nil {
 		return nil, err
 	}
@@ -229,6 +234,13 @@ func (s *postgresAddonService) CreatePostgresAddon(ctx context.Context, postgres
 
 	var createdPostgresAddon *models.PostgresAddon
 	err = s.postgresAddonStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(ctx, postgresAddon.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		s.computePolicy.ApplyPostgresAddonDefaults(postgresAddon)
+		if limitErr := s.computePolicy.ValidatePostgresAddonLimits(ctx, postgresAddon.OrganisationID, "", postgresAddon); limitErr != nil {
+			return limitErr
+		}
 		// Create namespace
 		createdNamepace, err := s.namespaceService.CreateInDBWithTx(ctx, namespace)
 		if err != nil {
@@ -311,6 +323,7 @@ func (s *postgresAddonService) UpdatePostgresAddon(ctx context.Context, id strin
 		postgresAddon.Storage.StorageClass = existingPostgresAddon.Storage.StorageClass
 	}
 
+	s.computePolicy.ApplyPostgresAddonDefaults(postgresAddon)
 	// Validate update using validator
 	if err := s.validator.ValidateForUpdate(ctx, existingPostgresAddon, postgresAddon); err != nil {
 		return nil, err
@@ -329,6 +342,13 @@ func (s *postgresAddonService) UpdatePostgresAddon(ctx context.Context, id strin
 
 	var updatedPostgresAddon *models.PostgresAddon
 	err = s.postgresAddonStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(ctx, existingPostgresAddon.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		s.computePolicy.ApplyPostgresAddonDefaults(postgresAddon)
+		if limitErr := s.computePolicy.ValidatePostgresAddonLimits(ctx, existingPostgresAddon.OrganisationID, existingPostgresAddon.ID, postgresAddon); limitErr != nil {
+			return limitErr
+		}
 		// Update PostgreSQL addon within transaction
 		var updateErr *errors.ServiceError
 		updatedPostgresAddon, updateErr = s.postgresAddonStore.UpdateWithTx(ctx, postgresAddon)
@@ -548,8 +568,13 @@ func (s *postgresAddonService) TriggerBackup(ctx context.Context, id string) *er
 
 	// Update the backup requested timestamp
 	now := time.Now()
-	if err := s.postgresAddonStore.UpdateBackupRequestedAt(ctx, id, &now); err != nil {
-		return err
+	if txErr := s.postgresAddonStore.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(txCtx, addon.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		return s.postgresAddonStore.UpdateBackupRequestedAt(txCtx, id, &now)
+	}); txErr != nil {
+		return txErr
 	}
 
 	if err := s.BackgroundJobEnqueuer.Enqueue(models.PostgresAddonOperand{ID: id}); err != nil {
@@ -569,12 +594,16 @@ func (s *postgresAddonService) TriggerHibernate(ctx context.Context, id string, 
 		return permErr
 	}
 
-	// Update lifecycle config
-	postgresAddon.LifecycleConfig.HibernationEnabled = enabled
-
-	_, err = s.postgresAddonStore.Update(ctx, postgresAddon)
-	if err != nil {
-		return err
+	if txErr := s.postgresAddonStore.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(txCtx, postgresAddon.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		// Update lifecycle config
+		postgresAddon.LifecycleConfig.HibernationEnabled = enabled
+		_, updateErr := s.postgresAddonStore.UpdateWithTx(txCtx, postgresAddon)
+		return updateErr
+	}); txErr != nil {
+		return txErr
 	}
 
 	if err := s.BackgroundJobEnqueuer.Enqueue(models.PostgresAddonOperand{ID: id}); err != nil {
@@ -594,12 +623,16 @@ func (s *postgresAddonService) TriggerFence(ctx context.Context, id string, enab
 		return permErr
 	}
 
-	// Update lifecycle config
-	postgresAddon.LifecycleConfig.FencingEnabled = enabled
-
-	_, err = s.postgresAddonStore.Update(ctx, postgresAddon)
-	if err != nil {
-		return err
+	if txErr := s.postgresAddonStore.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(txCtx, postgresAddon.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		// Update lifecycle config
+		postgresAddon.LifecycleConfig.FencingEnabled = enabled
+		_, updateErr := s.postgresAddonStore.UpdateWithTx(txCtx, postgresAddon)
+		return updateErr
+	}); txErr != nil {
+		return txErr
 	}
 
 	if err := s.BackgroundJobEnqueuer.Enqueue(models.PostgresAddonOperand{ID: id}); err != nil {

--- a/pkg/services/postgres_addon_service.go
+++ b/pkg/services/postgres_addon_service.go
@@ -238,7 +238,11 @@ func (s *postgresAddonService) CreatePostgresAddon(ctx context.Context, postgres
 			return accessErr
 		}
 		s.computePolicy.ApplyPostgresAddonDefaults(postgresAddon)
-		if limitErr := s.computePolicy.ValidatePostgresAddonLimits(ctx, postgresAddon.OrganisationID, "", postgresAddon); limitErr != nil {
+		if limitErr := s.computePolicy.ValidatePostgresAddonLimits(ctx, computequota.PostgresAddonLimitChange{
+			OrganisationID: postgresAddon.OrganisationID,
+			CreatesAddon:   true,
+			Addon:          postgresAddon,
+		}); limitErr != nil {
 			return limitErr
 		}
 		// Create namespace
@@ -346,7 +350,11 @@ func (s *postgresAddonService) UpdatePostgresAddon(ctx context.Context, id strin
 			return accessErr
 		}
 		s.computePolicy.ApplyPostgresAddonDefaults(postgresAddon)
-		if limitErr := s.computePolicy.ValidatePostgresAddonLimits(ctx, existingPostgresAddon.OrganisationID, existingPostgresAddon.ID, postgresAddon); limitErr != nil {
+		if limitErr := s.computePolicy.ValidatePostgresAddonLimits(ctx, computequota.PostgresAddonLimitChange{
+			OrganisationID: existingPostgresAddon.OrganisationID,
+			CreatesAddon:   false,
+			Addon:          postgresAddon,
+		}); limitErr != nil {
 			return limitErr
 		}
 		// Update PostgreSQL addon within transaction

--- a/pkg/services/postgres_addon_service_test.go
+++ b/pkg/services/postgres_addon_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Stackdome/stackdome/pkg/auth"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	apperrors "github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/mocks"
@@ -26,6 +27,7 @@ var _ = Describe("PostgresAddonService cloud validation", func() {
 		service := NewPostgresAddonService(PostgresAddonServiceSpec{
 			Permissions:            permissions,
 			ExternalImportDisabled: true,
+			ComputePolicy:          computequota.NewSelfHostedPolicy(),
 		})
 		spec := &models.PostgresAddon{
 			Name:            addonType,
@@ -80,6 +82,7 @@ var _ = Describe("PostgresAddonService DeletePostgresAddon", func() {
 			postgresAddonStore: addonStore,
 			referenceService:   refs,
 			permissions:        permissions,
+			computePolicy:      computequota.NewSelfHostedPolicy(),
 			BackgroundJobEnqueuerDep: BackgroundJobEnqueuerDep{
 				BackgroundJobEnqueuer: enqueuer,
 			},
@@ -189,6 +192,7 @@ var _ = Describe("CreatePostgresAddon storage class defaulting", func() {
 			logger:             logger.NewLogger(),
 			postgresAddonStore: addonStore,
 			permissions:        permissions,
+			computePolicy:      computequota.NewSelfHostedPolicy(),
 			namespaceService:   namespaceSvc,
 			clusterService:     clusterService,
 			databaseService:    databaseService,
@@ -290,6 +294,7 @@ var _ = Describe("UpdatePostgresAddon storage class carry-forward", func() {
 			logger:             logger.NewLogger(),
 			postgresAddonStore: addonStore,
 			permissions:        permissions,
+			computePolicy:      computequota.NewSelfHostedPolicy(),
 			validator:          postgresaddon.NewPostgresAddonValidator(postgresaddon.PostgresAddonValidatorSpec{}),
 			BackgroundJobEnqueuerDep: BackgroundJobEnqueuerDep{
 				BackgroundJobEnqueuer: enqueuer,

--- a/pkg/services/stack_apply_test.go
+++ b/pkg/services/stack_apply_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Stackdome/stackdome/pkg/auth"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/logger"
 	"github.com/Stackdome/stackdome/pkg/mocks"
@@ -48,6 +49,7 @@ func newApplyStackTestEnv(ctrl *gomock.Controller) *applyStackTestEnv {
 		stackResourceService: env.resourceService,
 		referenceService:     env.referenceService,
 		defaultingService:    NewStackDefaultingService(),
+		computePolicy:        computequota.NewSelfHostedPolicy(),
 		logger:               logger.NewLogger(),
 		BackgroundJobEnqueuerDep: BackgroundJobEnqueuerDep{
 			BackgroundJobEnqueuer: env.backgroundEnqueue,

--- a/pkg/services/stack_release_service.go
+++ b/pkg/services/stack_release_service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Stackdome/stackdome/pkg/auth"
 	gitclient "github.com/Stackdome/stackdome/pkg/clients/git"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/credentials"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/interfaces"
@@ -70,7 +71,8 @@ type StackReleaseServiceSpec struct {
 	EventStore         stores.ReleaseEventStore
 	EventRecorder      ReleaseEventRecorder
 	// GitClients is optional; it defaults to real git clients.
-	GitClients sourceGitClientProvider
+	GitClients    sourceGitClientProvider
+	ComputePolicy computequota.Policy
 }
 
 type stackReleaseService struct {
@@ -82,6 +84,7 @@ type stackReleaseService struct {
 	eventStore         stores.ReleaseEventStore
 	eventRecorder      ReleaseEventRecorder
 	gitClients         sourceGitClientProvider
+	computePolicy      computequota.Policy
 	logger             logger.Logger
 	BackgroundJobEnqueuerDep
 }
@@ -100,6 +103,7 @@ func NewStackReleaseService(spec StackReleaseServiceSpec) StackReleaseService {
 		eventStore:         spec.EventStore,
 		eventRecorder:      spec.EventRecorder,
 		gitClients:         gitClients,
+		computePolicy:      spec.ComputePolicy,
 		logger:             logger.NewLoggerWithPrefix(context.Background(), "stack-release-service"),
 	}
 }
@@ -168,6 +172,17 @@ func (s *stackReleaseService) createReleaseForStack(ctx context.Context, stack *
 
 	var created *models.StackRelease
 	if txErr := s.store.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(txCtx, stack.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		if limitErr := s.computePolicy.ValidateStackLimits(txCtx, computequota.StackLimitChange{
+			Operation:            computequota.StackLimitReplaceStack,
+			OrganisationID:       stack.OrganisationID,
+			StackID:              stack.ID,
+			DesiredResourceCount: int64(len(snapshot.Resources)),
+		}); limitErr != nil {
+			return limitErr
+		}
 		var e *errors.ServiceError
 		created, e = s.store.Create(txCtx, release)
 		if e != nil {
@@ -244,6 +259,17 @@ func (s *stackReleaseService) RollbackRelease(ctx context.Context, stackID, from
 
 	var created *models.StackRelease
 	if txErr := s.store.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(txCtx, stack.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		if limitErr := s.computePolicy.ValidateStackLimits(txCtx, computequota.StackLimitChange{
+			Operation:            computequota.StackLimitReplaceStack,
+			OrganisationID:       stack.OrganisationID,
+			StackID:              stack.ID,
+			DesiredResourceCount: int64(len(src.Snapshot.Resources)),
+		}); limitErr != nil {
+			return limitErr
+		}
 		var e *errors.ServiceError
 		created, e = s.store.Create(txCtx, release)
 		if e != nil {

--- a/pkg/services/stack_release_service.go
+++ b/pkg/services/stack_release_service.go
@@ -172,13 +172,14 @@ func (s *stackReleaseService) createReleaseForStack(ctx context.Context, stack *
 
 	var created *models.StackRelease
 	if txErr := s.store.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		// Validate the exact release snapshot before it is persisted and enqueued for cluster reconciliation.
 		if accessErr := s.computePolicy.EnsureAccess(txCtx, stack.OrganisationID); accessErr != nil {
 			return accessErr
 		}
 		if limitErr := s.computePolicy.ValidateStackLimits(txCtx, computequota.StackLimitChange{
 			Operation:            computequota.StackLimitReplaceStack,
 			OrganisationID:       stack.OrganisationID,
-			StackID:              stack.ID,
+			ReplacedStackID:      stack.ID,
 			DesiredResourceCount: int64(len(snapshot.Resources)),
 		}); limitErr != nil {
 			return limitErr
@@ -259,13 +260,14 @@ func (s *stackReleaseService) RollbackRelease(ctx context.Context, stackID, from
 
 	var created *models.StackRelease
 	if txErr := s.store.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		// Validate the exact release snapshot before it is persisted and enqueued for cluster reconciliation.
 		if accessErr := s.computePolicy.EnsureAccess(txCtx, stack.OrganisationID); accessErr != nil {
 			return accessErr
 		}
 		if limitErr := s.computePolicy.ValidateStackLimits(txCtx, computequota.StackLimitChange{
 			Operation:            computequota.StackLimitReplaceStack,
 			OrganisationID:       stack.OrganisationID,
-			StackID:              stack.ID,
+			ReplacedStackID:      stack.ID,
 			DesiredResourceCount: int64(len(src.Snapshot.Resources)),
 		}); limitErr != nil {
 			return limitErr

--- a/pkg/services/stack_release_service_test.go
+++ b/pkg/services/stack_release_service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Stackdome/stackdome/pkg/auth"
 	gitclient "github.com/Stackdome/stackdome/pkg/clients/git"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/credentials"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/logger"
@@ -218,6 +219,7 @@ var _ = Describe("stackReleaseService release creation records release_created",
 			permissions:      perms,
 			referenceService: referenceSvc,
 			eventRecorder:    recorder,
+			computePolicy:    computequota.NewSelfHostedPolicy(),
 			BackgroundJobEnqueuerDep: BackgroundJobEnqueuerDep{
 				BackgroundJobEnqueuer: enqueuer,
 			},

--- a/pkg/services/stack_resource_service.go
+++ b/pkg/services/stack_resource_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Stackdome/stackdome/pkg/auth"
 	"github.com/Stackdome/stackdome/pkg/clustermanager"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/db"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/logger"
@@ -48,6 +49,7 @@ type StackResourceServiceSpec struct {
 	StackDomainService     StackDomainsService
 	ReferenceService       ReferenceService
 	ResourceValidator      stackresourcevalidator.Validator
+	ComputePolicy          computequota.Policy
 }
 
 type stackResourceService struct {
@@ -62,6 +64,7 @@ type stackResourceService struct {
 	domainNameService      StackDomainsService
 	referenceService       ReferenceService
 	resourceValidator      stackresourcevalidator.Validator
+	computePolicy          computequota.Policy
 }
 
 func NewStackResourceService(spec StackResourceServiceSpec) StackResourceService {
@@ -85,6 +88,7 @@ func NewStackResourceService(spec StackResourceServiceSpec) StackResourceService
 		domainNameService:      spec.StackDomainService,
 		referenceService:       spec.ReferenceService,
 		resourceValidator:      spec.ResourceValidator,
+		computePolicy:          spec.ComputePolicy,
 	}
 }
 
@@ -101,6 +105,7 @@ func (s *stackResourceService) Create(ctx context.Context, resource *models.Stac
 		return nil, permErr
 	}
 
+	s.computePolicy.ApplyStackResourceDefaults(resource)
 	siblings, sErr := s.stackResourceStore.GetByStackID(ctx, resource.StackID)
 	if sErr != nil {
 		return nil, sErr
@@ -115,6 +120,16 @@ func (s *stackResourceService) Create(ctx context.Context, resource *models.Stac
 
 	var created *models.StackResource
 	if err := s.stackStore.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(txCtx, stack.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		s.computePolicy.ApplyStackResourceDefaults(resource)
+		if limitErr := s.computePolicy.ValidateStackLimits(txCtx, computequota.StackLimitChange{
+			Operation:      computequota.StackLimitAddResource,
+			OrganisationID: stack.OrganisationID,
+		}); limitErr != nil {
+			return limitErr
+		}
 		var createErr *errors.ServiceError
 		created, createErr = s.InternalCreateWithTx(txCtx, stack, resource)
 		if createErr != nil {
@@ -146,6 +161,7 @@ func (s *stackResourceService) Update(ctx context.Context, stackID, resourceName
 	resource.ID = existing.ID
 	resource.Name = resourceName
 
+	s.computePolicy.ApplyStackResourceDefaults(resource)
 	all, sErr := s.stackResourceStore.GetByStackID(ctx, stackID)
 	if sErr != nil {
 		return nil, sErr
@@ -166,6 +182,16 @@ func (s *stackResourceService) Update(ctx context.Context, stackID, resourceName
 
 	var updated *models.StackResource
 	if txErr := s.stackStore.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(txCtx, stack.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		s.computePolicy.ApplyStackResourceDefaults(resource)
+		if limitErr := s.computePolicy.ValidateStackLimits(txCtx, computequota.StackLimitChange{
+			Operation:      computequota.StackLimitUpdateResource,
+			OrganisationID: stack.OrganisationID,
+		}); limitErr != nil {
+			return limitErr
+		}
 		var updateErr *errors.ServiceError
 		updated, updateErr = s.InternalUpdateWithTx(txCtx, stack, existing.ID, resource)
 		if updateErr != nil {
@@ -357,14 +383,21 @@ func (s *stackResourceService) Restart(ctx context.Context, stackID, resourceNam
 	}
 
 	now := time.Now().UTC()
-	if resource.LifecycleConfig == nil {
-		resource.LifecycleConfig = &models.LifecycleConfig{}
-	}
-	resource.LifecycleConfig.RestartRequestTime = &now
+	var updated *models.StackResource
+	if txErr := s.stackStore.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(txCtx, stack.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		if resource.LifecycleConfig == nil {
+			resource.LifecycleConfig = &models.LifecycleConfig{}
+		}
+		resource.LifecycleConfig.RestartRequestTime = &now
 
-	updated, updateErr := s.stackResourceStore.Update(ctx, resource.ID, resource, stack)
-	if updateErr != nil {
-		return nil, updateErr
+		var updateErr *errors.ServiceError
+		updated, updateErr = s.stackResourceStore.Update(txCtx, resource.ID, resource, stack)
+		return updateErr
+	}); txErr != nil {
+		return nil, txErr
 	}
 
 	// Patch the StackResource CR in the cluster directly with the new restart timestamp.

--- a/pkg/services/stack_resource_service_test.go
+++ b/pkg/services/stack_resource_service_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Stackdome/stackdome/pkg/auth"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/mocks"
 	"github.com/Stackdome/stackdome/pkg/models"
@@ -28,6 +29,7 @@ func TestStackResourceService_Restart(t *testing.T) {
 			stackStore:         mockStackStore,
 			stackResourceStore: mockResourceStore,
 			permissions:        mockPermissions,
+			computePolicy:      computequota.NewSelfHostedPolicy(),
 		}
 
 		ctx := context.Background()
@@ -67,6 +69,10 @@ func TestStackResourceService_Restart(t *testing.T) {
 		mockResourceStore.EXPECT().
 			GetByStackIDAndResourceName(ctx, stackID, resourceName).
 			Return(resource, nil)
+		mockStackStore.EXPECT().WithTransaction(ctx, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, fn func(context.Context) *errors.ServiceError) *errors.ServiceError {
+				return fn(ctx)
+			})
 
 		mockResourceStore.EXPECT().
 			Update(ctx, resource.ID, gomock.Any(), stack).
@@ -97,6 +103,7 @@ func TestStackResourceService_Restart(t *testing.T) {
 			stackStore:         mockStackStore,
 			stackResourceStore: mockResourceStore,
 			permissions:        mockPermissions,
+			computePolicy:      computequota.NewSelfHostedPolicy(),
 		}
 
 		ctx := context.Background()
@@ -136,6 +143,7 @@ func TestStackResourceService_Restart(t *testing.T) {
 			stackStore:         mockStackStore,
 			stackResourceStore: mockResourceStore,
 			permissions:        mockPermissions,
+			computePolicy:      computequota.NewSelfHostedPolicy(),
 		}
 
 		ctx := context.Background()

--- a/pkg/services/stack_resource_service_validation_test.go
+++ b/pkg/services/stack_resource_service_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Stackdome/stackdome/pkg/auth"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/mocks"
 	"github.com/Stackdome/stackdome/pkg/models"
@@ -32,6 +33,7 @@ func TestStackResourceService_Create_Validation(t *testing.T) {
 			stackResourceStore: mockResourceStore,
 			permissions:        mockPermissions,
 			resourceValidator:  mockValidator,
+			computePolicy:      computequota.NewSelfHostedPolicy(),
 		}
 
 		resource := &models.StackResource{StackID: stackID, Name: "web"}
@@ -78,6 +80,7 @@ func TestStackResourceService_Create_Validation(t *testing.T) {
 			resourceValidator:  mockValidator,
 			referenceService:   mockReferenceService,
 			domainNameService:  mockDomains,
+			computePolicy:      computequota.NewSelfHostedPolicy(),
 		}
 
 		resource := &models.StackResource{StackID: stackID, Name: "web"}
@@ -123,6 +126,7 @@ func TestStackResourceService_Create_Validation(t *testing.T) {
 			stackResourceStore: mockResourceStore,
 			permissions:        mockPermissions,
 			resourceValidator:  mockValidator,
+			computePolicy:      computequota.NewSelfHostedPolicy(),
 		}
 
 		resource := &models.StackResource{StackID: stackID, Name: "web"}
@@ -167,6 +171,7 @@ func TestStackResourceService_Update_Validation(t *testing.T) {
 			resourceValidator:  mockValidator,
 			referenceService:   mockReferenceService,
 			domainNameService:  mockDomains,
+			computePolicy:      computequota.NewSelfHostedPolicy(),
 		}
 
 		existing := &models.StackResource{ID: "resource-1", StackID: stackID, Name: resourceName}

--- a/pkg/services/stack_service.go
+++ b/pkg/services/stack_service.go
@@ -351,7 +351,7 @@ func (s *stackService) InternalUpdateStack(ctx context.Context, ID string, spec 
 		if limitErr := s.computePolicy.ValidateStackLimits(ctx, computequota.StackLimitChange{
 			Operation:            computequota.StackLimitReplaceStack,
 			OrganisationID:       existingStack.OrganisationID,
-			StackID:              existingStack.ID,
+			ReplacedStackID:      existingStack.ID,
 			DesiredResourceCount: int64(len(spec.StackResources)),
 		}); limitErr != nil {
 			return limitErr

--- a/pkg/services/stack_service.go
+++ b/pkg/services/stack_service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Stackdome/stackdome/pkg/auth"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/db"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/logger"
@@ -73,6 +74,7 @@ type StackServiceSpec struct {
 	CredentialResolver    CredentialResolver
 	GitIntegrationService GitIntegrationService
 	PlatformBaseDomain    string
+	ComputePolicy         computequota.Policy
 }
 
 type stackService struct {
@@ -92,6 +94,7 @@ type stackService struct {
 	releaseService       releaseServiceForStack
 	referenceService     ReferenceService
 	defaultingService    DefaultingService[*models.Stack]
+	computePolicy        computequota.Policy
 	ClusterResourceServiceDeps
 	BackgroundJobEnqueuerDep
 }
@@ -148,6 +151,7 @@ func NewStackService(spec StackServiceSpec) StackService {
 		permissions:          spec.Permissions,
 		referenceService:     spec.ReferenceService,
 		defaultingService:    NewStackDefaultingService(),
+		computePolicy:        spec.ComputePolicy,
 	}
 }
 
@@ -199,6 +203,7 @@ func (s *stackService) InternalCreateStack(ctx context.Context, spec *models.Sta
 	}
 
 	s.logger.Info(ctx, "running validation for stack creation: %s", spec.Name)
+	s.applyComputeStackResourceDefaults(spec)
 	if err := s.stackValidator.ValidateForCreate(ctx, spec); err != nil {
 		return nil, err
 	}
@@ -226,6 +231,17 @@ func (s *stackService) InternalCreateStack(ctx context.Context, spec *models.Sta
 
 	var createdStack *models.Stack
 	err = s.stackStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(ctx, spec.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		s.applyComputeStackResourceDefaults(spec)
+		if limitErr := s.computePolicy.ValidateStackLimits(ctx, computequota.StackLimitChange{
+			Operation:            computequota.StackLimitCreateStack,
+			OrganisationID:       spec.OrganisationID,
+			DesiredResourceCount: int64(len(spec.StackResources)),
+		}); limitErr != nil {
+			return limitErr
+		}
 		createdStack, err = s.InternalCreateWithTx(ctx, spec, namespaceForStack)
 		if err != nil {
 			return err
@@ -318,6 +334,7 @@ func (s *stackService) InternalUpdateStack(ctx context.Context, ID string, spec 
 	spec.ProjectID = existingStack.ProjectID
 	spec.UserID = existingStack.UserID
 
+	s.applyComputeStackResourceDefaults(spec)
 	if err := s.stackValidator.ValidateForUpdate(ctx, existingStack, spec); err != nil {
 		return nil, err
 	}
@@ -327,6 +344,18 @@ func (s *stackService) InternalUpdateStack(ctx context.Context, ID string, spec 
 	// Update stack and domains within transaction
 	var updatedStack *models.Stack
 	err = s.stackStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(ctx, existingStack.OrganisationID); accessErr != nil {
+			return accessErr
+		}
+		s.applyComputeStackResourceDefaults(spec)
+		if limitErr := s.computePolicy.ValidateStackLimits(ctx, computequota.StackLimitChange{
+			Operation:            computequota.StackLimitReplaceStack,
+			OrganisationID:       existingStack.OrganisationID,
+			StackID:              existingStack.ID,
+			DesiredResourceCount: int64(len(spec.StackResources)),
+		}); limitErr != nil {
+			return limitErr
+		}
 		updatedStack, err = s.InternalUpdateWithTx(ctx, spec, existingStack)
 		if err != nil {
 			return err
@@ -351,6 +380,12 @@ func (s *stackService) InternalUpdateStack(ctx context.Context, ID string, spec 
 
 	s.logger.WithField(logger.FieldStackID, updatedStack.ID).Info(ctx, "updated stack")
 	return updatedStack, nil
+}
+
+func (s *stackService) applyComputeStackResourceDefaults(stack *models.Stack) {
+	for _, resource := range stack.StackResources {
+		s.computePolicy.ApplyStackResourceDefaults(resource)
+	}
 }
 
 func (s *stackService) UpdateStackShell(ctx context.Context, ID string, spec *models.Stack) (*models.Stack, *errors.ServiceError) {
@@ -481,6 +516,9 @@ func (s *stackService) CreateStackVolume(ctx context.Context, stackID string, vo
 	}
 	var created *models.Volume
 	txErr := s.stackStore.WithTransaction(ctx, func(ctx context.Context) *errors.ServiceError {
+		if accessErr := s.computePolicy.EnsureAccess(ctx, stack.OrganisationID); accessErr != nil {
+			return accessErr
+		}
 		// Lock the stack row so concurrent creates serialize; the duplicate-name
 		// check below then observes any volume a competing request committed.
 		// There is no DB unique constraint on volume name within a stack (the

--- a/pkg/services/stack_validator_wiring_test.go
+++ b/pkg/services/stack_validator_wiring_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Stackdome/stackdome/config"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/db"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/mocks"
@@ -88,6 +89,7 @@ func newProductionWiredStackValidator(t testContext, sf db.SessionFactory, platf
 		CredentialResolver:    mocks.NewMockCredentialResolver(ctrl),
 		GitIntegrationService: mocks.NewMockGitIntegrationService(ctrl),
 		PlatformBaseDomain:    platformBaseDomain,
+		ComputePolicy:         computequota.NewSelfHostedPolicy(),
 	}).(*stackService)
 	return svc.stackValidator
 }

--- a/pkg/services/stack_volume_create_test.go
+++ b/pkg/services/stack_volume_create_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Stackdome/stackdome/pkg/auth"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/mocks"
 	"github.com/Stackdome/stackdome/pkg/models"
@@ -32,6 +33,7 @@ func TestStackService_CreateStackVolume(t *testing.T) {
 			stackStore:    mockStackStore,
 			volumeService: mockVolumeService,
 			permissions:   mockPermissions,
+			computePolicy: computequota.NewSelfHostedPolicy(),
 			BackgroundJobEnqueuerDep: BackgroundJobEnqueuerDep{
 				BackgroundJobEnqueuer: mockEnqueuer,
 			},
@@ -62,7 +64,11 @@ func TestStackService_CreateStackVolume(t *testing.T) {
 
 		mockStackStore := mocks.NewMockStackStore(ctrl)
 		mockPermissions := mocks.NewMockPermissionService(ctrl)
-		svc := &stackService{stackStore: mockStackStore, permissions: mockPermissions}
+		svc := &stackService{
+			stackStore:    mockStackStore,
+			permissions:   mockPermissions,
+			computePolicy: computequota.NewSelfHostedPolicy(),
+		}
 
 		mockStackStore.EXPECT().GetByID(ctx, stackID).Return(stack, nil)
 		mockPermissions.EXPECT().Check(ctx, projectID, auth.ResourceStacks, stackID, auth.ActionRead).Return(nil)

--- a/pkg/services/volume_service.go
+++ b/pkg/services/volume_service.go
@@ -295,7 +295,10 @@ func (s *volumeService) prepareCreate(ctx context.Context, spec *models.Volume) 
 	if spec.Size == "" {
 		return errors.Validation("spec.size is required")
 	}
-	return s.computePolicy.ValidateVolumeLimits(ctx, spec.OrganisationID, spec.Size)
+	return s.computePolicy.ValidateVolumeLimits(ctx, computequota.VolumeLimitChange{
+		OrganisationID: spec.OrganisationID,
+		Size:           spec.Size,
+	})
 }
 
 func (s *volumeService) UpdateStatus(ctx context.Context, ID string, status *models.VolumeStatus) *errors.ServiceError {

--- a/pkg/services/volume_service.go
+++ b/pkg/services/volume_service.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/Stackdome/stackdome/pkg/auth"
+	"github.com/Stackdome/stackdome/pkg/computequota"
 	"github.com/Stackdome/stackdome/pkg/db"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/logger"
@@ -43,6 +44,7 @@ type VolumeServiceSpec struct {
 	ReferenceService ReferenceService
 	Logger           logger.Logger
 	Permissions      auth.PermissionService
+	ComputePolicy    computequota.Policy
 }
 
 func NewVolumeService(spec VolumeServiceSpec) VolumeService {
@@ -56,6 +58,7 @@ func NewVolumeService(spec VolumeServiceSpec) VolumeService {
 		referenceService: spec.ReferenceService,
 		logger:           spec.Logger,
 		permissions:      spec.Permissions,
+		computePolicy:    spec.ComputePolicy,
 	}
 }
 
@@ -66,6 +69,7 @@ type volumeService struct {
 	clusterResourceService clusterresource.VolumeClusterResourceService
 	logger                 logger.Logger
 	permissions            auth.PermissionService
+	computePolicy          computequota.Policy
 }
 
 func (s *volumeService) InjectClusterResourceService(volumeClusterService clusterresource.VolumeClusterResourceService) {
@@ -104,7 +108,10 @@ func (s *volumeService) InternalCreateWithTx(ctx context.Context, stack *models.
 	volume.UserID = stack.UserID
 	volume.Namespace = stack.Namespace
 
-	createdVolume, err := s.CreateInDbWithTx(ctx, volume)
+	if err := s.prepareCreate(ctx, volume); err != nil {
+		return nil, err
+	}
+	createdVolume, err := s.createInDbWithTx(ctx, volume)
 	if err != nil {
 		return nil, errors.GeneralError("failed to create volume '%s': %s", volume.Name, err.Error())
 	}
@@ -231,11 +238,11 @@ func (s *volumeService) UpdateRemoteSourceRevision(ctx context.Context, ID strin
 
 // Assume ctx already has a transaction
 func (s *volumeService) CreateWithTx(ctx context.Context, spec *models.Volume) (*models.Volume, *errors.ServiceError) {
-	var createdVolume *models.Volume
-	var err *errors.ServiceError
-	createdVolume, err = s.volumeStore.CreateWithTx(ctx, spec)
+	if err := s.prepareCreate(ctx, spec); err != nil {
+		return nil, err
+	}
+	createdVolume, err := s.createInDbWithTx(ctx, spec)
 	if err != nil {
-		s.logger.Error(ctx, "failed to create volume: %v", err)
 		return nil, err
 	}
 	cerr := s.clusterResourceService.CreateVolumeInCluster(ctx, createdVolume)
@@ -265,14 +272,30 @@ func (s *volumeService) CreateInCluster(ctx context.Context, spec *models.Volume
 }
 
 func (s *volumeService) CreateInDbWithTx(ctx context.Context, spec *models.Volume) (*models.Volume, *errors.ServiceError) {
-	var createdVolume *models.Volume
-	var err *errors.ServiceError
-	createdVolume, err = s.volumeStore.CreateWithTx(ctx, spec)
+	if err := s.prepareCreate(ctx, spec); err != nil {
+		return nil, err
+	}
+	return s.createInDbWithTx(ctx, spec)
+}
+
+func (s *volumeService) createInDbWithTx(ctx context.Context, spec *models.Volume) (*models.Volume, *errors.ServiceError) {
+	createdVolume, err := s.volumeStore.CreateWithTx(ctx, spec)
 	if err != nil {
 		s.logger.Error(ctx, "failed to create volume: %v", err)
 		return nil, err
 	}
 	return createdVolume, nil
+}
+
+func (s *volumeService) prepareCreate(ctx context.Context, spec *models.Volume) *errors.ServiceError {
+	if err := s.computePolicy.EnsureAccess(ctx, spec.OrganisationID); err != nil {
+		return err
+	}
+	s.computePolicy.ApplyVolumeDefaults(spec)
+	if spec.Size == "" {
+		return errors.Validation("spec.size is required")
+	}
+	return s.computePolicy.ValidateVolumeLimits(ctx, spec.OrganisationID, spec.Size)
 }
 
 func (s *volumeService) UpdateStatus(ctx context.Context, ID string, status *models.VolumeStatus) *errors.ServiceError {

--- a/pkg/stores/pgstore/compute_access.go
+++ b/pkg/stores/pgstore/compute_access.go
@@ -1,0 +1,170 @@
+package pgstore
+
+import (
+	"context"
+	stderrors "errors"
+	"time"
+
+	"github.com/Stackdome/stackdome/pkg/computeaccess"
+	"github.com/Stackdome/stackdome/pkg/db"
+	"github.com/Stackdome/stackdome/pkg/errors"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const sharedComputeCapacityAdvisoryLockKey int64 = 0x535441434b444f4d
+
+type ComputeAccessStoreSpec struct {
+	SessionFactory db.SessionFactory
+	// MaxActiveSharedComputeLeases is platform-wide and fixed for this store.
+	MaxActiveSharedComputeLeases int
+}
+
+type computeAccessStore struct {
+	sessionFactory               db.SessionFactory
+	maxActiveSharedComputeLeases int
+}
+
+// NewComputeAccessStore fixes the platform capacity ceiling at construction so
+// individual activation callers cannot weaken the platform-wide limit.
+func NewComputeAccessStore(spec ComputeAccessStoreSpec) computeaccess.Store {
+	return &computeAccessStore{
+		sessionFactory:               spec.SessionFactory,
+		maxActiveSharedComputeLeases: spec.MaxActiveSharedComputeLeases,
+	}
+}
+
+func (s *computeAccessStore) Activate(ctx context.Context, activation computeaccess.ComputeAccessActivation) (*computeaccess.ComputeAccess, *errors.ServiceError) {
+	tx := db.TxFromContext(ctx)
+	if tx == nil {
+		return nil, errors.GeneralError("transaction not found in context")
+	}
+	if s.maxActiveSharedComputeLeases <= 0 {
+		return nil, errors.GeneralError("maximum active shared compute leases must be greater than zero")
+	}
+
+	// Return an existing grant so retrying the first capacity-consuming request
+	// is safe.
+	access, err := findCurrentComputeAccessForUpdate(tx, activation.OrganisationID)
+	if err == nil {
+		return validateComputeAccess(access, activation.StartsAt)
+	}
+	if !stderrors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, errors.GeneralError("failed to get compute access: %v", err)
+	}
+
+	// Serialize first-time grants before checking the platform-wide ceiling.
+	if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", sharedComputeCapacityAdvisoryLockKey).Error; err != nil {
+		return nil, errors.GeneralError("failed to lock shared compute capacity: %v", err)
+	}
+
+	// A concurrent activation may have completed while this transaction waited
+	// for the advisory lock.
+	access, err = findCurrentComputeAccessForUpdate(tx, activation.OrganisationID)
+	if err == nil {
+		return validateComputeAccess(access, activation.StartsAt)
+	}
+	if !stderrors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, errors.GeneralError("failed to get compute access: %v", err)
+	}
+
+	// With no current lease, an existing entitlement is a previously consumed
+	// grant and must not be issued again.
+	entitlementPreviouslyGranted, err := hasComputeEntitlementForUpdate(tx, activation.OrganisationID, activation.EntitlementSource)
+	if err != nil {
+		return nil, errors.GeneralError("failed to get compute entitlement: %v", err)
+	}
+	if entitlementPreviouslyGranted {
+		return nil, errors.ComputeAccessInactive()
+	}
+
+	// Capacity remains reserved until runtime cleanup marks the lease cleaned.
+	var activeLeaseCount int64
+	if err := tx.Model(&computeaccess.SharedComputeLease{}).
+		Where("state <> ?", computeaccess.SharedComputeLeaseStateCleaned).
+		Count(&activeLeaseCount).Error; err != nil {
+		return nil, errors.GeneralError("failed to count shared compute leases: %v", err)
+	}
+	if activeLeaseCount >= int64(s.maxActiveSharedComputeLeases) {
+		return nil, errors.SharedComputeCapacityReached()
+	}
+
+	entitlement := &computeaccess.ComputeEntitlement{
+		ID:             uuid.NewString(),
+		OrganisationID: activation.OrganisationID,
+		Source:         activation.EntitlementSource,
+		Status:         computeaccess.ComputeEntitlementStatusActive,
+		StartsAt:       activation.StartsAt,
+		ExpiresAt:      activation.ExpiresAt,
+	}
+	if err := tx.Create(entitlement).Error; err != nil {
+		return nil, errors.GeneralError("failed to create compute entitlement: %v", err)
+	}
+
+	lease := &computeaccess.SharedComputeLease{
+		ID:             uuid.NewString(),
+		OrganisationID: activation.OrganisationID,
+		EntitlementID:  entitlement.ID,
+		State:          computeaccess.SharedComputeLeaseStateActive,
+		ActivatedAt:    activation.StartsAt,
+	}
+	if err := tx.Create(lease).Error; err != nil {
+		return nil, errors.GeneralError("failed to create shared compute lease: %v", err)
+	}
+
+	return &computeaccess.ComputeAccess{Entitlement: entitlement, Lease: lease}, nil
+}
+
+func findCurrentComputeAccessForUpdate(tx *gorm.DB, organisationID string) (*computeaccess.ComputeAccess, error) {
+	var lease computeaccess.SharedComputeLease
+	if err := tx.Clauses(clause.Locking{Strength: rowLockStrengthUpdate}).
+		Where("organisation_id = ? AND state <> ?", organisationID, computeaccess.SharedComputeLeaseStateCleaned).
+		First(&lease).Error; err != nil {
+		return nil, err
+	}
+
+	var entitlement computeaccess.ComputeEntitlement
+	if err := tx.Clauses(clause.Locking{Strength: rowLockStrengthUpdate}).
+		Where("id = ?", lease.EntitlementID).
+		First(&entitlement).Error; err != nil {
+		return nil, err
+	}
+
+	return &computeaccess.ComputeAccess{Entitlement: &entitlement, Lease: &lease}, nil
+}
+
+func hasComputeEntitlementForUpdate(tx *gorm.DB, organisationID string, source computeaccess.ComputeEntitlementSource) (bool, error) {
+	var entitlement computeaccess.ComputeEntitlement
+	err := tx.Clauses(clause.Locking{Strength: rowLockStrengthUpdate}).
+		Select("id").
+		Where("organisation_id = ? AND source = ?", organisationID, source).
+		First(&entitlement).Error
+	if stderrors.Is(err, gorm.ErrRecordNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func validateComputeAccess(access *computeaccess.ComputeAccess, now time.Time) (*computeaccess.ComputeAccess, *errors.ServiceError) {
+	if access == nil || access.Entitlement == nil || access.Lease == nil {
+		return nil, errors.ComputeAccessInactive()
+	}
+	entitlement := access.Entitlement
+	if entitlement.Status != computeaccess.ComputeEntitlementStatusActive {
+		return nil, errors.ComputeAccessInactive()
+	}
+	if entitlement.StartsAt.After(now) {
+		return nil, errors.ComputeAccessInactive()
+	}
+	if entitlement.ExpiresAt != nil && !entitlement.ExpiresAt.After(now) {
+		return nil, errors.ComputeAccessInactive()
+	}
+	if access.Lease.State != computeaccess.SharedComputeLeaseStateActive {
+		return nil, errors.ComputeAccessInactive()
+	}
+	return access, nil
+}

--- a/pkg/stores/pgstore/compute_access.go
+++ b/pkg/stores/pgstore/compute_access.go
@@ -13,6 +13,8 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// sharedComputeCapacityAdvisoryLockKey is the stable PostgreSQL advisory-lock
+// namespace key for shared-compute allocation; its eight bytes spell STACKDOM.
 const sharedComputeCapacityAdvisoryLockKey int64 = 0x535441434b444f4d
 
 type ComputeAccessStoreSpec struct {

--- a/pkg/stores/pgstore/compute_usage.go
+++ b/pkg/stores/pgstore/compute_usage.go
@@ -1,0 +1,70 @@
+package pgstore
+
+import (
+	"context"
+
+	"github.com/Stackdome/stackdome/pkg/computequota"
+	"github.com/Stackdome/stackdome/pkg/db"
+	"github.com/Stackdome/stackdome/pkg/errors"
+	"github.com/Stackdome/stackdome/pkg/models"
+	"gorm.io/gorm/clause"
+)
+
+type computeUsageStore struct{}
+
+var _ computequota.UsageStore = (*computeUsageStore)(nil)
+
+func NewComputeUsageStore() computequota.UsageStore {
+	return &computeUsageStore{}
+}
+
+func (*computeUsageStore) LockOrganisationAndGetUsage(ctx context.Context, organisationID, excludeStackID string) (computequota.ComputeUsage, *errors.ServiceError) {
+	tx := db.TxFromContext(ctx)
+	if tx == nil {
+		return computequota.ComputeUsage{}, errors.GeneralError("transaction not found in context")
+	}
+
+	organisationQuery := tx.Model(&models.Organisation{}).
+		Select("id").
+		Where("id = ?", organisationID).
+		Clauses(clause.Locking{Strength: rowLockStrengthUpdate})
+	var lockedOrganisationID string
+	result := organisationQuery.Scan(&lockedOrganisationID)
+	if result.Error != nil {
+		return computequota.ComputeUsage{}, errors.GeneralError("failed to lock organisation for compute usage: %v", result.Error)
+	}
+	if result.RowsAffected != 1 {
+		return computequota.ComputeUsage{}, errors.NotFound("organisation '%s' not found", organisationID)
+	}
+
+	usage := computequota.ComputeUsage{}
+	if err := tx.Model(&models.Stack{}).
+		Where("organisation_id = ?", organisationID).
+		Count(&usage.StackCount).Error; err != nil {
+		return computequota.ComputeUsage{}, errors.GeneralError("failed to count organisation stacks: %v", err)
+	}
+
+	stackResourceQuery := tx.Table("stack_resources AS sr").
+		Joins("JOIN stacks AS s ON s.id = sr.stack_id").
+		Where("s.organisation_id = ?", organisationID)
+	if excludeStackID != "" {
+		stackResourceQuery = stackResourceQuery.Where("s.id <> ?", excludeStackID)
+	}
+	if err := stackResourceQuery.Count(&usage.StackResourceCount).Error; err != nil {
+		return computequota.ComputeUsage{}, errors.GeneralError("failed to count organisation stack resources: %v", err)
+	}
+
+	if err := tx.Model(&models.Volume{}).
+		Where("organisation_id = ?", organisationID).
+		Count(&usage.VolumeCount).Error; err != nil {
+		return computequota.ComputeUsage{}, errors.GeneralError("failed to count organisation volumes: %v", err)
+	}
+
+	if err := tx.Model(&models.PostgresAddon{}).
+		Where("organisation_id = ?", organisationID).
+		Count(&usage.PostgresAddonCount).Error; err != nil {
+		return computequota.ComputeUsage{}, errors.GeneralError("failed to count organisation PostgreSQL addons: %v", err)
+	}
+
+	return usage, nil
+}

--- a/pkg/stores/pgstore/compute_usage.go
+++ b/pkg/stores/pgstore/compute_usage.go
@@ -18,7 +18,7 @@ func NewComputeUsageStore() computequota.UsageStore {
 	return &computeUsageStore{}
 }
 
-func (*computeUsageStore) LockOrganisationAndGetUsage(ctx context.Context, organisationID, excludeStackID string) (computequota.ComputeUsage, *errors.ServiceError) {
+func (*computeUsageStore) LockOrganisationAndGetUsage(ctx context.Context, organisationID, replacedStackID string) (computequota.ComputeUsage, *errors.ServiceError) {
 	tx := db.TxFromContext(ctx)
 	if tx == nil {
 		return computequota.ComputeUsage{}, errors.GeneralError("transaction not found in context")
@@ -47,8 +47,10 @@ func (*computeUsageStore) LockOrganisationAndGetUsage(ctx context.Context, organ
 	stackResourceQuery := tx.Table("stack_resources AS sr").
 		Joins("JOIN stacks AS s ON s.id = sr.stack_id").
 		Where("s.organisation_id = ?", organisationID)
-	if excludeStackID != "" {
-		stackResourceQuery = stackResourceQuery.Where("s.id <> ?", excludeStackID)
+	if replacedStackID != "" {
+		// A replacement supplies the complete desired resource set, so its old
+		// persisted resources must not contribute to the proposed total.
+		stackResourceQuery = stackResourceQuery.Where("s.id <> ?", replacedStackID)
 	}
 	if err := stackResourceQuery.Count(&usage.StackResourceCount).Error; err != nil {
 		return computequota.ComputeUsage{}, errors.GeneralError("failed to count organisation stack resources: %v", err)

--- a/pkg/worker/clusterimageregistry/cluster_image_registry_worker.go
+++ b/pkg/worker/clusterimageregistry/cluster_image_registry_worker.go
@@ -98,6 +98,9 @@ func (w *clusterImageRegistryWorker) Execute(ctx context.Context, operand worker
 			}
 			continue
 		}
+		if cluster.SharedCompute && registry.Status != nil && registry.Status.State == models.RegistryStatePending {
+			continue
+		}
 
 		if registry.Status != nil && registry.Status.State == models.RegistryStateRunning {
 			continue

--- a/pkg/worker/preview/provision_reconciler.go
+++ b/pkg/worker/preview/provision_reconciler.go
@@ -80,7 +80,7 @@ func (r *provisionReconciler) Reconcile(ctx context.Context, preview *models.Pre
 			}
 		}
 
-		if txErr := r.previewStackStore.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
+		txErr := r.previewStackStore.WithTransaction(ctx, func(txCtx context.Context) *errors.ServiceError {
 			if needsUpdate {
 				if _, sErr := r.stackService.InternalUpdateStack(txCtx, *preview.StackID, model); sErr != nil {
 					return sErr
@@ -109,7 +109,11 @@ func (r *provisionReconciler) Reconcile(ctx context.Context, preview *models.Pre
 				return sErr
 			}
 			return nil
-		}); txErr != nil {
+		})
+		if txErr != nil {
+			if reason, recognized := previewAdmissionDenialReason(txErr); recognized {
+				return r.fail(ctx, preview, reason, txErr.Reason)
+			}
 			return resultNil, fmt.Errorf("sync transaction failed: %w", txErr)
 		}
 
@@ -158,11 +162,31 @@ func (r *provisionReconciler) Reconcile(ctx context.Context, preview *models.Pre
 		}
 		return nil
 	}); txErr != nil {
+		if reason, recognized := previewAdmissionDenialReason(txErr); recognized {
+			return r.fail(ctx, preview, reason, txErr.Reason)
+		}
 		return resultNil, fmt.Errorf("provision transaction failed: %w", txErr)
 	}
 
 	r.logger.Info(ctx, "preview %s provisioned, stack %s created", preview.ID, created.ID)
 	return resultRequeueAfter(convergePollInterval), nil
+}
+
+func previewAdmissionDenialReason(sErr *errors.ServiceError) (string, bool) {
+	if sErr == nil {
+		return "", false
+	}
+
+	switch sErr.Code {
+	case errors.ErrorComputeAccessInactive:
+		return "ComputeAccessInactive", true
+	case errors.ErrorComputeQuotaExceeded:
+		return "ComputeQuotaExceeded", true
+	case errors.ErrorSharedComputeCapacityReached:
+		return "SharedComputeCapacityUnavailable", true
+	default:
+		return "", false
+	}
 }
 
 func (r *provisionReconciler) resolveStackfileContent(ctx context.Context, preview *models.PreviewStack, config *models.StackPreviewConfig) ([]byte, string, *errors.OperationError) {

--- a/pkg/worker/preview/provision_reconciler_test.go
+++ b/pkg/worker/preview/provision_reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/http"
 	"sync"
 	"time"
 
@@ -184,6 +185,50 @@ var _ = Describe("ProvisionReconciler", func() {
 			Expect(result).To(Equal(resultNil))
 		})
 
+		DescribeTable("durably fails when the create transaction returns a recognized compute denial",
+			func(denial *errors.ServiceError, expectedReason string, expectedHTTPStatus int) {
+				stackfileContent := []byte("name: my-app")
+				builtStack := &models.Stack{Name: "my-app"}
+				createdStack := &models.Stack{ID: "stack-1", Name: "my-app"}
+				txCtx, cancelTx := context.WithCancel(ctx)
+				defer cancelTx()
+				transactionExited := false
+				Expect(denial.HttpCode).To(Equal(expectedHTTPStatus))
+
+				cfgStore.EXPECT().GetByID(ctx, "cfg-1").Return(config, nil)
+				previewService.EXPECT().InternalFetchStackfile(ctx, config, preview.CommitSHA).
+					Return(stackfileContent, "hash-abc", nil)
+				previewService.EXPECT().InternalBuildStackFromContent(ctx, config, preview, stackfileContent).
+					Return(builtStack, nil)
+				previewStore.EXPECT().WithTransaction(ctx, gomock.Any()).
+					DoAndReturn(func(_ context.Context, fn func(context.Context) *errors.ServiceError) *errors.ServiceError {
+						txErr := fn(txCtx)
+						Expect(txErr).To(BeIdenticalTo(denial))
+						transactionExited = true
+						return txErr
+					})
+				stackSvc.EXPECT().InternalCreateStack(txCtx, builtStack).Return(createdStack, nil)
+				releaseSvc.EXPECT().InternalCreateRelease(txCtx, "stack-1", gomock.Any()).Return(nil, denial)
+				previewStore.EXPECT().Update(ctx, preview).
+					DoAndReturn(func(_ context.Context, failed *models.PreviewStack) (*models.PreviewStack, *errors.ServiceError) {
+						Expect(transactionExited).To(BeTrue())
+						Expect(failed.Status).To(Equal(models.PreviewStackStatus{
+							Phase:   models.PreviewStackPhaseFailed,
+							Reason:  expectedReason,
+							Message: denial.Reason,
+						}))
+						return failed, nil
+					})
+
+				result, err := reconciler.Reconcile(ctx, preview)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(resultStop))
+			},
+			Entry("compute access inactive", errors.ComputeAccessInactive(), "ComputeAccessInactive", http.StatusGone),
+			Entry("compute quota exceeded", errors.ComputeQuotaExceeded("stack resource limit exceeded"), "ComputeQuotaExceeded", http.StatusBadRequest),
+			Entry("shared compute capacity reached", errors.SharedComputeCapacityReached(), "SharedComputeCapacityUnavailable", http.StatusTooManyRequests),
+		)
+
 		It("uses inline StackfileContent instead of fetching, creates stack and release", func() {
 			preview.StackfileContent = ptr.To("name: inline-app")
 			inlineContent := []byte("name: inline-app")
@@ -299,6 +344,47 @@ var _ = Describe("ProvisionReconciler", func() {
 			result, err := reconciler.Reconcile(ctx, preview)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(resultRequeueAfter(convergePollInterval)))
+		})
+
+		It("durably fails after a recognized compute denial rolls back a sync transaction", func() {
+			stackfileContent := []byte("name: updated-app")
+			builtStack := &models.Stack{Name: "updated-app"}
+			updatedStack := &models.Stack{ID: stackID, Name: "updated-app"}
+			denial := errors.ComputeAccessInactive()
+			txCtx, cancelTx := context.WithCancel(ctx)
+			defer cancelTx()
+			transactionExited := false
+
+			cfgStore.EXPECT().GetByID(ctx, "cfg-1").Return(config, nil)
+			previewService.EXPECT().InternalFetchStackfile(ctx, config, preview.CommitSHA).
+				Return(stackfileContent, "new-hash", nil)
+			previewService.EXPECT().InternalBuildStackFromContent(ctx, config, preview, stackfileContent).
+				Return(builtStack, nil)
+			previewStore.EXPECT().WithTransaction(ctx, gomock.Any()).
+				DoAndReturn(func(_ context.Context, fn func(context.Context) *errors.ServiceError) *errors.ServiceError {
+					txErr := fn(txCtx)
+					Expect(txErr).To(BeIdenticalTo(denial))
+					transactionExited = true
+					return txErr
+				})
+			stackSvc.EXPECT().InternalUpdateStack(txCtx, stackID, builtStack).Return(updatedStack, nil)
+			releaseSvc.EXPECT().InternalCreateRelease(txCtx, stackID, gomock.Any()).Return(nil, denial)
+			previewStore.EXPECT().Update(ctx, preview).
+				DoAndReturn(func(_ context.Context, failed *models.PreviewStack) (*models.PreviewStack, *errors.ServiceError) {
+					Expect(transactionExited).To(BeTrue())
+					Expect(failed.ReconcilerStatus.LastAppliedStackfileHash).To(Equal("old-hash"))
+					Expect(failed.ActiveReleaseID).To(BeNil())
+					Expect(failed.Status).To(Equal(models.PreviewStackStatus{
+						Phase:   models.PreviewStackPhaseFailed,
+						Reason:  "ComputeAccessInactive",
+						Message: denial.Reason,
+					}))
+					return failed, nil
+				})
+
+			result, err := reconciler.Reconcile(ctx, preview)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(resultStop))
 		})
 
 		It("calls UpdateStack when image overrides are present", func() {

--- a/pkg/worker/release/registry_prerequisite_reconciler.go
+++ b/pkg/worker/release/registry_prerequisite_reconciler.go
@@ -1,0 +1,53 @@
+package release
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Stackdome/stackdome/pkg/models"
+	"github.com/Stackdome/stackdome/pkg/services/clusterresource"
+	"github.com/Stackdome/stackdome/pkg/stores"
+)
+
+type registryPrerequisiteReconciler struct {
+	imageRegistryStore    stores.ClusterImageRegistryStore
+	imageRegistryResource clusterresource.ClusterImageRegistryService
+}
+
+func newRegistryPrerequisiteReconciler(spec ReleaseWorkerSpec) *registryPrerequisiteReconciler {
+	return &registryPrerequisiteReconciler{
+		imageRegistryStore:    spec.ImageRegistryStore,
+		imageRegistryResource: spec.ImageRegistryResource,
+	}
+}
+
+func (r *registryPrerequisiteReconciler) Name() string { return "registry-prerequisite" }
+
+func (r *registryPrerequisiteReconciler) Reconcile(ctx context.Context, release *models.StackRelease) (subReconcilerResult, error) {
+	if !snapshotUsesInClusterRegistry(release.Snapshot) {
+		return resultNil, nil
+	}
+
+	registry, serr := r.imageRegistryStore.GetForOrgAndCluster(
+		ctx,
+		release.Snapshot.Stack.OrganisationID,
+		release.Snapshot.Stack.ClusterID,
+	)
+	if serr != nil {
+		return resultNil, fmt.Errorf("load in-cluster registry prerequisite: %w", serr)
+	}
+	if resourceErr := r.imageRegistryResource.EnsureImageRegistryInCluster(ctx, registry); resourceErr != nil {
+		return resultNil, fmt.Errorf("ensure in-cluster registry prerequisite: %w", resourceErr)
+	}
+
+	return resultNil, nil
+}
+
+func snapshotUsesInClusterRegistry(snapshot models.StackSnapshot) bool {
+	for _, resource := range snapshot.Resources {
+		if resource != nil && resource.BuildConfig != nil && resource.BuildConfig.BuildImageRepository.UseInClusterRegistry {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/worker/release/release_worker.go
+++ b/pkg/worker/release/release_worker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Stackdome/stackdome/pkg/credentials"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/models"
+	"github.com/Stackdome/stackdome/pkg/services/clusterresource"
 	"github.com/Stackdome/stackdome/pkg/stackdeploy"
 	"github.com/Stackdome/stackdome/pkg/stores"
 	"github.com/Stackdome/stackdome/pkg/worker"
@@ -47,6 +48,8 @@ type ReleaseWorkerSpec struct {
 	ReleaseWorkerEnqueuer workermanager.BackgroundJobEnqueuer
 	ValidationRecords     stores.ResourceValidationRecordStore
 	RegistryClients       registryClientProvider
+	ImageRegistryStore    stores.ClusterImageRegistryStore
+	ImageRegistryResource clusterresource.ClusterImageRegistryService
 	Env                   string
 }
 
@@ -68,6 +71,7 @@ func NewReleaseWorker(spec ReleaseWorkerSpec) worker.Worker {
 			newDeadlineReconciler(spec),
 			newSimulatorReconciler(spec),
 			newValidationReconciler(spec),
+			newRegistryPrerequisiteReconciler(spec),
 			newRenderReconciler(spec),
 			newApplyReconciler(spec),
 			newConvergeReconciler(spec),

--- a/test/cloudint/cloud_integration_test.go
+++ b/test/cloudint/cloud_integration_test.go
@@ -1,0 +1,30 @@
+//go:build cloud_e2e
+
+package cloudint
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Stackdome/stackdome/test/int/bootstrap"
+)
+
+var cloudEnv = &bootstrap.Environment{}
+
+func TestStackdomeCloudIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Stackdome Cloud Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	Expect(bootstrap.SetupCloud(cloudEnv, ctx)).To(Succeed())
+	DeferCleanup(func() {
+		cancel()
+		cloudEnv.Cleanup()
+	})
+})

--- a/test/cloudint/cloud_policy_e2e_test.go
+++ b/test/cloudint/cloud_policy_e2e_test.go
@@ -1,0 +1,403 @@
+//go:build cloud_e2e
+
+package cloudint
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Stackdome/stackdome/pkg/api/openapi"
+	"github.com/Stackdome/stackdome/pkg/computeaccess"
+	serviceerrors "github.com/Stackdome/stackdome/pkg/errors"
+	"github.com/Stackdome/stackdome/pkg/models"
+	"github.com/Stackdome/stackdome/test/int/bootstrap"
+	"github.com/Stackdome/stackdome/test/int/shared"
+	registryv1alpha1 "stackdome.io/cluster-agent/api/registry/v1alpha1"
+)
+
+var _ = Describe("Stackdome Cloud compute policy", Ordered, func() {
+	const projectName = models.DefaultProjectName
+
+	var (
+		primaryStack *openapi.Stack
+		buildStack   *openapi.Stack
+		postgres     *openapi.PostgresAddon
+	)
+
+	It("boots in Cloud shared mode with pending infrastructure and no compute grant", func() {
+		ctx := context.Background()
+		db := cloudEnv.Database.GetSessionFactory().New(ctx)
+
+		var registry models.ClusterImageRegistry
+		Expect(db.Where("organisation_id = ? AND cluster_id = ?", cloudEnv.OrgID, cloudEnv.ClusterID).
+			Take(&registry).Error).To(Succeed())
+		Expect(registry.Name).To(Equal(cloudEnv.RegistryName))
+		Expect(registry.BackendStorageSize).To(Equal("2Gi"))
+		Expect(registry.BackendStorageClass).To(Equal(bootstrap.CloudTestStorageClass))
+		Expect(registry.Status).NotTo(BeNil())
+		Expect(registry.Status.State).To(Equal(models.RegistryStatePending))
+
+		clusterRegistry := &registryv1alpha1.ClusterRegistry{}
+		err := cloudEnv.Cluster.GetClient().Get(ctx, client.ObjectKey{Name: registry.Name}, clusterRegistry)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "signup must not eagerly create the ClusterRegistry CR")
+
+		entitlements, leases := computeAccessCounts(ctx, cloudEnv.OrgID)
+		Expect(entitlements).To(BeZero())
+		Expect(leases).To(BeZero())
+	})
+
+	It("rolls back a rejected first grant and activates exactly once on valid use", func() {
+		invalidAddon := postgresAddon("first-use-rejected", 2, "1Gi")
+		apiErr := shared.CreatePostgresAddonExpectError(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			invalidAddon,
+			http.StatusBadRequest,
+		)
+		expectServiceError(apiErr, serviceerrors.ErrorComputeQuotaExceeded)
+
+		ctx := context.Background()
+		entitlements, leases := computeAccessCounts(ctx, cloudEnv.OrgID)
+		Expect(entitlements).To(BeZero(), "a rejected transaction must not consume the trial")
+		Expect(leases).To(BeZero(), "a rejected transaction must not reserve shared capacity")
+		var rejectedAddonCount int64
+		Expect(cloudEnv.Database.GetSessionFactory().New(ctx).
+			Model(&models.PostgresAddon{}).
+			Where("organisation_id = ?", cloudEnv.OrgID).
+			Count(&rejectedAddonCount).Error).To(Succeed())
+		Expect(rejectedAddonCount).To(BeZero())
+
+		stack := shared.CreateSimpleStack("cloud-primary")
+		stack.Spec.StackResources[0].SetReplicas(7)
+		primaryStack = shared.CreateStack(cloudEnv.Client, cloudEnv.OrgID, projectName, stack)
+		Expect(primaryStack.Spec.StackResources).To(HaveLen(1))
+		Expect(primaryStack.Spec.StackResources[0].GetReplicas()).To(Equal(int32(1)))
+
+		var entitlement computeaccess.ComputeEntitlement
+		Expect(cloudEnv.Database.GetSessionFactory().New(ctx).
+			Where("organisation_id = ?", cloudEnv.OrgID).
+			Take(&entitlement).Error).To(Succeed())
+		Expect(entitlement.Source).To(Equal(computeaccess.ComputeEntitlementSourceTrial))
+		Expect(entitlement.Status).To(Equal(computeaccess.ComputeEntitlementStatusActive))
+		Expect(entitlement.ExpiresAt).NotTo(BeNil())
+
+		var lease computeaccess.SharedComputeLease
+		Expect(cloudEnv.Database.GetSessionFactory().New(ctx).
+			Where("organisation_id = ?", cloudEnv.OrgID).
+			Take(&lease).Error).To(Succeed())
+		Expect(lease.EntitlementID).To(Equal(entitlement.ID))
+		Expect(lease.State).To(Equal(computeaccess.SharedComputeLeaseStateActive))
+	})
+
+	It("enforces stack and resource limits on creates and replacements", func() {
+		second := shared.CreateShellStack(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			shared.CreateSimpleStack("cloud-second"),
+		)
+
+		apiErr := shared.CreateStackExpectError(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			shared.CreateSimpleStack("cloud-third"),
+			http.StatusBadRequest,
+		)
+		expectServiceError(apiErr, serviceerrors.ErrorComputeQuotaExceeded)
+
+		shared.CreateStackResource(cloudEnv.Client, cloudEnv.OrgID, projectName, primaryStack.GetId(), stackResource("worker"))
+		shared.CreateStackResource(cloudEnv.Client, cloudEnv.OrgID, projectName, primaryStack.GetId(), stackResource("jobs"))
+		apiErr = shared.CreateStackResourceExpectError(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			primaryStack.GetId(),
+			stackResource("over-limit"),
+			http.StatusBadRequest,
+		)
+		expectServiceError(apiErr, serviceerrors.ErrorComputeQuotaExceeded)
+
+		overLimitReplacement := stackWithResources("cloud-primary", "one", "two", "three", "four")
+		apiErr = shared.ApplyStackExpectError(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			primaryStack.GetId(),
+			overLimitReplacement,
+			http.StatusBadRequest,
+		)
+		expectServiceError(apiErr, serviceerrors.ErrorComputeQuotaExceeded)
+		Expect(shared.GetStack(cloudEnv.Client, cloudEnv.OrgID, projectName, primaryStack.GetId()).Spec.StackResources).To(HaveLen(3))
+
+		primaryStack = shared.UpdateStack(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			primaryStack.GetId(),
+			stackWithResources("cloud-primary", "web"),
+		)
+		Expect(primaryStack.Spec.StackResources).To(HaveLen(1))
+		Expect(primaryStack.Spec.StackResources[0].GetReplicas()).To(Equal(int32(1)))
+
+		entitlements, leases := computeAccessCounts(context.Background(), cloudEnv.OrgID)
+		Expect(entitlements).To(Equal(int64(1)))
+		Expect(leases).To(Equal(int64(1)))
+
+		shared.DeleteStack(cloudEnv.Client, cloudEnv.OrgID, projectName, second.GetId())
+		shared.WaitForStackDeleted(cloudEnv.Client, cloudEnv.OrgID, projectName, second.GetId(), 2*time.Minute)
+	})
+
+	It("defaults and eagerly provisions volumes while enforcing their quota", func() {
+		defaulted := createStackVolume(primaryStack.GetId(), volume("cloud-data", ""), http.StatusCreated)
+		Expect(defaulted.Spec.GetSize()).To(Equal("2Gi"))
+		Expect(defaulted.Spec.GetStorageClass()).To(Equal(bootstrap.CloudTestStorageClass))
+		waitForVolumeReady(defaulted.GetId())
+
+		apiErr := createStackVolumeExpectError(primaryStack.GetId(), volume("cloud-too-large", "3Gi"), http.StatusBadRequest)
+		expectServiceError(apiErr, serviceerrors.ErrorComputeQuotaExceeded)
+
+		second := createStackVolume(primaryStack.GetId(), volume("cloud-cache", "1Gi"), http.StatusCreated)
+		waitForVolumeReady(second.GetId())
+		apiErr = createStackVolumeExpectError(primaryStack.GetId(), volume("cloud-third-volume", "1Gi"), http.StatusBadRequest)
+		expectServiceError(apiErr, serviceerrors.ErrorComputeQuotaExceeded)
+	})
+
+	It("defaults PostgreSQL storage and rejects instance and quota violations", func() {
+		postgres = shared.CreatePostgresAddon(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			postgresAddon("cloud-postgres", 1, ""),
+		)
+		Expect(postgres.Spec.Instances.GetCount()).To(Equal(int32(1)))
+		Expect(postgres.Spec.Storage.GetSize()).To(Equal("2Gi"))
+		shared.WaitForAddonReady(cloudEnv.Client, cloudEnv.OrgID, projectName, postgres.GetId(), 10*time.Minute)
+
+		apiErr := shared.CreatePostgresAddonExpectError(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			postgresAddon("cloud-second-postgres", 1, "1Gi"),
+			http.StatusBadRequest,
+		)
+		expectServiceError(apiErr, serviceerrors.ErrorComputeQuotaExceeded)
+
+		oversizeUpdate := postgresAddon(postgres.GetName(), 1, "3Gi")
+		apiErr = shared.UpdatePostgresAddonExpectError(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			postgres.GetId(),
+			oversizeUpdate,
+			http.StatusBadRequest,
+		)
+		expectServiceError(apiErr, serviceerrors.ErrorBadRequest)
+
+		persisted := shared.GetPostgresAddon(cloudEnv.Client, cloudEnv.OrgID, projectName, postgres.GetId())
+		Expect(persisted.Spec.Instances.GetCount()).To(Equal(int32(1)))
+		Expect(persisted.Spec.Storage.GetSize()).To(Equal("2Gi"))
+	})
+
+	It("creates the pending registry only when a build release needs it", func() {
+		ctx := context.Background()
+		clusterRegistry := &registryv1alpha1.ClusterRegistry{}
+		err := cloudEnv.Cluster.GetClient().Get(ctx, client.ObjectKey{Name: cloudEnv.RegistryName}, clusterRegistry)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+		buildStackSpec := shared.CreateStackWithBuildSource("cloud-build", "https://github.com/Stackdome/test-repo.git")
+		buildStackSpec.Spec.StackResources[0].Source.Git.SetDockerfilePath("docker/Dockerfile.prod")
+		buildStack = shared.CreateStack(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			buildStackSpec,
+		)
+		release := shared.CreateRelease(cloudEnv.Client, cloudEnv.OrgID, projectName, buildStack.GetId())
+
+		Eventually(func(g Gomega) {
+			actual := &registryv1alpha1.ClusterRegistry{}
+			g.Expect(cloudEnv.Cluster.GetClient().Get(ctx, client.ObjectKey{Name: cloudEnv.RegistryName}, actual)).To(Succeed())
+			g.Expect(actual.Spec.Storage.Size).To(Equal("2Gi"))
+			g.Expect(actual.Spec.Storage.StorageClass).NotTo(BeNil())
+			g.Expect(*actual.Spec.Storage.StorageClass).To(Equal(bootstrap.CloudTestStorageClass))
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		shared.WaitForReleaseReleased(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			buildStack.GetId(),
+			release.GetId(),
+			10*time.Minute,
+		)
+	})
+
+	It("enforces the platform lease ceiling without partially persisting the rejected request", func() {
+		suffix := time.Now().UnixNano()
+		signup := shared.SignupNewUser(
+			"Capacity Test",
+			fmt.Sprintf("cloud-capacity-%d@example.com", suffix),
+			"supersecret123",
+			fmt.Sprintf("Cloud Capacity %d", suffix),
+		)
+		secondOrgID := signup.User.GetOrganisationId()
+		secondClient := shared.AuthenticatedClient(signup.GetJwtToken())
+
+		apiErr := shared.CreateStackExpectError(
+			secondClient,
+			secondOrgID,
+			projectName,
+			shared.CreateSimpleStack("capacity-rejected"),
+			http.StatusTooManyRequests,
+		)
+		expectServiceError(apiErr, serviceerrors.ErrorSharedComputeCapacityReached)
+
+		entitlements, leases := computeAccessCounts(context.Background(), secondOrgID)
+		Expect(entitlements).To(BeZero())
+		Expect(leases).To(BeZero())
+		var stackCount int64
+		Expect(cloudEnv.Database.GetSessionFactory().New(context.Background()).
+			Model(&models.Stack{}).
+			Where("organisation_id = ?", secondOrgID).
+			Count(&stackCount).Error).To(Succeed())
+		Expect(stackCount).To(BeZero())
+	})
+
+	It("blocks new mutations after expiry while allowing deletion", func() {
+		ctx := context.Background()
+		expiredAt := time.Now().Add(-time.Minute)
+		Expect(cloudEnv.Database.GetSessionFactory().New(ctx).
+			Model(&computeaccess.ComputeEntitlement{}).
+			Where("organisation_id = ?", cloudEnv.OrgID).
+			Update("expires_at", expiredAt).Error).To(Succeed())
+
+		apiErr := shared.CreateStackResourceExpectError(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			primaryStack.GetId(),
+			stackResource("after-expiry"),
+			http.StatusGone,
+		)
+		expectServiceError(apiErr, serviceerrors.ErrorComputeAccessInactive)
+
+		shared.DeletePostgresAddon(cloudEnv.Client, cloudEnv.OrgID, projectName, postgres.GetId())
+		if buildStack != nil {
+			shared.DeleteStack(cloudEnv.Client, cloudEnv.OrgID, projectName, buildStack.GetId())
+		}
+		shared.DeleteStack(cloudEnv.Client, cloudEnv.OrgID, projectName, primaryStack.GetId())
+	})
+})
+
+func computeAccessCounts(ctx context.Context, organisationID string) (int64, int64) {
+	db := cloudEnv.Database.GetSessionFactory().New(ctx)
+	var entitlementCount int64
+	Expect(db.Model(&computeaccess.ComputeEntitlement{}).
+		Where("organisation_id = ?", organisationID).
+		Count(&entitlementCount).Error).To(Succeed())
+	var leaseCount int64
+	Expect(db.Model(&computeaccess.SharedComputeLease{}).
+		Where("organisation_id = ?", organisationID).
+		Count(&leaseCount).Error).To(Succeed())
+	return entitlementCount, leaseCount
+}
+
+func expectServiceError(apiErr *openapi.GenericOpenAPIError, code serviceerrors.ServiceErrorCode) {
+	var response openapi.Error
+	Expect(json.Unmarshal(apiErr.Body(), &response)).To(Succeed())
+	Expect(response.GetCode()).To(Equal(fmt.Sprintf("%d", code)))
+}
+
+func stackResource(name string) *openapi.StackResource {
+	resource := openapi.NewStackResource(name)
+	resource.SetSource(openapi.SourceSpec{Image: openapi.NewImageSource(shared.TestImage)})
+	resource.SetReplicas(9)
+	return resource
+}
+
+func stackWithResources(name string, resourceNames ...string) *openapi.Stack {
+	resources := make([]openapi.StackResource, 0, len(resourceNames))
+	for _, resourceName := range resourceNames {
+		resources = append(resources, *stackResource(resourceName))
+	}
+	spec := openapi.NewStackSpec()
+	spec.SetStackResources(resources)
+	return openapi.NewStack(name, *spec)
+}
+
+func volume(name, size string) *openapi.Volume {
+	spec := openapi.NewVolumeSpec(size, false, openapi.READ_WRITE_ONCE)
+	return openapi.NewVolume(name, *spec)
+}
+
+func createStackVolume(stackID string, requested *openapi.Volume, expectedStatus int) *openapi.Volume {
+	created, response, err := cloudEnv.Client.DefaultApi.
+		ApiV1OrganizationsOrgIdProjectsProjectNameStacksIdVolumesPost(
+			context.Background(),
+			cloudEnv.OrgID,
+			models.DefaultProjectName,
+			stackID,
+		).
+		Volume(*requested).
+		Execute()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(response.StatusCode).To(Equal(expectedStatus))
+	Expect(created).NotTo(BeNil())
+	return created
+}
+
+func createStackVolumeExpectError(stackID string, requested *openapi.Volume, expectedStatus int) *openapi.GenericOpenAPIError {
+	_, response, err := cloudEnv.Client.DefaultApi.
+		ApiV1OrganizationsOrgIdProjectsProjectNameStacksIdVolumesPost(
+			context.Background(),
+			cloudEnv.OrgID,
+			models.DefaultProjectName,
+			stackID,
+		).
+		Volume(*requested).
+		Execute()
+	Expect(err).To(HaveOccurred())
+	Expect(response.StatusCode).To(Equal(expectedStatus))
+	var apiErr *openapi.GenericOpenAPIError
+	Expect(stderrors.As(err, &apiErr)).To(BeTrue())
+	return apiErr
+}
+
+func waitForVolumeReady(volumeID string) {
+	Eventually(func(g Gomega) {
+		volume, response, err := cloudEnv.Client.DefaultApi.
+			ApiV1OrganizationsOrgIdProjectsProjectNameVolumesIdGet(
+				context.Background(),
+				cloudEnv.OrgID,
+				models.DefaultProjectName,
+				volumeID,
+			).
+			Execute()
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(response.StatusCode).To(Equal(http.StatusOK))
+		g.Expect(volume.Status).NotTo(BeNil())
+		g.Expect(volume.Status.GetPhase()).To(Equal(models.VolumePhaseReady))
+	}, 3*time.Minute, 2*time.Second).Should(Succeed())
+}
+
+func postgresAddon(name string, instances int32, storageSize string) *openapi.PostgresAddon {
+	version := openapi.NewPostgresVersion(16)
+	version.SetMinor(6)
+	spec := openapi.NewPostgresAddonSpec(
+		*version,
+		*openapi.NewPostgresInstances(instances),
+		*openapi.NewPostgresStorage(storageSize),
+	)
+	return openapi.NewPostgresAddon(name, *spec)
+}

--- a/test/cloudint/cloud_policy_e2e_test.go
+++ b/test/cloudint/cloud_policy_e2e_test.go
@@ -173,18 +173,27 @@ var _ = Describe("Stackdome Cloud compute policy", Ordered, func() {
 		expectServiceError(apiErr, serviceerrors.ErrorComputeQuotaExceeded)
 	})
 
-	It("defaults PostgreSQL storage and rejects instance and quota violations", func() {
+	It("enforces PostgreSQL instance, storage, and addon limits", func() {
+		apiErr := shared.CreatePostgresAddonExpectError(
+			cloudEnv.Client,
+			cloudEnv.OrgID,
+			projectName,
+			postgresAddon("cloud-too-large-postgres", 1, "3Gi"),
+			http.StatusBadRequest,
+		)
+		expectServiceError(apiErr, serviceerrors.ErrorComputeQuotaExceeded)
+
 		postgres = shared.CreatePostgresAddon(
 			cloudEnv.Client,
 			cloudEnv.OrgID,
 			projectName,
-			postgresAddon("cloud-postgres", 1, ""),
+			postgresAddon("cloud-postgres", 1, "1Gi"),
 		)
 		Expect(postgres.Spec.Instances.GetCount()).To(Equal(int32(1)))
-		Expect(postgres.Spec.Storage.GetSize()).To(Equal("2Gi"))
+		Expect(postgres.Spec.Storage.GetSize()).To(Equal("1Gi"))
 		shared.WaitForAddonReady(cloudEnv.Client, cloudEnv.OrgID, projectName, postgres.GetId(), 10*time.Minute)
 
-		apiErr := shared.CreatePostgresAddonExpectError(
+		apiErr = shared.CreatePostgresAddonExpectError(
 			cloudEnv.Client,
 			cloudEnv.OrgID,
 			projectName,
@@ -206,7 +215,7 @@ var _ = Describe("Stackdome Cloud compute policy", Ordered, func() {
 
 		persisted := shared.GetPostgresAddon(cloudEnv.Client, cloudEnv.OrgID, projectName, postgres.GetId())
 		Expect(persisted.Spec.Instances.GetCount()).To(Equal(int32(1)))
-		Expect(persisted.Spec.Storage.GetSize()).To(Equal("2Gi"))
+		Expect(persisted.Spec.Storage.GetSize()).To(Equal("1Gi"))
 	})
 
 	It("creates the pending registry only when a build release needs it", func() {

--- a/test/cloudint/cloud_policy_e2e_test.go
+++ b/test/cloudint/cloud_policy_e2e_test.go
@@ -158,11 +158,11 @@ var _ = Describe("Stackdome Cloud compute policy", Ordered, func() {
 		shared.WaitForStackDeleted(cloudEnv.Client, cloudEnv.OrgID, projectName, second.GetId(), 2*time.Minute)
 	})
 
-	It("defaults and eagerly provisions volumes while enforcing their quota", func() {
-		defaulted := createStackVolume(primaryStack.GetId(), volume("cloud-data", ""), http.StatusCreated)
-		Expect(defaulted.Spec.GetSize()).To(Equal("2Gi"))
-		Expect(defaulted.Spec.GetStorageClass()).To(Equal(bootstrap.CloudTestStorageClass))
-		waitForVolumeReady(defaulted.GetId())
+	It("enforces the storage class and eagerly provisions volumes within quota", func() {
+		created := createStackVolume(primaryStack.GetId(), volume("cloud-data", "1Gi"), http.StatusCreated)
+		Expect(created.Spec.GetSize()).To(Equal("1Gi"))
+		Expect(created.Spec.GetStorageClass()).To(Equal(bootstrap.CloudTestStorageClass))
+		waitForVolumeReady(created.GetId())
 
 		apiErr := createStackVolumeExpectError(primaryStack.GetId(), volume("cloud-too-large", "3Gi"), http.StatusBadRequest)
 		expectServiceError(apiErr, serviceerrors.ErrorComputeQuotaExceeded)

--- a/test/int/bootstrap/bootstrap.go
+++ b/test/int/bootstrap/bootstrap.go
@@ -117,7 +117,7 @@ func Setup(env *Environment, ctx context.Context) (retErr error) {
 	logger.Info("Bootstrapping client against platform defaults")
 	clientManager := NewClientManager(serverManager.GetBaseURL(), logger)
 	env.clientManager = clientManager
-	if err := clientManager.Bootstrap(ctx, sharedComputeCluster.ID); err != nil {
+	if err := clientManager.Bootstrap(ctx, sharedComputeCluster.ID, dbManager.GetSessionFactory()); err != nil {
 		return fmt.Errorf("client bootstrap failed: %w", err)
 	}
 

--- a/test/int/bootstrap/client.go
+++ b/test/int/bootstrap/client.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
 	"github.com/Stackdome/stackdome/install"
 	"github.com/Stackdome/stackdome/pkg/api/openapi"
+	"github.com/Stackdome/stackdome/pkg/db"
+	"github.com/Stackdome/stackdome/pkg/models"
 	"github.com/Stackdome/stackdome/pkg/testutil"
 	"github.com/go-logr/logr"
+	"gorm.io/gorm"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,7 +68,7 @@ func NewClientManager(baseURL string, logger logr.Logger) *ClientManager {
 	}
 }
 
-func (cm *ClientManager) Bootstrap(ctx context.Context, sharedComputeClusterID string) error {
+func (cm *ClientManager) Bootstrap(ctx context.Context, sharedComputeClusterID string, sessionFactory db.SessionFactory) error {
 	cm.logger.Info("Starting client bootstrap")
 
 	// Create context with 10-minute timeout for client bootstrap
@@ -84,10 +86,11 @@ func (cm *ClientManager) Bootstrap(ctx context.Context, sharedComputeClusterID s
 	cm.configureAuthentication()
 	cm.clusterID = sharedComputeClusterID
 
-	cm.logger.Info("Waiting for the seeded org image registry to become Running")
-	if err := cm.waitForRegistryRunning(bootstrapCtx); err != nil {
-		return fmt.Errorf("failed waiting for registry: %w", err)
+	registryName, err := findSeededRegistryName(bootstrapCtx, sessionFactory.New(bootstrapCtx), cm.orgID, cm.clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to discover seeded registry: %w", err)
 	}
+	cm.registryName = registryName
 
 	cm.logger.Info("Client bootstrap completed successfully",
 		"orgID", cm.orgID,
@@ -274,35 +277,13 @@ func ExtractAPIServerClusterCredentials(ctx context.Context, cluster *testutil.T
 	return clusterURL, caData, saToken, nil
 }
 
-func (cm *ClientManager) waitForRegistryRunning(ctx context.Context) error {
-	timeout := 5 * time.Minute
-	deadline := time.Now().Add(timeout)
-
-	for time.Now().Before(deadline) {
-		resp, httpResp, err := cm.client.DefaultApi.ApiV1OrganizationsOrgIdImageRegistriesGet(ctx, cm.orgID).Execute()
-		if err != nil {
-			cm.logger.Info("Registry list request failed, retrying", "error", err.Error())
-			time.Sleep(5 * time.Second)
-			continue
-		}
-		if httpResp.StatusCode != http.StatusOK {
-			time.Sleep(5 * time.Second)
-			continue
-		}
-
-		for _, reg := range resp.GetItems() {
-			if reg.Status != nil && reg.Status.State != nil && *reg.Status.State == openapi.IMAGE_REGISTRY_RUNNING {
-				cm.logger.Info("Cluster image registry is Running", "name", reg.Name)
-				cm.registryName = reg.GetName()
-				return nil
-			}
-			if reg.Status != nil {
-				cm.logger.Info("Registry not yet Running", "name", reg.Name, "state", string(reg.Status.GetState()))
-			}
-		}
-
-		time.Sleep(5 * time.Second)
+func findSeededRegistryName(ctx context.Context, session *gorm.DB, organisationID, clusterID string) (string, error) {
+	var registry models.ClusterImageRegistry
+	if err := session.WithContext(ctx).
+		Select("name").
+		Where("organisation_id = ? AND cluster_id = ?", organisationID, clusterID).
+		Take(&registry).Error; err != nil {
+		return "", fmt.Errorf("find seeded image registry for organisation %q and cluster %q: %w", organisationID, clusterID, err)
 	}
-
-	return fmt.Errorf("timed out after %v waiting for cluster image registry to become Running", timeout)
+	return registry.Name, nil
 }

--- a/test/int/bootstrap/cloud.go
+++ b/test/int/bootstrap/cloud.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	CloudTestBaseDomain   = "sd.localhost"
-	CloudTestStorageClass = "standard"
+	CloudTestBaseDomain     = "sd.localhost"
+	CloudTestStorageClass   = "standard"
+	cloudTestMaxStorageSize = "2Gi"
 )
 
 // SetupCloud starts the integration environment with the real Stackdome Cloud
@@ -61,7 +62,7 @@ func SetupCloud(env *Environment, ctx context.Context) (retErr error) {
 	serverManager := NewServerManager(dbManager.GetSessionFactory(), dbManager.GetConfig(), logger)
 	serverManager.config.RuntimeMode = config.RuntimeModeStackdomeCloud
 	serverManager.config.ComputeMode = config.ComputeModeShared
-	serverManager.config.StackdomeCloud = cloudTestConfig()
+	serverManager.config.StackdomeCloud = cloudTestConfig(serverManager.config.Server.Hostname)
 	env.serverManager = serverManager
 	if err := serverManager.Bootstrap(ctx); err != nil {
 		return fmt.Errorf("server bootstrap failed: %w", err)
@@ -93,7 +94,7 @@ func SetupCloud(env *Environment, ctx context.Context) (retErr error) {
 	return nil
 }
 
-func cloudTestConfig() *config.StackdomeCloudConfig {
+func cloudTestConfig(expectedHostname string) *config.StackdomeCloudConfig {
 	return &config.StackdomeCloudConfig{
 		Access: config.StackdomeCloudComputeAccessConfig{
 			MaxActiveSharedComputeLeases: 1,
@@ -104,17 +105,17 @@ func cloudTestConfig() *config.StackdomeCloudConfig {
 			MaxStackResourcesPerOrganization: 3,
 			ReplicasPerStackResource:         1,
 			MaxVolumesPerOrganization:        2,
-			MaxVolumeSize:                    "2Gi",
+			MaxVolumeSize:                    cloudTestMaxStorageSize,
 			VolumeStorageClass:               CloudTestStorageClass,
 			MaxPostgresAddonsPerOrganization: 1,
 			PostgresInstances:                1,
-			MaxPostgresStorageSize:           "2Gi",
+			MaxPostgresStorageSize:           cloudTestMaxStorageSize,
 			ConcurrentBuilds:                 1,
 		},
 		Registry: config.StackdomeCloudRegistryConfig{
 			MaxActiveRegistries: 1,
 			StorageClass:        CloudTestStorageClass,
-			StorageSize:         "2Gi",
+			StorageSize:         cloudTestMaxStorageSize,
 		},
 		Features: config.StackdomeCloudFeaturesConfig{},
 		Signup: config.StackdomeCloudSignupConfig{
@@ -122,7 +123,7 @@ func cloudTestConfig() *config.StackdomeCloudConfig {
 			Turnstile: config.StackdomeCloudTurnstileConfig{
 				Enabled:             true,
 				SiteKey:             "cloud-e2e-site-key",
-				ExpectedHostname:    "localhost",
+				ExpectedHostname:    expectedHostname,
 				ExpectedAction:      "signup",
 				VerificationTimeout: config.ConfigDuration(5 * time.Second),
 			},

--- a/test/int/bootstrap/cloud.go
+++ b/test/int/bootstrap/cloud.go
@@ -110,6 +110,10 @@ func cloudTestConfig(expectedHostname string) *config.StackdomeCloudConfig {
 			MaxPostgresAddonsPerOrganization: 1,
 			PostgresInstances:                1,
 			MaxPostgresStorageSize:           cloudTestMaxStorageSize,
+			PostgresCPURequest:               "50m",
+			PostgresCPULimit:                 "500m",
+			PostgresMemoryRequest:            "128Mi",
+			PostgresMemoryLimit:              "1Gi",
 			ConcurrentBuilds:                 1,
 		},
 		Registry: config.StackdomeCloudRegistryConfig{

--- a/test/int/bootstrap/cloud.go
+++ b/test/int/bootstrap/cloud.go
@@ -1,0 +1,143 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/Stackdome/stackdome/config"
+	"github.com/Stackdome/stackdome/pkg/computequota"
+	"github.com/Stackdome/stackdome/pkg/models"
+	"github.com/go-logr/stdr"
+)
+
+const (
+	CloudTestBaseDomain   = "sd.localhost"
+	CloudTestStorageClass = "standard"
+)
+
+// SetupCloud starts the integration environment with the real Stackdome Cloud
+// runtime wiring and deliberately small limits. It is separate from Setup so
+// the self-hosted suite remains unchanged.
+func SetupCloud(env *Environment, ctx context.Context) (retErr error) {
+	logger := stdr.New(log.New(os.Stderr, "", log.LstdFlags))
+	logger.Info("Starting Stackdome Cloud integration test bootstrap")
+	env.logger = logger
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			logger.Error(fmt.Errorf("panic during bootstrap: %v", recovered), "Bootstrap failed with panic, attempting cleanup")
+			env.Cleanup()
+			panic(recovered)
+		}
+		if retErr != nil {
+			logger.Error(retErr, "Bootstrap failed, cleaning up")
+			env.Cleanup()
+		}
+	}()
+
+	dbManager := NewDatabaseManager()
+	env.Database = dbManager
+	if err := dbManager.Bootstrap(ctx); err != nil {
+		return fmt.Errorf("database bootstrap failed: %w", err)
+	}
+
+	clusterManager := NewClusterManager()
+	env.clusterManager = clusterManager
+	if err := clusterManager.Bootstrap(ctx); err != nil {
+		return fmt.Errorf("cluster bootstrap failed: %w", err)
+	}
+	env.Cluster = clusterManager.GetCluster()
+
+	if err := exportSharedComputeProvisioningEnv(ctx, env.Cluster); err != nil {
+		return fmt.Errorf("failed to export shared-compute provisioning env: %w", err)
+	}
+	if err := os.Setenv(config.EnvPlatformBaseDomain.Name, CloudTestBaseDomain); err != nil {
+		return fmt.Errorf("failed to set Cloud test platform base domain: %w", err)
+	}
+
+	serverManager := NewServerManager(dbManager.GetSessionFactory(), dbManager.GetConfig(), logger)
+	serverManager.config.RuntimeMode = config.RuntimeModeStackdomeCloud
+	serverManager.config.ComputeMode = config.ComputeModeShared
+	serverManager.config.StackdomeCloud = cloudTestConfig()
+	env.serverManager = serverManager
+	if err := serverManager.Bootstrap(ctx); err != nil {
+		return fmt.Errorf("server bootstrap failed: %w", err)
+	}
+
+	var sharedComputeCluster models.Cluster
+	if err := dbManager.GetSessionFactory().New(ctx).
+		Where("shared_compute = ?", true).
+		First(&sharedComputeCluster).Error; err != nil {
+		return fmt.Errorf("failed to resolve shared-compute cluster: %w", err)
+	}
+
+	clientManager := NewClientManager(serverManager.GetBaseURL(), logger)
+	env.clientManager = clientManager
+	if err := clientManager.Bootstrap(ctx, sharedComputeCluster.ID, dbManager.GetSessionFactory()); err != nil {
+		return fmt.Errorf("client bootstrap failed: %w", err)
+	}
+
+	env.Client = clientManager.GetClient()
+	env.ClusterID = clientManager.GetClusterID()
+	env.OrgID = clientManager.GetOrgID()
+	env.UserToken = clientManager.GetUserToken()
+	env.RegistryName = clientManager.GetRegistryName()
+
+	logger.Info("Stackdome Cloud integration environment initialized",
+		"orgID", env.OrgID,
+		"clusterID", env.ClusterID,
+		"serverURL", serverManager.GetBaseURL())
+	return nil
+}
+
+func cloudTestConfig() *config.StackdomeCloudConfig {
+	return &config.StackdomeCloudConfig{
+		Access: config.StackdomeCloudComputeAccessConfig{
+			MaxActiveSharedComputeLeases: 1,
+			TrialEntitlementDuration:     config.ConfigDuration(6 * time.Hour),
+		},
+		Limits: computequota.ComputeLimits{
+			MaxStacksPerOrganization:         2,
+			MaxStackResourcesPerOrganization: 3,
+			ReplicasPerStackResource:         1,
+			MaxVolumesPerOrganization:        2,
+			MaxVolumeSize:                    "2Gi",
+			VolumeStorageClass:               CloudTestStorageClass,
+			MaxPostgresAddonsPerOrganization: 1,
+			PostgresInstances:                1,
+			MaxPostgresStorageSize:           "2Gi",
+			ConcurrentBuilds:                 1,
+		},
+		Registry: config.StackdomeCloudRegistryConfig{
+			MaxActiveRegistries: 1,
+			StorageClass:        CloudTestStorageClass,
+			StorageSize:         "2Gi",
+		},
+		Features: config.StackdomeCloudFeaturesConfig{},
+		Signup: config.StackdomeCloudSignupConfig{
+			ClientIPSource: config.StackdomeCloudClientIPSourceRemoteAddr,
+			Turnstile: config.StackdomeCloudTurnstileConfig{
+				Enabled:             true,
+				SiteKey:             "cloud-e2e-site-key",
+				ExpectedHostname:    "localhost",
+				ExpectedAction:      "signup",
+				VerificationTimeout: config.ConfigDuration(5 * time.Second),
+			},
+			Throttle: config.StackdomeCloudThrottleConfig{
+				IP: config.StackdomeCloudIPThrottleConfig{
+					MaxTrackedClients: 100,
+					MaxAttempts:       20,
+					Window:            config.ConfigDuration(time.Minute),
+				},
+				Email: config.StackdomeCloudEmailThrottleConfig{
+					MaxTrackedAddresses: 100,
+					MaxAttempts:         20,
+					Window:              config.ConfigDuration(time.Minute),
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- add compute entitlements, shared-compute leases, configurable usage limits, and request-boundary policy enforcement
- persist preview admission denials as durable failure states instead of retrying indefinitely
- seed shared-compute registries as pending, provision them lazily from build releases, and make E2E bootstrap depend only on the seeded database row

## Verification

- `go test -count=1 $(go list ./... | rg -v "/test/int$")`
- `mage lint`

The root E2E suite was not run.