### PR TITLE
Cloud alpha: add password signup protection core

### DIFF
--- a/pkg/clients/turnstile/client.go
+++ b/pkg/clients/turnstile/client.go
@@ -1,0 +1,140 @@
+// Package turnstile verifies Cloudflare Turnstile challenge tokens.
+package turnstile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	CanonicalSiteverifyEndpoint       = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+	maxTokenLength                    = 2048
+	maxResponseBytes            int64 = 64 * 1024
+)
+
+// Verifier verifies one Turnstile token for a client IP address.
+type Verifier interface {
+	Verify(context.Context, string, netip.Addr) error
+}
+
+// ClientSpec contains the secret verification settings that are never exposed
+// through the public application configuration endpoint.
+type ClientSpec struct {
+	Secret           string
+	ExpectedHostname string
+	ExpectedAction   string
+	Timeout          time.Duration
+}
+
+type client struct {
+	secret           string
+	expectedHostname string
+	expectedAction   string
+	endpoint         string
+	httpClient       *http.Client
+}
+
+// NewClient constructs a verifier that always uses Cloudflare's canonical
+// siteverify endpoint.
+func NewClient(spec ClientSpec) (Verifier, error) {
+	if strings.TrimSpace(spec.Secret) == "" {
+		return nil, errors.New("turnstile secret is required")
+	}
+	if strings.TrimSpace(spec.ExpectedHostname) == "" {
+		return nil, errors.New("turnstile expected hostname is required")
+	}
+	if strings.TrimSpace(spec.ExpectedAction) == "" {
+		return nil, errors.New("turnstile expected action is required")
+	}
+	if spec.Timeout <= 0 {
+		return nil, errors.New("turnstile verification timeout must be positive")
+	}
+
+	return newClient(spec, CanonicalSiteverifyEndpoint), nil
+}
+
+func newClient(spec ClientSpec, endpoint string) Verifier {
+	return &client{
+		secret:           spec.Secret,
+		expectedHostname: spec.ExpectedHostname,
+		expectedAction:   spec.ExpectedAction,
+		endpoint:         endpoint,
+		httpClient: &http.Client{
+			Timeout: spec.Timeout,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+type siteverifyResponse struct {
+	Success  bool   `json:"success"`
+	Hostname string `json:"hostname"`
+	Action   string `json:"action"`
+}
+
+func (c *client) Verify(ctx context.Context, token string, remoteIP netip.Addr) error {
+	if token == "" || len(token) > maxTokenLength || !remoteIP.IsValid() {
+		return errors.New("turnstile verification failed: invalid input")
+	}
+
+	form := url.Values{
+		"secret":   {c.secret},
+		"response": {token},
+		"remoteip": {remoteIP.Unmap().String()},
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.endpoint,
+		strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		return errors.New("turnstile verification failed: request creation failed")
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return errors.New("turnstile verification failed: request failed")
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return errors.New("turnstile verification failed: unexpected HTTP status")
+	}
+
+	responseBody, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	if err != nil {
+		return errors.New("turnstile verification failed: response read failed")
+	}
+	if int64(len(responseBody)) > maxResponseBytes {
+		return errors.New("turnstile verification failed: response too large")
+	}
+
+	var result siteverifyResponse
+	if err := json.Unmarshal(responseBody, &result); err != nil {
+		return errors.New("turnstile verification failed: malformed response")
+	}
+	if !result.Success {
+		return errors.New("turnstile verification failed: challenge rejected")
+	}
+	if result.Hostname != c.expectedHostname {
+		return errors.New("turnstile verification failed: hostname mismatch")
+	}
+	if result.Action != c.expectedAction {
+		return errors.New("turnstile verification failed: action mismatch")
+	}
+
+	return nil
+}
+
+var _ Verifier = (*client)(nil)

--- a/pkg/clients/turnstile/client_test.go
+++ b/pkg/clients/turnstile/client_test.go
@@ -1,0 +1,99 @@
+package turnstile
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Turnstile verifier", func() {
+	It("submits the canonical siteverify fields", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+			defer GinkgoRecover()
+
+			Expect(request.Method).To(Equal(http.MethodPost))
+			Expect(request.Header.Get("Content-Type")).To(Equal("application/x-www-form-urlencoded"))
+			Expect(request.ParseForm()).To(Succeed())
+			Expect(request.Form.Get("secret")).To(Equal("test-secret"))
+			Expect(request.Form.Get("response")).To(Equal("test-token"))
+			Expect(request.Form.Get("remoteip")).To(Equal("203.0.113.10"))
+
+			Expect(json.NewEncoder(response).Encode(map[string]any{
+				"success":  true,
+				"hostname": "stackdome.com",
+				"action":   "turnstile-spin-v2",
+			})).To(Succeed())
+		}))
+		DeferCleanup(server.Close)
+
+		verifier := newClient(validClientSpec(), server.URL)
+		Expect(verifier.Verify(
+			context.Background(),
+			"test-token",
+			netip.MustParseAddr("203.0.113.10"),
+		)).To(Succeed())
+	})
+
+	DescribeTable("rejecting untrusted siteverify results",
+		func(responseBody map[string]any) {
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+				defer GinkgoRecover()
+
+				Expect(json.NewEncoder(response).Encode(responseBody)).To(Succeed())
+			}))
+			DeferCleanup(server.Close)
+
+			verifier := newClient(validClientSpec(), server.URL)
+			err := verifier.Verify(context.Background(), "test-token", netip.MustParseAddr("203.0.113.10"))
+			Expect(err).To(HaveOccurred())
+		},
+		Entry(
+			"when the challenge is rejected",
+			map[string]any{"success": false},
+		),
+		Entry(
+			"when the hostname differs",
+			map[string]any{
+				"success": true, "hostname": "attacker.example", "action": "turnstile-spin-v2",
+			},
+		),
+		Entry(
+			"when the action differs",
+			map[string]any{
+				"success": true, "hostname": "stackdome.com", "action": "different-action",
+			},
+		),
+	)
+
+	It("fails closed when siteverify is unavailable", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+			response.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		serverURL := server.URL
+		server.Close()
+
+		verifier := newClient(validClientSpec(), serverURL)
+		err := verifier.Verify(context.Background(), "test-token", netip.MustParseAddr("203.0.113.10"))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("rejects incomplete configuration", func() {
+		_, err := NewClient(ClientSpec{Timeout: time.Second})
+		Expect(err).To(MatchError("turnstile secret is required"))
+	})
+})
+
+func validClientSpec() ClientSpec {
+	return ClientSpec{
+		Secret:           "test-secret",
+		ExpectedHostname: "stackdome.com",
+		ExpectedAction:   "turnstile-spin-v2",
+		Timeout:          time.Second,
+	}
+}

--- a/pkg/clients/turnstile/turnstile_suite_test.go
+++ b/pkg/clients/turnstile/turnstile_suite_test.go
@@ -1,0 +1,13 @@
+package turnstile
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTurnstile(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Turnstile Suite")
+}

--- a/pkg/signupprotection/client_ip.go
+++ b/pkg/signupprotection/client_ip.go
@@ -1,0 +1,65 @@
+// Package signupprotection applies bot verification and bounded throttles to
+// public password signup.
+package signupprotection
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+const cloudflareConnectingIPHeader = "CF-Connecting-IP"
+
+// ErrClientIPUnavailable means the configured source did not contain one valid address.
+var ErrClientIPUnavailable = errors.New("client IP unavailable")
+
+// ClientIPResolver derives a client address from one configured source.
+type ClientIPResolver interface {
+	Resolve(*http.Request) (netip.Addr, error)
+}
+
+type cloudflareClientIPResolver struct{}
+
+// NewCloudflareClientIPResolver trusts exactly one CF-Connecting-IP value.
+// The origin must accept traffic exclusively from Cloudflare when this is used.
+func NewCloudflareClientIPResolver() ClientIPResolver {
+	return cloudflareClientIPResolver{}
+}
+
+func (cloudflareClientIPResolver) Resolve(request *http.Request) (netip.Addr, error) {
+	values := request.Header.Values(cloudflareConnectingIPHeader)
+	if len(values) != 1 || strings.Contains(values[0], ",") {
+		return netip.Addr{}, ErrClientIPUnavailable
+	}
+
+	return parseClientIP(strings.TrimSpace(values[0]))
+}
+
+type directClientIPResolver struct{}
+
+// NewDirectClientIPResolver reads the network peer and ignores proxy headers.
+func NewDirectClientIPResolver() ClientIPResolver {
+	return directClientIPResolver{}
+}
+
+func (directClientIPResolver) Resolve(request *http.Request) (netip.Addr, error) {
+	host, _, err := net.SplitHostPort(request.RemoteAddr)
+	if err != nil {
+		return netip.Addr{}, ErrClientIPUnavailable
+	}
+
+	return parseClientIP(host)
+}
+
+func parseClientIP(value string) (netip.Addr, error) {
+	clientIP, err := netip.ParseAddr(value)
+	if err != nil || clientIP.Zone() != "" {
+		return netip.Addr{}, ErrClientIPUnavailable
+	}
+	return clientIP.Unmap(), nil
+}
+
+var _ ClientIPResolver = cloudflareClientIPResolver{}
+var _ ClientIPResolver = directClientIPResolver{}

--- a/pkg/signupprotection/client_ip_test.go
+++ b/pkg/signupprotection/client_ip_test.go
@@ -1,0 +1,51 @@
+package signupprotection
+
+import (
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Client IP resolution", func() {
+	Describe("Cloudflare", func() {
+		It("accepts one valid CF-Connecting-IP value", func() {
+			request := httptest.NewRequest("POST", "/api/v1/user-signup", nil)
+			request.Header.Set("CF-Connecting-IP", "::ffff:203.0.113.10")
+
+			clientIP, err := NewCloudflareClientIPResolver().Resolve(request)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clientIP.String()).To(Equal("203.0.113.10"))
+		})
+
+		DescribeTable("rejecting ambiguous or invalid values",
+			func(values ...string) {
+				request := httptest.NewRequest("POST", "/api/v1/user-signup", nil)
+				for _, value := range values {
+					request.Header.Add("CF-Connecting-IP", value)
+				}
+
+				_, err := NewCloudflareClientIPResolver().Resolve(request)
+				Expect(err).To(MatchError(ErrClientIPUnavailable))
+			},
+			Entry("when the header is absent"),
+			Entry("when the value is invalid", "not-an-ip"),
+			Entry("when one value contains a list", "203.0.113.10, 203.0.113.11"),
+			Entry("when multiple values are present", "203.0.113.10", "203.0.113.11"),
+		)
+	})
+
+	Describe("direct connections", func() {
+		It("uses RemoteAddr and ignores forwarding headers", func() {
+			request := httptest.NewRequest("POST", "/api/v1/user-signup", nil)
+			request.RemoteAddr = "[2001:db8::10]:4321"
+			request.Header.Set("X-Forwarded-For", "203.0.113.99")
+
+			clientIP, err := NewDirectClientIPResolver().Resolve(request)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clientIP.String()).To(Equal("2001:db8::10"))
+		})
+	})
+})

--- a/pkg/signupprotection/limiter.go
+++ b/pkg/signupprotection/limiter.go
@@ -1,0 +1,143 @@
+package signupprotection
+
+import (
+	"crypto/sha256"
+	"errors"
+	"net/netip"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ThrottleSpec configures one bounded fixed-window attempt store.
+type ThrottleSpec struct {
+	MaxTrackedKeys int
+	MaxAttempts    int
+	Window         time.Duration
+	Now            func() time.Time
+}
+
+type fixedWindowEntry struct {
+	windowStart time.Time
+	count       int
+}
+
+type fixedWindowLimiter[Key comparable] struct {
+	mutex          sync.Mutex
+	entries        map[Key]fixedWindowEntry
+	maxTrackedKeys int
+	maxAttempts    int
+	window         time.Duration
+	now            func() time.Time
+	nextExpiry     time.Time
+}
+
+func newFixedWindowLimiter[Key comparable](spec ThrottleSpec) (*fixedWindowLimiter[Key], error) {
+	if spec.MaxTrackedKeys <= 0 {
+		return nil, errors.New("throttle max tracked keys must be positive")
+	}
+	if spec.MaxAttempts <= 0 {
+		return nil, errors.New("throttle max attempts must be positive")
+	}
+	if spec.Window <= 0 {
+		return nil, errors.New("throttle window must be positive")
+	}
+	if spec.Now == nil {
+		return nil, errors.New("throttle clock is required")
+	}
+
+	return &fixedWindowLimiter[Key]{
+		entries:        make(map[Key]fixedWindowEntry, spec.MaxTrackedKeys),
+		maxTrackedKeys: spec.MaxTrackedKeys,
+		maxAttempts:    spec.MaxAttempts,
+		window:         spec.Window,
+		now:            spec.Now,
+	}, nil
+}
+
+func (l *fixedWindowLimiter[Key]) Allow(key Key) bool {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	now := l.now()
+	if entry, found := l.entries[key]; found {
+		if !now.Before(entry.windowStart.Add(l.window)) {
+			entry.windowStart = now
+			entry.count = 1
+			l.entries[key] = entry
+			return true
+		}
+		if entry.count >= l.maxAttempts {
+			return false
+		}
+
+		entry.count++
+		l.entries[key] = entry
+		return true
+	}
+
+	if len(l.entries) >= l.maxTrackedKeys {
+		if now.Before(l.nextExpiry) {
+			return false
+		}
+		l.removeExpiredEntries(now)
+		if len(l.entries) >= l.maxTrackedKeys {
+			return false
+		}
+	}
+
+	l.entries[key] = fixedWindowEntry{windowStart: now, count: 1}
+	l.trackNextExpiry(now.Add(l.window))
+	return true
+}
+
+func (l *fixedWindowLimiter[Key]) removeExpiredEntries(now time.Time) {
+	l.nextExpiry = time.Time{}
+	for key, entry := range l.entries {
+		expiresAt := entry.windowStart.Add(l.window)
+		if !now.Before(expiresAt) {
+			delete(l.entries, key)
+			continue
+		}
+		l.trackNextExpiry(expiresAt)
+	}
+}
+
+func (l *fixedWindowLimiter[Key]) trackNextExpiry(expiresAt time.Time) {
+	if l.nextExpiry.IsZero() || expiresAt.Before(l.nextExpiry) {
+		l.nextExpiry = expiresAt
+	}
+}
+
+type ipLimiter struct {
+	store *fixedWindowLimiter[netip.Addr]
+}
+
+func newIPLimiter(spec ThrottleSpec) (*ipLimiter, error) {
+	store, err := newFixedWindowLimiter[netip.Addr](spec)
+	if err != nil {
+		return nil, err
+	}
+	return &ipLimiter{store: store}, nil
+}
+
+func (l *ipLimiter) Allow(clientIP netip.Addr) bool {
+	return l.store.Allow(clientIP.Unmap())
+}
+
+type emailLimiter struct {
+	store *fixedWindowLimiter[[sha256.Size]byte]
+}
+
+func newEmailLimiter(spec ThrottleSpec) (*emailLimiter, error) {
+	store, err := newFixedWindowLimiter[[sha256.Size]byte](spec)
+	if err != nil {
+		return nil, err
+	}
+	return &emailLimiter{store: store}, nil
+}
+
+func (l *emailLimiter) Allow(email string) bool {
+	normalizedEmail := strings.ToLower(strings.TrimSpace(email))
+	return l.store.Allow(sha256.Sum256([]byte(normalizedEmail)))
+}

--- a/pkg/signupprotection/limiter_test.go
+++ b/pkg/signupprotection/limiter_test.go
@@ -1,0 +1,69 @@
+package signupprotection
+
+import (
+	"net/netip"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Signup attempt throttles", func() {
+	var (
+		now  time.Time
+		spec ThrottleSpec
+	)
+
+	BeforeEach(func() {
+		now = time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+		spec = ThrottleSpec{
+			MaxTrackedKeys: 2,
+			MaxAttempts:    2,
+			Window:         time.Minute,
+			Now:            func() time.Time { return now },
+		}
+	})
+
+	It("allows the configured attempts and resets after the window", func() {
+		limiter, err := newIPLimiter(spec)
+		Expect(err).NotTo(HaveOccurred())
+		clientIP := netip.MustParseAddr("203.0.113.10")
+
+		Expect(limiter.Allow(clientIP)).To(BeTrue())
+		Expect(limiter.Allow(clientIP)).To(BeTrue())
+		Expect(limiter.Allow(clientIP)).To(BeFalse())
+
+		now = now.Add(time.Minute)
+		Expect(limiter.Allow(clientIP)).To(BeTrue())
+	})
+
+	It("rejects untracked keys while the bounded store is full", func() {
+		spec.MaxTrackedKeys = 1
+		limiter, err := newIPLimiter(spec)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(limiter.Allow(netip.MustParseAddr("203.0.113.10"))).To(BeTrue())
+		Expect(limiter.Allow(netip.MustParseAddr("203.0.113.11"))).To(BeFalse())
+
+		now = now.Add(time.Minute)
+		Expect(limiter.Allow(netip.MustParseAddr("203.0.113.11"))).To(BeTrue())
+	})
+
+	It("normalizes equivalent IP addresses", func() {
+		spec.MaxAttempts = 1
+		limiter, err := newIPLimiter(spec)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(limiter.Allow(netip.MustParseAddr("::ffff:203.0.113.10"))).To(BeTrue())
+		Expect(limiter.Allow(netip.MustParseAddr("203.0.113.10"))).To(BeFalse())
+	})
+
+	It("normalizes and hashes email addresses", func() {
+		spec.MaxAttempts = 1
+		limiter, err := newEmailLimiter(spec)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(limiter.Allow(" Person@Example.COM ")).To(BeTrue())
+		Expect(limiter.Allow("person@example.com")).To(BeFalse())
+	})
+})

--- a/pkg/signupprotection/protection.go
+++ b/pkg/signupprotection/protection.go
@@ -1,0 +1,103 @@
+package signupprotection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/Stackdome/stackdome/pkg/clients/turnstile"
+	apperrors "github.com/Stackdome/stackdome/pkg/errors"
+)
+
+const (
+	signupLimitReason        = "too many signup attempts"
+	signupVerificationReason = "signup verification failed"
+)
+
+// PasswordSignupAttempt contains the untrusted inputs needed at the public
+// password-signup request boundary.
+type PasswordSignupAttempt struct {
+	ClientIP       netip.Addr
+	Email          string
+	TurnstileToken string
+}
+
+// PasswordSignupProtection decides whether password signup may continue.
+type PasswordSignupProtection interface {
+	Check(context.Context, PasswordSignupAttempt) *apperrors.ServiceError
+}
+
+// PasswordSignupProtectionSpec contains the cloud verifier and bounded limits.
+type PasswordSignupProtectionSpec struct {
+	Verifier      turnstile.Verifier
+	IPThrottle    ThrottleSpec
+	EmailThrottle ThrottleSpec
+}
+
+// passwordSignupProtection verifies and throttles one public password signup
+// before the existing signup service is called.
+type passwordSignupProtection struct {
+	verifier     turnstile.Verifier
+	ipLimiter    *ipLimiter
+	emailLimiter *emailLimiter
+}
+
+// NewPasswordSignupProtection constructs cloud password-signup protection.
+func NewPasswordSignupProtection(spec PasswordSignupProtectionSpec) (PasswordSignupProtection, error) {
+	if spec.Verifier == nil {
+		return nil, errors.New("signup protection verifier is required")
+	}
+
+	ipLimiter, err := newIPLimiter(spec.IPThrottle)
+	if err != nil {
+		return nil, fmt.Errorf("invalid IP throttle: %w", err)
+	}
+	emailLimiter, err := newEmailLimiter(spec.EmailThrottle)
+	if err != nil {
+		return nil, fmt.Errorf("invalid email throttle: %w", err)
+	}
+
+	return &passwordSignupProtection{
+		verifier:     spec.Verifier,
+		ipLimiter:    ipLimiter,
+		emailLimiter: emailLimiter,
+	}, nil
+}
+
+func (p *passwordSignupProtection) Check(
+	ctx context.Context,
+	attempt PasswordSignupAttempt,
+) *apperrors.ServiceError {
+	if !attempt.ClientIP.IsValid() {
+		return apperrors.Forbidden(signupVerificationReason)
+	}
+
+	clientIP := attempt.ClientIP.Unmap()
+	if !p.ipLimiter.Allow(clientIP) {
+		return apperrors.TooManyRequests(signupLimitReason)
+	}
+	if err := p.verifier.Verify(ctx, attempt.TurnstileToken, clientIP); err != nil {
+		return apperrors.Forbidden(signupVerificationReason)
+	}
+	if !p.emailLimiter.Allow(attempt.Email) {
+		return apperrors.TooManyRequests(signupLimitReason)
+	}
+
+	return nil
+}
+
+type disabledPasswordSignupProtection struct{}
+
+// NewDisabledPasswordSignupProtection preserves self-hosted signup without
+// cloud verification or throttling.
+func NewDisabledPasswordSignupProtection() PasswordSignupProtection {
+	return disabledPasswordSignupProtection{}
+}
+
+func (disabledPasswordSignupProtection) Check(context.Context, PasswordSignupAttempt) *apperrors.ServiceError {
+	return nil
+}
+
+var _ PasswordSignupProtection = (*passwordSignupProtection)(nil)
+var _ PasswordSignupProtection = disabledPasswordSignupProtection{}

--- a/pkg/signupprotection/protection_test.go
+++ b/pkg/signupprotection/protection_test.go
@@ -1,0 +1,107 @@
+package signupprotection
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"time"
+
+	apperrors "github.com/Stackdome/stackdome/pkg/errors"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type verifierFunc func(context.Context, string, netip.Addr) error
+
+func (verify verifierFunc) Verify(ctx context.Context, token string, clientIP netip.Addr) error {
+	return verify(ctx, token, clientIP)
+}
+
+var _ = Describe("Password signup protection", func() {
+	var throttle ThrottleSpec
+
+	BeforeEach(func() {
+		throttle = ThrottleSpec{
+			MaxTrackedKeys: 10,
+			MaxAttempts:    1,
+			Window:         time.Minute,
+			Now:            time.Now,
+		}
+	})
+
+	It("checks IP throttling before Turnstile", func() {
+		verificationCalls := 0
+		protector := newProtector(verifierFunc(func(context.Context, string, netip.Addr) error {
+			verificationCalls++
+			return nil
+		}), throttle)
+		clientIP := netip.MustParseAddr("203.0.113.10")
+
+		Expect(protector.Check(context.Background(), PasswordSignupAttempt{
+			ClientIP: clientIP, Email: "first@example.com", TurnstileToken: "valid",
+		})).To(BeNil())
+		serviceErr := protector.Check(context.Background(), PasswordSignupAttempt{
+			ClientIP: clientIP, Email: "second@example.com", TurnstileToken: "valid",
+		})
+
+		Expect(serviceErr.Code).To(Equal(apperrors.ErrorTooManyRequests))
+		Expect(verificationCalls).To(Equal(1))
+	})
+
+	It("does not consume the email limit when Turnstile rejects the request", func() {
+		protector := newProtector(verifierFunc(func(_ context.Context, token string, _ netip.Addr) error {
+			if token == "invalid" {
+				return errors.New("rejected")
+			}
+			return nil
+		}), throttle)
+
+		serviceErr := protector.Check(context.Background(), PasswordSignupAttempt{
+			ClientIP:       netip.MustParseAddr("203.0.113.10"),
+			Email:          "person@example.com",
+			TurnstileToken: "invalid",
+		})
+		Expect(serviceErr.Code).To(Equal(apperrors.ErrorForbidden))
+
+		Expect(protector.Check(context.Background(), PasswordSignupAttempt{
+			ClientIP:       netip.MustParseAddr("203.0.113.11"),
+			Email:          "person@example.com",
+			TurnstileToken: "valid",
+		})).To(BeNil())
+	})
+
+	It("applies the email limit after successful verification", func() {
+		protector := newProtector(verifierFunc(func(context.Context, string, netip.Addr) error {
+			return nil
+		}), throttle)
+
+		Expect(protector.Check(context.Background(), PasswordSignupAttempt{
+			ClientIP:       netip.MustParseAddr("203.0.113.10"),
+			Email:          " Person@Example.com ",
+			TurnstileToken: "valid",
+		})).To(BeNil())
+		serviceErr := protector.Check(context.Background(), PasswordSignupAttempt{
+			ClientIP:       netip.MustParseAddr("203.0.113.11"),
+			Email:          "person@example.com",
+			TurnstileToken: "valid",
+		})
+
+		Expect(serviceErr.Code).To(Equal(apperrors.ErrorTooManyRequests))
+	})
+
+	It("allows signup when protection is explicitly disabled", func() {
+		protection := NewDisabledPasswordSignupProtection()
+
+		Expect(protection.Check(context.Background(), PasswordSignupAttempt{})).To(BeNil())
+	})
+})
+
+func newProtector(verifier verifierFunc, throttle ThrottleSpec) PasswordSignupProtection {
+	protector, err := NewPasswordSignupProtection(PasswordSignupProtectionSpec{
+		Verifier:      verifier,
+		IPThrottle:    throttle,
+		EmailThrottle: throttle,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return protector
+}

--- a/pkg/signupprotection/signupprotection_suite_test.go
+++ b/pkg/signupprotection/signupprotection_suite_test.go
@@ -1,0 +1,13 @@
+package signupprotection
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSignupProtection(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Signup Protection Suite")
+}


### PR DESCRIPTION
## Objective

Add the standalone components needed to protect public password signup in Stackdome Cloud, without changing any request path yet.

## Changes

- Add a canonical Cloudflare Turnstile siteverify client with timeout, bounded response parsing, and exact hostname/action validation.
- Add explicit Cloudflare and direct client-IP resolvers.
- Add bounded in-memory fixed-window IP and normalized-email throttles.
- Add one password-signup protection flow with the order: IP throttle, Turnstile verification, email throttle.
- Add an explicitly disabled implementation for self-hosted wiring.
- Cover new behavior with Ginkgo/Gomega tests only.

## Scope

This PR does not change handlers, services, OpenAPI, frontend behavior, GitHub OAuth, or invite acceptance. Backend integration will be a separate stacked PR.

## Alpha limitations

- Throttle state is per-process and resets on restart.
- This assumes the single Hub replica selected for alpha.
- The Cloudflare resolver is safe only when the origin accepts traffic exclusively from Cloudflare.

## Verification

- `go test -race ./pkg/clients/turnstile ./pkg/signupprotection`
- `go vet ./pkg/clients/turnstile ./pkg/signupprotection`
- `go test ./pkg/...`