### PR TITLE
feat(observability): redesign Grafana operations dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ observability-check: promtool ## Validate the alpha dashboard and Prometheus rul
 		tail -n +2 | sed 's/^  //' > "$$tmp_rules"; \
 	"$(PROMTOOL)" check rules "$$tmp_rules"; \
 	jq empty deploy/observability/grafana/alpha-overview.json; \
+	sh deploy/observability/grafana/alpha-overview_test.sh; \
 	echo "Observability artifacts are valid"
 .PHONY: observability-check
 

--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -16,6 +16,20 @@ To view the dashboard in Grafana:
 3. Select the Prometheus datasource that scrapes `stackdome-api-metrics`.
 4. Select **Import**.
 
+## Reading the dashboard
+
+The first viewport is an operations summary. Start with request rate, 5xx rate,
+failed stacks, worker queue depth, and snapshot collection. The latency strip
+shows the traffic-weighted average plus p50, p95, and p99 across user-facing
+requests. Health, metrics, and streaming routes are excluded so long-lived or
+internal traffic does not distort the service-level view.
+
+Treat p95 as the primary latency signal: its two-second critical threshold
+matches the `StackdomeAPIHighLatency` alert. Average and p50 describe the common
+case, while p99 exposes rare severe slowness. Use **Slow routes (p95)** in the
+API diagnostics section to identify which route is responsible for a rising
+aggregate percentile.
+
 Example ServiceMonitor endpoint:
 
 ```yaml
@@ -33,7 +47,7 @@ Run:
 make observability-check
 ```
 
-The target installs the pinned Prometheus `v3.13.2` `promtool` binary at `bin/promtool`, validates the alert rules, and parses the Grafana dashboard JSON. The binary stays inside the ignored project `bin/` directory and is reused on later runs. Run `make promtool` when only the tool installation is needed.
+The target installs the pinned Prometheus `v3.13.2` `promtool` binary at `bin/promtool`, validates the alert rules, parses the Grafana dashboard JSON, and checks the dashboard's overview and latency-query contract. The binary stays inside the ignored project `bin/` directory and is reused on later runs. Run `make promtool` when only the tool installation is needed.
 
 ## Five-minute smoke test
 

--- a/deploy/observability/grafana/alpha-overview.json
+++ b/deploy/observability/grafana/alpha-overview.json
@@ -1,38 +1,725 @@
 {
-  "annotations": {"list": []},
+  "annotations": {
+    "list": []
+  },
+  "description": "Operations-first view of Stackdome API traffic, stack health, and worker processing.",
   "editable": true,
   "graphTooltip": 1,
   "id": null,
   "links": [],
   "panels": [
-    {"type":"row","title":"API","gridPos":{"h":1,"w":24,"x":0,"y":0},"collapsed":false,"panels":[]},
-    {"type":"timeseries","title":"Requests / second by route","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"sum by (method, route) (rate(stackdome_http_server_requests_total[5m]))","legendFormat":"{{method}} {{route}}","refId":"A"}],"gridPos":{"h":8,"w":12,"x":0,"y":1}},
-    {"type":"timeseries","title":"Response codes by route","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"sum by (route, status) (rate(stackdome_http_server_requests_total[5m]))","legendFormat":"{{status}} {{route}}","refId":"A"}],"gridPos":{"h":8,"w":12,"x":12,"y":1}},
-    {"type":"timeseries","title":"Request latency percentiles","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"histogram_quantile(0.50, sum by (route, le) (rate(stackdome_http_server_request_duration_seconds_bucket{route!~\".*stream.*\"}[5m])))","legendFormat":"p50 {{route}}","refId":"A"},{"expr":"histogram_quantile(0.95, sum by (route, le) (rate(stackdome_http_server_request_duration_seconds_bucket{route!~\".*stream.*\"}[5m])))","legendFormat":"p95 {{route}}","refId":"B"},{"expr":"histogram_quantile(0.99, sum by (route, le) (rate(stackdome_http_server_request_duration_seconds_bucket{route!~\".*stream.*\"}[5m])))","legendFormat":"p99 {{route}}","refId":"C"}],"fieldConfig":{"defaults":{"unit":"s"},"overrides":[]},"gridPos":{"h":8,"w":18,"x":0,"y":9}},
-    {"type":"stat","title":"In-flight requests","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"sum(stackdome_http_server_in_flight_requests)","refId":"A"}],"gridPos":{"h":8,"w":6,"x":18,"y":9}},
-
-    {"type":"row","title":"Stacks","gridPos":{"h":1,"w":24,"x":0,"y":17},"collapsed":false,"panels":[]},
-    {"type":"bargauge","title":"Current stacks by state","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"max by (state) (stackdome_stacks)","legendFormat":"{{state}}","refId":"A"}],"gridPos":{"h":8,"w":8,"x":0,"y":18}},
-    {"type":"timeseries","title":"Stack state history","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"max by (state) (stackdome_stacks)","legendFormat":"{{state}}","refId":"A"}],"gridPos":{"h":8,"w":8,"x":8,"y":18}},
-    {"type":"bargauge","title":"Current failures by type","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"max by (type) (stackdome_stack_failures)","legendFormat":"{{type}}","refId":"A"}],"gridPos":{"h":8,"w":8,"x":16,"y":18}},
-    {"type":"timeseries","title":"Stack resources by state","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"max by (state) (stackdome_stack_resources)","legendFormat":"{{state}}","refId":"A"}],"gridPos":{"h":8,"w":18,"x":0,"y":26}},
-    {"type":"stat","title":"Snapshot collection","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"min(stackdome_stack_snapshot_collection_success)","refId":"A"}],"fieldConfig":{"defaults":{"mappings":[{"options":{"0":{"color":"red","text":"Failed"},"1":{"color":"green","text":"Healthy"}},"type":"value"}]},"overrides":[]},"gridPos":{"h":8,"w":6,"x":18,"y":26}},
-
-    {"type":"row","title":"Workers","gridPos":{"h":1,"w":24,"x":0,"y":34},"collapsed":false,"panels":[]},
-    {"type":"timeseries","title":"Queue depth","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"workqueue_depth","legendFormat":"{{name}}","refId":"A"}],"gridPos":{"h":8,"w":8,"x":0,"y":35}},
-    {"type":"timeseries","title":"p95 queue wait","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"histogram_quantile(0.95, sum by (name, le) (rate(workqueue_queue_duration_seconds_bucket[5m])))","legendFormat":"{{name}}","refId":"A"}],"fieldConfig":{"defaults":{"unit":"s"},"overrides":[]},"gridPos":{"h":8,"w":8,"x":8,"y":35}},
-    {"type":"timeseries","title":"p95 execution duration","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"histogram_quantile(0.95, sum by (name, le) (rate(workqueue_work_duration_seconds_bucket[5m])))","legendFormat":"{{name}}","refId":"A"}],"fieldConfig":{"defaults":{"unit":"s"},"overrides":[]},"gridPos":{"h":8,"w":8,"x":16,"y":35}},
-    {"type":"timeseries","title":"Execution outcomes","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"sum by (worker, result) (rate(stackdome_worker_executions_total[5m]))","legendFormat":"{{worker}} {{result}}","refId":"A"}],"gridPos":{"h":8,"w":8,"x":0,"y":43}},
-    {"type":"timeseries","title":"Retries","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"sum by (name) (rate(workqueue_retries_total[5m]))","legendFormat":"{{name}}","refId":"A"}],"gridPos":{"h":8,"w":8,"x":8,"y":43}},
-    {"type":"timeseries","title":"Longest running work","datasource":{"type":"prometheus","uid":"${DS_PROMETHEUS}"},"targets":[{"expr":"workqueue_longest_running_processor_seconds","legendFormat":"{{name}}","refId":"A"}],"fieldConfig":{"defaults":{"unit":"s"},"overrides":[]},"gridPos":{"h":8,"w":8,"x":16,"y":43}}
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "panels": [],
+      "title": "Service overview",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "User-facing API requests per second over the last five minutes. Health, metrics, and streaming routes are excluded.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "decimals": 2,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 1},
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(stackdome_http_server_requests_total{route!~\"/health|/metrics|.*stream.*\"}[5m])) or vector(0)",
+          "instant": false,
+          "legendFormat": "Requests / second",
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Percentage of user-facing API requests returning 5xx responses. Critical at 5%, matching the alert rule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "decimals": 2,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 1},
+              {"color": "red", "value": 5}
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 1},
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "(100 * sum(rate(stackdome_http_server_requests_total{route!~\"/health|/metrics|.*stream.*\",status=~\"5..\"}[5m])) / clamp_min(sum(rate(stackdome_http_server_requests_total{route!~\"/health|/metrics|.*stream.*\"}[5m])), 0.000001)) or vector(0)",
+          "instant": false,
+          "legendFormat": "5xx",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx error rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Requests currently being handled by the API server across all HTTP methods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "decimals": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 1},
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "sum(stackdome_http_server_in_flight_requests) or vector(0)",
+          "instant": false,
+          "legendFormat": "In flight",
+          "refId": "A"
+        }
+      ],
+      "title": "In-flight requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Stacks currently in Failed or Error state. Any non-zero value needs attention.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 1}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 12, "y": 1},
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "sum(max by (state) (stackdome_stacks{state=~\"Failed|Error\"})) or vector(0)",
+          "instant": false,
+          "legendFormat": "Failed stacks",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed stacks",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Total queued work across Stackdome workers. Critical above 25, matching the backlog alert.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 10},
+              {"color": "red", "value": 25}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 1},
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "sum(max by (name) (workqueue_depth)) or vector(0)",
+          "instant": false,
+          "legendFormat": "Queued work",
+          "refId": "A"
+        }
+      ],
+      "title": "Worker queue depth",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Whether the API can read stack status snapshots from PostgreSQL.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [
+            {
+              "options": {
+                "0": {"color": "red", "index": 1, "text": "Failed"},
+                "1": {"color": "green", "index": 0, "text": "Healthy"}
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "green", "value": 1}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 20, "y": 1},
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "min(stackdome_stack_snapshot_collection_success)",
+          "instant": false,
+          "legendFormat": "Snapshot collection",
+          "refId": "A"
+        }
+      ],
+      "title": "Snapshot collection",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Traffic-weighted mean latency for user-facing, non-streaming requests over five minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 1},
+              {"color": "red", "value": 2}
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 5},
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(stackdome_http_server_request_duration_seconds_sum{route!~\"/health|/metrics|.*stream.*\"}[5m])) / clamp_min(sum(rate(stackdome_http_server_request_duration_seconds_count{route!~\"/health|/metrics|.*stream.*\"}[5m])), 0.000001)",
+          "instant": false,
+          "legendFormat": "Average",
+          "refId": "A"
+        }
+      ],
+      "title": "Average latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Median latency across all user-facing, non-streaming requests over five minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 0.5},
+              {"color": "red", "value": 1}
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 5},
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(stackdome_http_server_request_duration_seconds_bucket{route!~\"/health|/metrics|.*stream.*\"}[5m])))",
+          "instant": false,
+          "legendFormat": "p50",
+          "refId": "A"
+        }
+      ],
+      "title": "p50 latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "95% of user-facing, non-streaming requests complete within this time. Critical above two seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 1},
+              {"color": "red", "value": 2}
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 5},
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(stackdome_http_server_request_duration_seconds_bucket{route!~\"/health|/metrics|.*stream.*\"}[5m])))",
+          "instant": false,
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "title": "p95 latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "99% of user-facing, non-streaming requests complete within this time, exposing rare severe slowness.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 2},
+              {"color": "red", "value": 5}
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 5},
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(stackdome_http_server_request_duration_seconds_bucket{route!~\"/health|/metrics|.*stream.*\"}[5m])))",
+          "instant": false,
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "title": "p99 latency",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
+      "id": 12,
+      "panels": [],
+      "title": "API diagnostics",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "The ten busiest user-facing API routes by request rate. Use this to understand current traffic mix.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
+      "id": 13,
+      "options": {
+        "legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true, "sortBy": "Mean", "sortDesc": true, "width": 430},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (method, route) (rate(stackdome_http_server_requests_total{route!~\"/health|/metrics|.*stream.*\"}[5m])))",
+          "legendFormat": "{{method}} {{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request throughput by route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Aggregate p50, p95, and p99 latency for user-facing requests. This shows the typical and tail experience without route-level noise.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "line"}},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 2}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
+      "id": 14,
+      "options": {
+        "legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {"expr": "histogram_quantile(0.50, sum by (le) (rate(stackdome_http_server_request_duration_seconds_bucket{route!~\"/health|/metrics|.*stream.*\"}[5m])))", "legendFormat": "p50", "refId": "A"},
+        {"expr": "histogram_quantile(0.95, sum by (le) (rate(stackdome_http_server_request_duration_seconds_bucket{route!~\"/health|/metrics|.*stream.*\"}[5m])))", "legendFormat": "p95", "refId": "B"},
+        {"expr": "histogram_quantile(0.99, sum by (le) (rate(stackdome_http_server_request_duration_seconds_bucket{route!~\"/health|/metrics|.*stream.*\"}[5m])))", "legendFormat": "p99", "refId": "C"}
+      ],
+      "title": "User-facing latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "User-facing request rate grouped into bounded response status classes, keeping errors visible without a series for every route and code.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 12, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "unit": "reqps"
+        },
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "2xx"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "4xx"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "5xx"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
+      "id": 15,
+      "options": {
+        "legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true, "width": 260},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "expr": "sum by (status_class) (rate(stackdome_http_server_request_duration_seconds_count{route!~\"/health|/metrics|.*stream.*\"}[5m]))",
+          "legendFormat": "{{status_class}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Response rate by status class",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "The ten routes with the highest p95 latency. Use this after aggregate p95 rises to locate the slow path.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "line"}},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 2}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 18},
+      "id": 16,
+      "options": {
+        "legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true, "sortBy": "Mean", "sortDesc": true, "width": 430},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "expr": "topk(10, histogram_quantile(0.95, sum by (route, le) (rate(stackdome_http_server_request_duration_seconds_bucket{route!~\"/health|/metrics|.*stream.*\"}[5m]))))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Slow routes (p95)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 26},
+      "id": 17,
+      "panels": [],
+      "title": "Stack health",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Current stacks grouped by lifecycle state. Failed or Error states require attention; Pending and Progressing indicate active work.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "decimals": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}, "unit": "short"},
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "Ready"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "Failed"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "Error"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "Pending"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "Progressing"}, "properties": [{"id": "color", "value": {"fixedColor": "yellow", "mode": "fixed"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 27},
+      "id": 18,
+      "options": {"displayMode": "gradient", "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": true, "sizing": "auto", "valueMode": "color"},
+      "targets": [{"expr": "max by (state) (stackdome_stacks)", "legendFormat": "{{state}}", "refId": "A"}],
+      "title": "Current stacks by state",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "How stack lifecycle states have changed over time. Use this to distinguish a transient deployment from a persistent problem.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "stepAfter", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 27},
+      "id": 19,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "max by (state) (stackdome_stacks)", "legendFormat": "{{state}}", "refId": "A"}],
+      "title": "Stack state history",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Current unhealthy stack resources grouped by their latest bounded failure type.",
+      "fieldConfig": {
+        "defaults": {"color": {"fixedColor": "red", "mode": "fixed"}, "decimals": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 27},
+      "id": 20,
+      "options": {"displayMode": "gradient", "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": true, "sizing": "auto", "valueMode": "color"},
+      "targets": [{"expr": "max by (type) (stackdome_stack_failures)", "legendFormat": "{{type}}", "refId": "A"}],
+      "title": "Current failures by type",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Stack resources grouped by current lifecycle state. This reveals resource-level degradation hidden by the parent stack state.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "stepAfter", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 35},
+      "id": 21,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true, "width": 320}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "max by (state) (stackdome_stack_resources)", "legendFormat": "{{state}}", "refId": "A"}],
+      "title": "Stack resources by state",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 43},
+      "id": 22,
+      "panels": [],
+      "title": "Worker health",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Queued work by worker. Sustained depth above 25 indicates backlog and matches the critical alert threshold.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 12, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "line"}}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 25}]}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 44},
+      "id": 23,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true, "width": 260}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "workqueue_depth", "legendFormat": "{{name}}", "refId": "A"}],
+      "title": "Queue depth by worker",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "95% of queued work starts within this time for each worker. Sustained values above 60 seconds trigger the backlog alert.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "line"}}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 60}]}, "unit": "s"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 44},
+      "id": 24,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true, "width": 260}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "histogram_quantile(0.95, sum by (name, le) (rate(workqueue_queue_duration_seconds_bucket[5m])))", "legendFormat": "{{name}}", "refId": "A"}],
+      "title": "Queue wait (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "95% of worker executions complete within this time, grouped by worker.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "s"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 44},
+      "id": 25,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true, "width": 260}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "histogram_quantile(0.95, sum by (name, le) (rate(workqueue_work_duration_seconds_bucket[5m])))", "legendFormat": "{{name}}", "refId": "A"}],
+      "title": "Execution duration (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Worker execution rate by terminal result. Error and panic series are the primary failure signals.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "ops"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 52},
+      "id": 26,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true, "width": 280}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "sum by (worker, result) (rate(stackdome_worker_executions_total[5m]))", "legendFormat": "{{worker}} · {{result}}", "refId": "A"}],
+      "title": "Execution outcomes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Retry rate by worker. Rising retries often precede queue backlog or terminal execution errors.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "ops"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 52},
+      "id": 27,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true, "width": 260}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "sum by (name) (rate(workqueue_retries_total[5m]))", "legendFormat": "{{name}}", "refId": "A"}],
+      "title": "Retry rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Age of the longest-running processor by worker. A continuously increasing line can indicate stuck work.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "s"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 52},
+      "id": 28,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true, "width": 260}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "workqueue_longest_running_processor_seconds", "legendFormat": "{{name}}", "refId": "A"}],
+      "title": "Longest-running work",
+      "type": "timeseries"
+    }
   ],
   "refresh": "15s",
   "schemaVersion": 39,
   "tags": ["stackdome", "alpha", "observability"],
-  "templating": {"list": [{"name":"DS_PROMETHEUS","type":"datasource","query":"prometheus","label":"Prometheus","current":{}}]},
-  "time": {"from":"now-6h","to":"now"},
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "label": "Prometheus",
+        "name": "DS_PROMETHEUS",
+        "query": "prometheus",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-3h", "to": "now"},
+  "timepicker": {"refresh_intervals": ["5s", "10s", "15s", "30s", "1m", "5m", "15m"]},
   "timezone": "browser",
-  "title": "Stackdome Alpha Overview",
+  "title": "Stackdome Operations Overview",
   "uid": "stackdome-alpha-overview",
-  "version": 1
+  "version": 2
 }

--- a/deploy/observability/grafana/alpha-overview_test.sh
+++ b/deploy/observability/grafana/alpha-overview_test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+dashboard=${1:-deploy/observability/grafana/alpha-overview.json}
+excluded_routes='/health|/metrics|.*stream.*'
+
+jq -e --arg excluded_routes "$excluded_routes" '
+  . as $dashboard |
+  def panel($title): first($dashboard.panels[] | select(.title == $title));
+  def require($condition; $message): if $condition then true else error($message) end;
+  require(.time.from == "now-3h"; "dashboard must default to the last three hours") and
+  require(.refresh == "15s"; "dashboard must refresh every 15 seconds") and
+  require([.panels[].id] | all(. != null) and (length == (unique | length)); "panel IDs must be present and unique") and
+  require(["Request rate", "5xx error rate", "In-flight requests", "Failed stacks", "Worker queue depth", "Snapshot collection", "Average latency", "p50 latency", "p95 latency", "p99 latency"] | all(. as $title | panel($title) != null); "overview and aggregate latency panels must be present") and
+  require(["Average latency", "p50 latency", "p95 latency", "p99 latency"] | all(. as $title | panel($title).targets[0].expr | contains($excluded_routes)); "aggregate latency panels must exclude internal and streaming routes") and
+  require(panel("Average latency").targets[0].expr | contains("_sum") and contains("_count"); "average latency must divide histogram sum by count") and
+  require(["p50 latency", "p95 latency", "p99 latency"] | all(. as $title | panel($title).targets[0].expr | contains("sum by (le)")); "percentiles must aggregate histogram buckets by le") and
+  require(["5xx error rate", "Worker queue depth", "Snapshot collection", "p95 latency"] | all(. as $title | panel($title).options.colorMode == "value"); "healthy overview states must not fill cards with background color") and
+  require(panel("Failed stacks").options.colorMode == "background"; "failed stacks must retain the strongest incident emphasis") and
+  require([.panels[] | select(.type != "row") | .description] | all(type == "string" and length > 0); "every data panel must have a description")
+' "$dashboard" >/dev/null


### PR DESCRIPTION
## Summary

- redesign the Stackdome Grafana dashboard around an operations-first service overview
- add aggregate average, p50, p95, and p99 latency for user-facing, non-streaming routes
- retain route, stack, and worker diagnostics with clearer legends and alert-aligned thresholds
- add a jq dashboard contract test to `observability-check` and document how to interpret the latency panels

## Validation

- `make observability-check`
- Go package suite excluding environment-dependent integration entrypoints
- all 26 dashboard PromQL expressions queried successfully against staging Prometheus
- Grafana browser QA: no No data panels, query errors, or console errors
- staging ConfigMap matched the checked-in dashboard and Grafana rollout revision 3 reached 1/1 Ready
