### PR TITLE
Cloud alpha: add conditional Turnstile signup widget

### DIFF
--- a/frontend/src/components/auth/turnstile-widget.tsx
+++ b/frontend/src/components/auth/turnstile-widget.tsx
@@ -1,0 +1,139 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from "react";
+
+const turnstileScriptID = "cloudflare-turnstile-script";
+const turnstileScriptURL =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+export interface TurnstileRenderOptions {
+  sitekey: string;
+  action: string;
+  callback: (token: string) => void;
+  "expired-callback": () => void;
+  "error-callback": () => void;
+}
+
+export interface TurnstileAPI {
+  render(container: HTMLElement, options: TurnstileRenderOptions): string;
+  reset(widgetID: string): void;
+  remove(widgetID: string): void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileAPI;
+  }
+}
+
+export interface TurnstileWidgetHandle {
+  reset(): void;
+}
+
+interface TurnstileWidgetProps {
+  siteKey: string;
+  action: string;
+  onToken(token: string): void;
+  onUnavailable(): void;
+}
+
+let scriptPromise: Promise<TurnstileAPI> | null = null;
+
+function loadTurnstile(): Promise<TurnstileAPI> {
+  if (window.turnstile) return Promise.resolve(window.turnstile);
+  if (scriptPromise) return scriptPromise;
+
+  scriptPromise = new Promise<TurnstileAPI>((resolve, reject) => {
+    const existingScript = document.getElementById(turnstileScriptID) as HTMLScriptElement | null;
+    const script = existingScript ?? document.createElement("script");
+
+    const handleLoad = () => {
+      if (window.turnstile) {
+        resolve(window.turnstile);
+        return;
+      }
+      reject(new Error("Turnstile loaded without a browser API"));
+    };
+    const handleError = () => reject(new Error("failed to load Turnstile"));
+
+    script.addEventListener("load", handleLoad, { once: true });
+    script.addEventListener("error", handleError, { once: true });
+
+    if (!existingScript) {
+      script.id = turnstileScriptID;
+      script.src = turnstileScriptURL;
+      script.async = true;
+      script.defer = true;
+      document.head.appendChild(script);
+    }
+  }).catch((error: unknown) => {
+    scriptPromise = null;
+    throw error;
+  });
+
+  return scriptPromise;
+}
+
+export const TurnstileWidget = forwardRef<TurnstileWidgetHandle, TurnstileWidgetProps>(
+  function TurnstileWidget({ siteKey, action, onToken, onUnavailable }, ref) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const widgetIDRef = useRef<string | null>(null);
+    const onTokenRef = useRef(onToken);
+    const onUnavailableRef = useRef(onUnavailable);
+
+    onTokenRef.current = onToken;
+    onUnavailableRef.current = onUnavailable;
+
+    useImperativeHandle(ref, () => ({
+      reset() {
+        if (widgetIDRef.current && window.turnstile) {
+          window.turnstile.reset(widgetIDRef.current);
+        }
+      },
+    }));
+
+    useEffect(() => {
+      let active = true;
+      let turnstile: TurnstileAPI | undefined;
+
+      loadTurnstile()
+        .then((api) => {
+          if (!active || !containerRef.current) return;
+          turnstile = api;
+          widgetIDRef.current = api.render(containerRef.current, {
+            sitekey: siteKey,
+            action,
+            callback: (token) => onTokenRef.current(token),
+            "expired-callback": () => onTokenRef.current(""),
+            "error-callback": () => {
+              onTokenRef.current("");
+              onUnavailableRef.current();
+            },
+          });
+        })
+        .catch(() => {
+          if (active) onUnavailableRef.current();
+        });
+
+      return () => {
+        active = false;
+        if (widgetIDRef.current && turnstile) {
+          turnstile.remove(widgetIDRef.current);
+          widgetIDRef.current = null;
+        }
+      };
+    }, [siteKey, action]);
+
+    return (
+      <div
+        ref={containerRef}
+        className="cf-turnstile min-h-[65px]"
+        data-sitekey={siteKey}
+        data-action={action}
+      />
+    );
+  },
+);

--- a/frontend/src/hooks/tests/use-signup-config.test.ts
+++ b/frontend/src/hooks/tests/use-signup-config.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useSignupConfig } from "@/hooks/use-signup-config";
+import * as configApi from "@/api/config";
+
+vi.mock("@/api/config");
+
+describe("useSignupConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(configApi.getCachedAppConfig).mockReturnValue(null);
+  });
+
+  it("returns the public Turnstile settings from app config", async () => {
+    vi.mocked(configApi.getAppConfig).mockResolvedValue({
+      signup: {
+        turnstile: {
+          enabled: true,
+          site_key: "public-site-key",
+          action: "turnstile-spin-v2",
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useSignupConfig());
+
+    await waitFor(() =>
+      expect(result.current.turnstile).toEqual({
+        enabled: true,
+        site_key: "public-site-key",
+        action: "turnstile-spin-v2",
+      }),
+    );
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fails closed when app config cannot be loaded", async () => {
+    vi.mocked(configApi.getAppConfig).mockRejectedValue(new Error("network"));
+
+    const { result } = renderHook(() => useSignupConfig());
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+    expect(result.current.turnstile).toBeUndefined();
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/frontend/src/hooks/use-signup-config.ts
+++ b/frontend/src/hooks/use-signup-config.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { getAppConfig, getCachedAppConfig } from "@/api/config";
+import type { components } from "@/api/types/openapi";
+
+type TurnstileConfig = components["schemas"]["TurnstileConfigResponse"];
+
+export function useSignupConfig() {
+  const cached = getCachedAppConfig();
+  const [turnstile, setTurnstile] = useState<TurnstileConfig | undefined>(
+    cached?.signup?.turnstile,
+  );
+  const [loading, setLoading] = useState(cached === null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    getAppConfig()
+      .then((config) => {
+        if (!active) return;
+        setTurnstile(config.signup?.turnstile);
+        setError(null);
+      })
+      .catch((cause: unknown) => {
+        if (!active) return;
+        setTurnstile(undefined);
+        setError(cause instanceof Error ? cause : new Error("failed to load app config"));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { turnstile, loading, error };
+}

--- a/frontend/src/pages/signup/components/signup-form.tsx
+++ b/frontend/src/pages/signup/components/signup-form.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,6 +12,11 @@ import { setAuthSession } from "@/lib/common";
 import { getErrorMessage } from "@/api/client";
 import { FieldLabel } from "@/pages/auth/components/auth-shell";
 import { GitHubSignInButton } from "@/components/auth/github-sign-in-button";
+import {
+  TurnstileWidget,
+  type TurnstileWidgetHandle,
+} from "@/components/auth/turnstile-widget";
+import { useSignupConfig } from "@/hooks/use-signup-config";
 
 export function SignupForm() {
   const [formData, setFormData] = useState<SignupFormData>({
@@ -24,8 +29,21 @@ export function SignupForm() {
   const [errors, setErrors] = useState<Partial<SignupFormData>>({});
   const [serverError, setServerError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [turnstileToken, setTurnstileToken] = useState("");
+  const turnstileWidget = useRef<TurnstileWidgetHandle>(null);
   const { signup } = useSignup();
+  const {
+    turnstile,
+    loading: signupConfigLoading,
+    error: signupConfigError,
+  } = useSignupConfig();
   const navigate = useNavigate();
+  const turnstileEnabled = turnstile?.enabled === true;
+
+  const resetTurnstile = () => {
+    setTurnstileToken("");
+    turnstileWidget.current?.reset();
+  };
 
   const validateForm = (): boolean => {
     const result = signupSchema.safeParse(formData);
@@ -53,7 +71,15 @@ export function SignupForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!validateForm()) return;
+    if (!validateForm()) {
+      if (turnstileEnabled) resetTurnstile();
+      return;
+    }
+    if (signupConfigLoading || signupConfigError) return;
+    if (turnstileEnabled && !turnstileToken) {
+      setServerError("Complete the verification before creating your account.");
+      return;
+    }
     setIsLoading(true);
     setErrors({});
     setServerError(null);
@@ -63,6 +89,7 @@ export function SignupForm() {
         email: formData.email,
         password: formData.password,
         organisation: { name: formData.organisationName },
+        ...(turnstileEnabled ? { turnstile_token: turnstileToken } : {}),
       };
       const response: UserSignupResponse = await signup(payload);
       if (response && response.jwt_token && response.user) {
@@ -71,6 +98,7 @@ export function SignupForm() {
       navigate("/dashboard");
     } catch (err) {
       setServerError(getErrorMessage(err));
+      if (turnstileEnabled) resetTurnstile();
     } finally {
       setIsLoading(false);
     }
@@ -84,6 +112,12 @@ export function SignupForm() {
         {serverError && (
           <div className="rounded-2xl border border-danger-border bg-danger-bg px-4 py-2 text-sm text-danger">
             {serverError}
+          </div>
+        )}
+
+        {signupConfigError && (
+          <div className="rounded-2xl border border-danger-border bg-danger-bg px-4 py-2 text-sm text-danger">
+            Signup is temporarily unavailable.
           </div>
         )}
 
@@ -168,7 +202,30 @@ export function SignupForm() {
           )}
         </div>
 
-        <Button type="submit" variant="outline" className="w-full" disabled={isLoading}>
+        {turnstileEnabled && turnstile && (
+          <TurnstileWidget
+            ref={turnstileWidget}
+            siteKey={turnstile.site_key}
+            action={turnstile.action}
+            onToken={setTurnstileToken}
+            onUnavailable={() => {
+              setTurnstileToken("");
+              setServerError("Verification is temporarily unavailable.");
+            }}
+          />
+        )}
+
+        <Button
+          type="submit"
+          variant="outline"
+          className="w-full"
+          disabled={
+            isLoading ||
+            signupConfigLoading ||
+            signupConfigError !== null ||
+            (turnstileEnabled && !turnstileToken)
+          }
+        >
           {isLoading ? (
             <>
               <Loader2 className="animate-spin h-4 w-4" />

--- a/frontend/src/pages/signup/components/tests/signup-form-turnstile.test.tsx
+++ b/frontend/src/pages/signup/components/tests/signup-form-turnstile.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  TurnstileAPI,
+  TurnstileRenderOptions,
+} from "@/components/auth/turnstile-widget";
+import { SignupForm } from "@/pages/signup/components/signup-form";
+
+const mocks = vi.hoisted(() => ({
+  signup: vi.fn(),
+  signupConfig: vi.fn(),
+  navigate: vi.fn(),
+}));
+
+vi.mock("@/pages/signup/hooks/use-signup", () => ({
+  useSignup: () => ({ signup: mocks.signup }),
+}));
+vi.mock("@/hooks/use-signup-config", () => ({
+  useSignupConfig: () => mocks.signupConfig(),
+}));
+vi.mock("@/components/auth/github-sign-in-button", () => ({
+  GitHubSignInButton: () => null,
+}));
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router-dom")>()),
+  useNavigate: () => mocks.navigate,
+}));
+
+describe("SignupForm Turnstile integration", () => {
+  let renderOptions: TurnstileRenderOptions | undefined;
+  let reset: ReturnType<typeof vi.fn>;
+  let remove: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mocks.signup.mockReset();
+    mocks.signupConfig.mockReset();
+    mocks.navigate.mockReset();
+    reset = vi.fn();
+    remove = vi.fn();
+    const turnstile: TurnstileAPI = {
+      render: vi.fn((_container, options) => {
+        renderOptions = options;
+        return "widget-id";
+      }),
+      reset,
+      remove,
+    };
+    window.turnstile = turnstile;
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete window.turnstile;
+  });
+
+  it("does not render or submit Turnstile when disabled", async () => {
+    mocks.signupConfig.mockReturnValue({
+      turnstile: { enabled: false, site_key: "", action: "" },
+      loading: false,
+      error: null,
+    });
+    mocks.signup.mockResolvedValue({});
+    const user = userEvent.setup();
+    render(<SignupForm />);
+
+    await fillSignupForm(user);
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => expect(mocks.signup).toHaveBeenCalledTimes(1));
+    expect(mocks.signup.mock.calls[0][0]).not.toHaveProperty("turnstile_token");
+    expect(renderOptions).toBeUndefined();
+  });
+
+  it("submits the token returned by an enabled widget", async () => {
+    enableTurnstileConfig();
+    mocks.signup.mockResolvedValue({});
+    const user = userEvent.setup();
+    render(<SignupForm />);
+
+    await waitFor(() => expect(renderOptions).toBeDefined());
+    act(() => renderOptions?.callback("browser-token"));
+    await fillSignupForm(user);
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => expect(mocks.signup).toHaveBeenCalledTimes(1));
+    expect(mocks.signup.mock.calls[0][0]).toMatchObject({
+      email: "person@example.com",
+      turnstile_token: "browser-token",
+    });
+    expect(renderOptions?.sitekey).toBe("public-site-key");
+    expect(renderOptions?.action).toBe("turnstile-spin-v2");
+  });
+
+  it("resets the widget after the signup request fails", async () => {
+    enableTurnstileConfig();
+    mocks.signup.mockRejectedValue(new Error("rejected"));
+    const user = userEvent.setup();
+    render(<SignupForm />);
+
+    await waitFor(() => expect(renderOptions).toBeDefined());
+    act(() => renderOptions?.callback("browser-token"));
+    await fillSignupForm(user);
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => expect(reset).toHaveBeenCalledWith("widget-id"));
+  });
+
+  function enableTurnstileConfig() {
+    mocks.signupConfig.mockReturnValue({
+      turnstile: {
+        enabled: true,
+        site_key: "public-site-key",
+        action: "turnstile-spin-v2",
+      },
+      loading: false,
+      error: null,
+    });
+  }
+});
+
+async function fillSignupForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText("Full name"), "Person");
+  await user.type(screen.getByLabelText("Organization"), "Example");
+  await user.type(screen.getByLabelText("Email"), "person@example.com");
+  await user.type(screen.getByLabelText(/^Password/), "password123");
+  await user.type(screen.getByLabelText(/^Confirm password/), "password123");
+}


### PR DESCRIPTION
## Objective

Add the browser side of cloud password-signup protection without changing self-hosted signup or GitHub OAuth.

## Changes

- Read public Turnstile settings from the existing `/api/v1/config` cache.
- Load Cloudflare Turnstile only when the backend enables it.
- Render the configured site key/action on the password signup form.
- Submit `turnstile_token` only when enabled.
- Disable signup until verification succeeds and reset the single-use token after unsuccessful submission.
- Fail closed when config or widget loading fails.
- Leave the existing invite frontend untouched; #256 rejects invite-token signup in `stackdome_cloud`.

## Verification

- `pnpm --prefix frontend test:run` (193 files, 1596 tests passed)
- `pnpm --prefix frontend lint` (0 errors; existing warnings only)
- `pnpm --prefix frontend build`
- Browser inspection at desktop and mobile viewports
- After restacking: targeted frontend tests (5 passed), production build, and Hub handler/server tests

Local browser validation reaches the existing widget, but Cloudflare returns error 110200 because localhost is not registered on that widget. Production hostname/domain validation remains a deployment check.

## Stack

Base: #256
Depends on: #255 (merged)
