### PR TITLE
Fix: show the full API token and its CLI command, both copyable

### DIFF
--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -198,7 +198,11 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
           <>
             <DialogHeader>
               <DialogTitle>Token created</DialogTitle>
-              <DialogDescription>Copy it now. You won&apos;t be able to see it again.</DialogDescription>
+              <DialogDescription>
+                {rawToken
+                  ? "Copy it now. You won't be able to see it again."
+                  : "The token was created, but the server did not return it. Revoke it and create another."}
+              </DialogDescription>
             </DialogHeader>
             <div className="min-w-0 space-y-4 py-2">
               {rawToken && (

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -61,6 +61,41 @@ function todayLocal(): string {
   return `${now.getFullYear()}-${month}-${day}`;
 }
 
+const quickStartCommand = (token: string) => `stackdome login --url ${SERVER_URL} --token ${token}`;
+
+function CopyBlock({
+  label,
+  value,
+  copied,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  copied: boolean;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="min-w-0 space-y-1.5">
+      <span className="flex items-center gap-2 text-sm leading-none font-medium select-none">{label}</span>
+      <div className="flex items-start gap-2">
+        <pre className="min-w-0 flex-1 rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-xs break-all whitespace-pre-wrap">
+          {value}
+        </pre>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="shrink-0"
+          onClick={onCopy}
+          aria-label={copied ? "Copied" : `Copy ${label.toLowerCase()}`}
+        >
+          {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateTokenDialogProps) {
   const { toast } = useToast();
   const [name, setName] = useState("");
@@ -71,7 +106,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [created, setCreated] = useState<APITokenCreateResponse | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
   const copyTimer = useRef<ReturnType<typeof setTimeout>>(null);
 
   useEffect(() => () => { if (copyTimer.current) clearTimeout(copyTimer.current); }, []);
@@ -84,7 +119,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
     setError(null);
     setScopes(null);
     setScopesError(null);
-    setCopied(false);
+    setCopied(null);
     getApiTokenScopes()
       .then((res) => {
         setScopes(res);
@@ -135,18 +170,19 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
     }
   }
 
-  async function handleCopy() {
-    if (!created?.token) return;
+  async function handleCopy(field: string, value: string) {
     try {
-      await copyText(created.token);
+      await copyText(value);
     } catch (e) {
       toast({ title: "Copy failed", description: getErrorMessage(e), variant: "destructive" });
       return;
     }
-    setCopied(true);
+    setCopied(field);
     if (copyTimer.current) clearTimeout(copyTimer.current);
-    copyTimer.current = setTimeout(() => setCopied(false), COPY_FLASH_MS);
+    copyTimer.current = setTimeout(() => setCopied(null), COPY_FLASH_MS);
   }
+
+  const rawToken = created?.token;
 
   function handleClose() {
     const wasCreated = created !== null;
@@ -165,33 +201,22 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
               <DialogDescription>You won&apos;t see this again — copy it now.</DialogDescription>
             </DialogHeader>
             <div className="min-w-0 space-y-4 py-2">
-              <div className="min-w-0 space-y-1.5">
-                <span className="flex items-center gap-2 text-sm leading-none font-medium select-none">Token</span>
-                <div className="flex items-center gap-2">
-                  <pre className="min-w-0 flex-1 overflow-x-auto rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-xs">
-                    {created.token}
-                  </pre>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleCopy}
-                    aria-label={copied ? "Copied" : "Copy token"}
-                  >
-                    {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                  </Button>
-                </div>
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="token-quickstart">Quick start</Label>
-                <Input
-                  id="token-quickstart"
-                  readOnly
-                  value={`stackdome login --url ${SERVER_URL} --token ${created.token}`}
-                  onFocus={(e) => e.currentTarget.select()}
-                  className="font-mono text-xs"
-                />
-              </div>
+              {rawToken && (
+                <>
+                  <CopyBlock
+                    label="Token"
+                    value={rawToken}
+                    copied={copied === "token"}
+                    onCopy={() => handleCopy("token", rawToken)}
+                  />
+                  <CopyBlock
+                    label="Quick start"
+                    value={quickStartCommand(rawToken)}
+                    copied={copied === "quickstart"}
+                    onCopy={() => handleCopy("quickstart", quickStartCommand(rawToken))}
+                  />
+                </>
+              )}
             </div>
             <DialogFooter>
               <Button onClick={handleClose}>Done</Button>

--- a/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/src/pages/api-tokens/components/create-token-dialog.tsx
@@ -39,13 +39,13 @@ interface CreateTokenDialogProps {
   onCreated: () => void;
 }
 
-// Native <input type="date"> only carries a calendar day — treat it as the
+// Native <input type="date"> only carries a calendar day, so treat it as the
 // end of that day in the user's local time so "expires on this date" reads
 // naturally, then hand the API an RFC3339 timestamp.
 //
 // Built from numeric y/m/d rather than parsing a "YYYY-MM-DDTHH:mm:ss" string:
 // a date-time string with no timezone offset is local time in every current
-// engine, but some older engines read it as UTC — the numeric constructor
+// engine, but some older engines read it as UTC. The numeric constructor
 // can't be ambiguous either way.
 function endOfDayRFC3339(date: string): string {
   const [year, month, day] = date.split("-").map(Number);
@@ -61,35 +61,35 @@ function todayLocal(): string {
   return `${now.getFullYear()}-${month}-${day}`;
 }
 
-const quickStartCommand = (token: string) => `stackdome login --url ${SERVER_URL} --token ${token}`;
+const cliLoginCommand = (token: string) => `stackdome login --url ${SERVER_URL} --token ${token}`;
 
 function CopyBlock({
   label,
+  copyLabel,
   value,
   copied,
   onCopy,
 }: {
   label: string;
+  copyLabel: string;
   value: string;
   copied: boolean;
   onCopy: () => void;
 }) {
   return (
     <div className="min-w-0 space-y-1.5">
-      <span className="flex items-center gap-2 text-sm leading-none font-medium select-none">{label}</span>
-      <div className="flex items-start gap-2">
-        <pre className="min-w-0 flex-1 rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-xs break-all whitespace-pre-wrap">
-          {value}
-        </pre>
+      <span className="text-[12px] text-muted-foreground select-none">{label}</span>
+      <div className="relative rounded-md border border-border bg-muted/40 py-2 pr-11 pl-3">
+        <p className="min-w-0 font-mono text-[13px] leading-5 break-all text-foreground">{value}</p>
         <Button
           type="button"
-          variant="outline"
+          variant="ghost"
           size="icon"
-          className="shrink-0"
+          className="absolute top-1.5 right-1.5 size-7 text-muted-foreground transition-transform hover:text-foreground active:scale-95"
           onClick={onCopy}
-          aria-label={copied ? "Copied" : `Copy ${label.toLowerCase()}`}
+          aria-label={copied ? "Copied" : copyLabel}
         >
-          {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+          {copied ? <Check className="size-3.5 text-success" /> : <Copy className="size-3.5" />}
         </Button>
       </div>
     </div>
@@ -144,7 +144,7 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
       setError("Expiry must be in the future.");
       return;
     }
-    // Scopes come from the server contract — never guess a full-access scope
+    // Scopes come from the server contract. Never guess a full-access scope
     // when that contract couldn't be read.
     if (!scopes) {
       setError("Scopes haven't loaded yet.");
@@ -198,22 +198,24 @@ export function CreateTokenDialog({ open, onOpenChange, onCreated }: CreateToken
           <>
             <DialogHeader>
               <DialogTitle>Token created</DialogTitle>
-              <DialogDescription>You won&apos;t see this again — copy it now.</DialogDescription>
+              <DialogDescription>Copy it now. You won&apos;t be able to see it again.</DialogDescription>
             </DialogHeader>
             <div className="min-w-0 space-y-4 py-2">
               {rawToken && (
                 <>
                   <CopyBlock
                     label="Token"
+                    copyLabel="Copy token"
                     value={rawToken}
                     copied={copied === "token"}
                     onCopy={() => handleCopy("token", rawToken)}
                   />
                   <CopyBlock
-                    label="Quick start"
-                    value={quickStartCommand(rawToken)}
-                    copied={copied === "quickstart"}
-                    onCopy={() => handleCopy("quickstart", quickStartCommand(rawToken))}
+                    label="Log in with the CLI"
+                    copyLabel="Copy CLI login command"
+                    value={cliLoginCommand(rawToken)}
+                    copied={copied === "cli"}
+                    onCopy={() => handleCopy("cli", cliLoginCommand(rawToken))}
                   />
                 </>
               )}

--- a/frontend/src/pages/api-tokens/tests/index.test.tsx
+++ b/frontend/src/pages/api-tokens/tests/index.test.tsx
@@ -76,9 +76,9 @@ describe("ApiTokensPage", () => {
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
-    // Shown twice: on its own, and inside the quick-start command.
+    // Shown twice: on its own, and inside the CLI login command.
     expect(await screen.findAllByText(/sd_raw_secret/)).toHaveLength(2);
-    expect(screen.getByText(/won't see this again/i)).toBeInTheDocument();
+    expect(screen.getByText(/won't be able to see it again/i)).toBeInTheDocument();
 
     // Dismissing the show-once view must drop the secret from state entirely.
     await userEvent.click(screen.getByRole("button", { name: /^done$/i }));
@@ -106,7 +106,7 @@ describe("ApiTokensPage", () => {
     expect(toastMock).not.toHaveBeenCalled();
   });
 
-  it("copies the quick-start command with the token embedded", async () => {
+  it("copies the CLI login command with the token embedded", async () => {
     Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
     vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
     renderPage();
@@ -116,7 +116,7 @@ describe("ApiTokensPage", () => {
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     await screen.findAllByText(/sd_raw_secret/);
 
-    await userEvent.click(screen.getByRole("button", { name: "Copy quick start" }));
+    await userEvent.click(screen.getByRole("button", { name: "Copy CLI login command" }));
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       expect.stringContaining("stackdome login --url "),
     );

--- a/frontend/src/pages/api-tokens/tests/index.test.tsx
+++ b/frontend/src/pages/api-tokens/tests/index.test.tsx
@@ -76,17 +76,18 @@ describe("ApiTokensPage", () => {
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
-    expect(await screen.findByText(/sd_raw_secret/)).toBeInTheDocument();
+    // Shown twice: on its own, and inside the quick-start command.
+    expect(await screen.findAllByText(/sd_raw_secret/)).toHaveLength(2);
     expect(screen.getByText(/won't see this again/i)).toBeInTheDocument();
 
     // Dismissing the show-once view must drop the secret from state entirely.
     await userEvent.click(screen.getByRole("button", { name: /^done$/i }));
-    expect(screen.queryByText(/sd_raw_secret/)).not.toBeInTheDocument();
+    expect(screen.queryAllByText(/sd_raw_secret/)).toHaveLength(0);
 
     // Reopening the create dialog must not resurface the previous secret.
     await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
     expect(await screen.findByLabelText(/name/i)).toBeInTheDocument();
-    expect(screen.queryByText(/sd_raw_secret/)).not.toBeInTheDocument();
+    expect(screen.queryAllByText(/sd_raw_secret/)).toHaveLength(0);
   });
 
   it("copies the token via the Clipboard API when available", async () => {
@@ -97,12 +98,32 @@ describe("ApiTokensPage", () => {
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
-    await screen.findByText(/sd_raw_secret/);
+    await screen.findAllByText(/sd_raw_secret/);
 
     await userEvent.click(screen.getByRole("button", { name: "Copy token" }));
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("sd_raw_secret");
     expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
     expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("copies the quick-start command with the token embedded", async () => {
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+    vi.mocked(tokensApi.createApiToken).mockResolvedValue({ id: "t2", name: "ci", token: "sd_raw_secret" });
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: /create token/i }));
+    await userEvent.type(screen.getByLabelText(/name/i), "ci");
+    await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    await screen.findAllByText(/sd_raw_secret/);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy quick start" }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("stackdome login --url "),
+    );
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("--token sd_raw_secret"),
+    );
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
   });
 
   it("falls back to a textarea copy when the Clipboard API is unavailable (insecure context)", async () => {
@@ -114,7 +135,7 @@ describe("ApiTokensPage", () => {
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
-    await screen.findByText(/sd_raw_secret/);
+    await screen.findAllByText(/sd_raw_secret/);
 
     // No throw / unhandled rejection from the missing Clipboard API.
     await userEvent.click(screen.getByRole("button", { name: "Copy token" }));
@@ -134,7 +155,7 @@ describe("ApiTokensPage", () => {
     await userEvent.type(screen.getByLabelText(/name/i), "ci");
     await waitFor(() => expect(screen.getByRole("button", { name: /^create$/i })).toBeEnabled());
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
-    await screen.findByText(/sd_raw_secret/);
+    await screen.findAllByText(/sd_raw_secret/);
 
     await userEvent.click(screen.getByRole("button", { name: "Copy token" }));
     await waitFor(() =>


### PR DESCRIPTION
## 📝 What this does

The show-once token view hid what you came for: the token sat in a horizontally scrolling box so its tail was off screen, and the CLI login command was a read-only input with no copy button at all. Both now wrap in full and each has its own copy button.

Stack reference integrity was split out into #262.

## 🔀 Changes

- Rendered the token and the CLI login command as wrapping blocks so neither is cut off
- Gave each its own copy button, with the check flashing only on the one you pressed
- Matched the labels, mono type, and ghost icon button to the Postgres connection panel, which already had this pattern
- Renamed the second block to name the action it performs rather than calling it a quick start
- Said what happened when the server returns no token, instead of rendering an empty dialog body

## 🧪 How to test

- [x] Open Settings, then API Tokens, and create a token
- [x] Confirm the whole token is visible without scrolling sideways
- [x] Copy the token, then copy the CLI command, and confirm each button flashes independently
- [x] Paste the CLI command and confirm it carries the server URL and the token