### PR TITLE
fix: allow local EventSource authentication

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -98,7 +98,11 @@ api.interceptors.request.use((config) => {
   if (token) {
     config.headers = config.headers || {};
     config.headers['Authorization'] = `Bearer ${token}`;
-    document.cookie = `auth_token=${token}; path=/; secure; samesite=strict`;
+    if (window.location.hostname === 'stackdome.127.0.0.1.nip.io') {
+      document.cookie = `auth_token=${token}; path=/; samesite=strict`;
+    } else {
+      document.cookie = `auth_token=${token}; path=/; secure; samesite=strict`;
+    }
   }
   return config;
 });


### PR DESCRIPTION
## Summary

- omit the `Secure` attribute from the auth cookie only on `stackdome.127.0.0.1.nip.io`
- preserve the existing secure cookie behavior for every other hostname
- restore native EventSource authentication for local stack and build log streams over HTTP

## Verification

- `pnpm test:run` (1,591 tests)
- `pnpm lint` (0 errors; existing warnings only)
- `pnpm build`