### PR TITLE
fix(stacks): initialize database data below volume roots

### DIFF
--- a/frontend/src/pages/stacks/data/blocks/registry.ts
+++ b/frontend/src/pages/stacks/data/blocks/registry.ts
@@ -32,6 +32,7 @@ export const blockCatalog: BlockPreset[] = [
       '    volumes: ["pgdata:/var/lib/postgresql/data"]',
       "    environment:",
       `      POSTGRES_PASSWORD: "${PLACEHOLDER_PASSWORD}"`,
+      '      PGDATA: "/var/lib/postgresql/data/pgdata"',
       "volumes:",
       "  pgdata: {}",
       "",
@@ -46,6 +47,7 @@ export const blockCatalog: BlockPreset[] = [
   },
   {
     id: BlockId.Mysql, name: "MySQL", category: "databases", icon: "mysql", summary: "mysql:8 · :3306",
+    args: "--datadir=/var/lib/mysql/data",
     compose: [
       "services:", "  mysql:", "    image: mysql:8", '    ports: ["3306:3306"]',
       '    volumes: ["mysql-data:/var/lib/mysql"]', "    environment:", `      MYSQL_ROOT_PASSWORD: "${PLACEHOLDER_PASSWORD}"`,
@@ -61,6 +63,7 @@ export const blockCatalog: BlockPreset[] = [
   },
   {
     id: BlockId.Mariadb, name: "MariaDB", category: "databases", icon: "mariadb", summary: "mariadb:11.4 · :3306",
+    args: "--datadir=/var/lib/mysql/data",
     compose: [
       "services:", "  mariadb:", "    image: mariadb:11.4", '    ports: ["3306:3306"]',
       '    volumes: ["mariadb-data:/var/lib/mysql"]', "    environment:", `      MARIADB_ROOT_PASSWORD: "${PLACEHOLDER_PASSWORD}"`,

--- a/frontend/src/pages/stacks/data/blocks/types.ts
+++ b/frontend/src/pages/stacks/data/blocks/types.ts
@@ -31,4 +31,5 @@ export interface BlockPreset {
   icon: string;      // BlockGlyph key: a lucide name ("globe", "box") or a brand key ("postgres", "redis", "mysql", "mongo")
   summary: string;   // mono one-liner shown on the card, e.g. "postgres:16 · :5432 · pgdata"
   compose?: string;  // 1-service docker-compose YAML; omitted for generic blocks
+  args?: string;     // container args applied without replacing the image entrypoint
 }

--- a/frontend/src/pages/stacks/data/templates/immich/stack.yaml
+++ b/frontend/src/pages/stacks/data/templates/immich/stack.yaml
@@ -33,6 +33,7 @@ services:
       POSTGRES_PASSWORD: "REPLACE_DB_PASSWORD_VALUE_HERE"
       POSTGRES_DB: immich
       POSTGRES_INITDB_ARGS: "--data-checksums"
+      PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - immich-db:/var/lib/postgresql/data
 

--- a/frontend/src/pages/stacks/data/templates/tests/template-conversion.test.ts
+++ b/frontend/src/pages/stacks/data/templates/tests/template-conversion.test.ts
@@ -11,6 +11,28 @@ describe("template conversion round-trip", () => {
     },
   );
 
+  it("keeps every bundled PostgreSQL resource below the mounted filesystem root", () => {
+    const postgresResources = templates.flatMap((template) => {
+      const { data } = templateToFormData(template);
+      return data.spec.stack_resources.filter(
+        (resource) =>
+          /(^|\/)postgres(?=:|$)/.test(resource.source?.image?.ref ?? "") &&
+          resource.volume_mounts?.some(
+            (mount) => mount.target_path === "/var/lib/postgresql/data",
+          ),
+      );
+    });
+
+    expect(postgresResources.length).toBeGreaterThan(0);
+    for (const postgres of postgresResources) {
+      expect(envByName(postgres).PGDATA).toEqual({
+        from: "stack",
+        name: "PGDATA",
+        value: "/var/lib/postgresql/data/pgdata",
+      });
+    }
+  });
+
   it("tooljet template produces the full 6-service stack", () => {
     const tooljet = getTemplateById("tooljet")!;
     const { data } = templateToFormData(tooljet);

--- a/frontend/src/pages/stacks/data/templates/tooljet/stack.yaml
+++ b/frontend/src/pages/stacks/data/templates/tooljet/stack.yaml
@@ -109,6 +109,7 @@ services:
       POSTGRES_DB: "tooljet_production"
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "REPLACE_POSTGRES_PASSWORD_VALUE_HERE"
+      PGDATA: /var/lib/postgresql/data/pgdata
 
   postgrest:
     image: postgrest/postgrest:v12.2.0

--- a/frontend/src/pages/stacks/lib/block-to-form.ts
+++ b/frontend/src/pages/stacks/lib/block-to-form.ts
@@ -78,6 +78,17 @@ function fillPlaceholderPasswords(resource: FormStackResourceData): FormStackRes
   } as FormStackResourceData;
 }
 
+function applyPresetArgs(resource: FormStackResourceData, args?: string): FormStackResourceData {
+  if (!args) return resource;
+  return {
+    ...resource,
+    execution_config: {
+      ...resource.execution_config,
+      args,
+    },
+  } as FormStackResourceData;
+}
+
 export function blockToResources(block: BlockPreset): {
   resources: FormStackResourceData[];
   volumes: FormVolumeData[];
@@ -92,9 +103,12 @@ export function blockToResources(block: BlockPreset): {
       `Block "${block.id}" failed to convert: ${result.errors?.[0]?.message ?? "unknown"}`
     );
   }
-  const resources = (result.data.spec.stack_resources ?? []).map((r) =>
-    DATA_BLOCK_CATEGORIES.has(block.category) ? fillPlaceholderPasswords(internalizePorts(r)) : r,
-  );
+  const resources = (result.data.spec.stack_resources ?? []).map((r) => {
+    const configured = applyPresetArgs(r, block.args);
+    return DATA_BLOCK_CATEGORIES.has(block.category)
+      ? fillPlaceholderPasswords(internalizePorts(configured))
+      : configured;
+  });
   return {
     resources,
     volumes: (result.data.spec.volumes ?? []) as FormVolumeData[],

--- a/frontend/src/pages/stacks/lib/tests/block-to-form.test.ts
+++ b/frontend/src/pages/stacks/lib/tests/block-to-form.test.ts
@@ -22,6 +22,30 @@ describe("block-to-form", () => {
     expect(volumes[0].name).toBe("pgdata");
   });
 
+  it("places postgres data below the volume root so filesystem metadata does not block initdb", () => {
+    const { resources } = blockToResources(getBlockById(BlockId.Postgres)!);
+    const env = (resources[0].execution_config?.environment_variables ?? []) as {
+      name?: string;
+      value?: string;
+    }[];
+
+    expect(env).toContainEqual({
+      from: "stack",
+      name: "PGDATA",
+      value: "/var/lib/postgresql/data/pgdata",
+    });
+  });
+
+  it.each([BlockId.Mysql, BlockId.Mariadb])(
+    "%s uses a child data directory without replacing the image entrypoint",
+    (id) => {
+      const { resources } = blockToResources(getBlockById(id)!);
+
+      expect(resources[0].execution_config?.command).toBeUndefined();
+      expect(resources[0].execution_config?.args).toBe("--datadir=/var/lib/mysql/data");
+    },
+  );
+
   it("converts a generic web block into an empty-image resource and no volumes", () => {
     const { resources, volumes } = blockToResources(getBlockById(BlockId.Web)!);
     expect(resources).toHaveLength(1);


### PR DESCRIPTION
## Summary

- set `PGDATA` below the mounted volume root for the PostgreSQL block and all bundled PostgreSQL templates
- keep MySQL and MariaDB image entrypoints while passing a child `--datadir`
- add regression coverage for block defaults and all bundled PostgreSQL templates

## Why

Longhorn ext4 volumes contain a `lost+found` directory at the filesystem root. PostgreSQL and MySQL reject that non-empty directory during first-time initialization. These frontend defaults place database files in a child directory while preserving the existing volume mounts.

## Verification

- `pnpm test:run` — 193 files, 1600 tests passed
- `pnpm lint` — 0 errors (25 pre-existing warnings)
- `pnpm build` — passed