### PR TITLE
Fix: show structured container failures before logs

### DIFF
--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/derive.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/derive.ts
@@ -125,7 +125,7 @@ export interface FailingResource {
   name: string;
   type: ResourceFailureTypeValue;
   stage: FailureStage;
-  reason: string;
+  reason?: string;
   message?: string;
   exitCode?: number;
   restartCount?: number;
@@ -152,6 +152,17 @@ const FAILURE_TYPE_LABELS: Record<string, string> = {
 export function humanizeFailureType(failureType?: string): string {
   if (!failureType) return "Unknown";
   return FAILURE_TYPE_LABELS[failureType] ?? failureType;
+}
+
+/** Prefer structured failure fields over free-form container output. */
+export function failureDiagnosis(
+  failure: Partial<Pick<FailingResource, "failureType" | "reason">>,
+): string | undefined {
+  const failureType = failure.failureType?.trim() || undefined;
+  const reason = failure.reason?.trim() || undefined;
+  const label = failureType ? humanizeFailureType(failureType) : undefined;
+  if (label && reason) return `${label} (${reason})`;
+  return label ?? reason ?? undefined;
 }
 
 /** Pick the active detail block from a last_failure (build vs container vs init).
@@ -182,7 +193,7 @@ export function deriveFailingResources(_release: StackRelease, liveStatus?: Rele
       name,
       type: f.type ?? ResourceFailureType.Runtime,
       stage,
-      reason: detail?.reason ?? humanizeFailureType(detail?.failure_type),
+      reason: detail?.reason,
       message: detail?.message,
       exitCode: detail?.exit_code,
       restartCount: detail?.restart_count,
@@ -393,7 +404,7 @@ export function toneDotClass(t: Tone): string {
  * Console messages drop the resource name (it sits in its own column) and lead with
  * the verb; the detail after the first ": " is kept. Unknown types pass through.
  */
-export function compactEventMessage(e: ReleaseEvent): string {
+export function compactEventMessage(e: ReleaseEvent, failure?: FailingResource): string {
   const msg = e.message ?? "";
   const detail = (prefix: string) => {
     const i = msg.indexOf(": ");
@@ -403,7 +414,14 @@ export function compactEventMessage(e: ReleaseEvent): string {
     case ReleaseEventType.ResourceDeploying: return detail("Deploying");
     case ReleaseEventType.ResourceWaiting: return detail("Waiting");
     case ReleaseEventType.ResourceReady: return "Ready";
-    case ReleaseEventType.ResourceFailed: return detail("Failed to start");
+    case ReleaseEventType.ResourceFailed: {
+      const eventReason = e.metadata?.reason?.trim() || undefined;
+      const matchesCurrentFailure = failure && (!eventReason || eventReason === failure.reason);
+      const diagnosis = matchesCurrentFailure ? failureDiagnosis(failure) : eventReason;
+      if (!diagnosis) return detail("Failed to start");
+      const exit = matchesCurrentFailure && failure.exitCode != null ? `, exit ${failure.exitCode}` : "";
+      return `Failed to start — ${diagnosis}${exit}`;
+    }
     default: return msg;
   }
 }

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/derive.test.ts
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/tests/derive.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { deriveFailingResources, deriveRecovered, humanizeFailureType, causeLabel, formatDuration, formatReleaseTime, ResourceFailureType } from "../derive";
+import { deriveFailingResources, deriveRecovered, failureDiagnosis, humanizeFailureType, causeLabel, formatDuration, formatReleaseTime, ResourceFailureType } from "../derive";
 import { deriveStages, deriveReleaseTitle, releaseGitSha, phaseTone, toneTextClass, toneDotClass, stateTone, toneFromVariant, BUILD_READY_CONDITION, CONDITION_TRUE } from "../derive";
 import { deriveHeaderHealth, latestDeployFailed, stackSummariesStale, stripUnpinnedGitRevisions } from "../derive";
 import type { FailingResource, Stack, StackResource } from "../derive";
@@ -71,6 +71,30 @@ describe("deriveFailingResources", () => {
   it("returns nothing without a live status (not live or active)", () => {
     expect(deriveFailingResources(release({}))).toEqual([]);
   });
+
+  it("preserves absent structured fields so a captured message remains the fallback", () => {
+    const liveStatus = liveStatusWith({
+      worker: { state: "Error", last_failure: {
+        type: "runtime_crash", container: { message: "captured termination output" } } },
+    });
+    const [failure] = deriveFailingResources(release({}), liveStatus);
+
+    expect(failure).toMatchObject({ message: "captured termination output" });
+    expect(failure.reason).toBeUndefined();
+    expect(failure.failureType).toBeUndefined();
+    expect(failureDiagnosis(failure)).toBeUndefined();
+  });
+
+  it("preserves a failure type without synthesizing a duplicate reason", () => {
+    const liveStatus = liveStatusWith({
+      worker: { state: "Error", last_failure: {
+        type: "runtime_crash", container: { failure_type: "out_of_memory" } } },
+    });
+    const [failure] = deriveFailingResources(release({}), liveStatus);
+
+    expect(failure.reason).toBeUndefined();
+    expect(failureDiagnosis(failure)).toBe("Out of memory");
+  });
 });
 
 describe("deriveRecovered", () => {
@@ -109,6 +133,22 @@ describe("humanizeFailureType", () => {
   it("falls back to the raw value", () => {
     expect(humanizeFailureType("weird_thing")).toBe("weird_thing");
     expect(humanizeFailureType(undefined)).toBe("Unknown");
+  });
+});
+
+describe("failureDiagnosis", () => {
+  it.each([
+    ["out_of_memory", "OOMKilled", "Out of memory (OOMKilled)"],
+    ["image_pull_failed", "ImagePullBackOff", "Image pull failed (ImagePullBackOff)"],
+    ["create_container_error", "CreateContainerError", "Container create error (CreateContainerError)"],
+  ])("prioritizes human-readable failure type %s before Kubernetes reason %s", (failureType, reason, expected) => {
+    expect(failureDiagnosis({ failureType, reason })).toBe(expected);
+  });
+
+  it("uses whichever structured field is available and leaves message-only failures to the caller", () => {
+    expect(failureDiagnosis({ reason: "CrashLoopBackOff" })).toBe("CrashLoopBackOff");
+    expect(failureDiagnosis({ failureType: "out_of_memory", reason: "" })).toBe("Out of memory");
+    expect(failureDiagnosis({ reason: "" })).toBeUndefined();
   });
 });
 

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/split-console.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/split-console.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { LogSnapshot } from "@/components/branded";
 import { fetchLogSnapshot } from "@/api/observability";
-import { BuildLogsLinkTarget, ReleaseEventLinkKind, type ReleaseEvent } from "@/api/releases";
+import { BuildLogsLinkTarget, ReleaseEventLinkKind, ReleaseEventType, type ReleaseEvent } from "@/api/releases";
 import type { FailingResource, ResourceSource } from "../derive";
-import { phaseTone, toneTextClass, toneDotClass, tonePillClass, ResourceFailureType, compactEventMessage } from "../derive";
+import { phaseTone, toneTextClass, toneDotClass, tonePillClass, ResourceFailureType, compactEventMessage, failureDiagnosis } from "../derive";
 import { BuildLogsModal } from "../build-logs-modal";
 
 export interface LogContext { orgId: string; projectName: string; stackId: string; }
@@ -49,11 +49,21 @@ export function SplitConsole({ rows, events, streaming, logContext }: SplitConso
   const [buildLogs, setBuildLogs] = useState<{ buildId: string; resourceName: string } | null>(null);
   if (rows.length === 0 && events.length === 0 && !streaming) return null;
 
+  const failuresByResource = new Map(rows.flatMap((row) => row.failure ? [[row.name, row.failure] as const] : []));
+  const latestFailureEventByResource = new Map<string, ReleaseEvent>();
+  for (const event of events) {
+    if (event.type === ReleaseEventType.ResourceFailed && event.resource_name) {
+      latestFailureEventByResource.set(event.resource_name, event);
+    }
+  }
   const selectedRow = rows.find((r) => r.name === selected);
   const visible = selectedRow ? events.filter((e) => e.resource_name === selectedRow.name) : events;
   const readyCount = rows.filter((r) => phaseTone(r.phase) === "ok").length;
   const failure = selectedRow?.failure;
-  const detailMsg = failure ? (failure.message ?? failure.reason) : selectedRow?.msg;
+  const diagnosis = failure ? failureDiagnosis(failure) : undefined;
+  const detailMsg = failure ? (diagnosis ?? failure.message) : selectedRow?.msg;
+  const capturedOutput = failure?.message?.trim();
+  const supportingLines = diagnosis && capturedOutput ? capturedOutput.split(/\r?\n/) : [];
   const isRuntimeCrash = failure?.type === ResourceFailureType.Runtime;
 
   return (
@@ -128,9 +138,15 @@ export function SplitConsole({ rows, events, streaming, logContext }: SplitConso
                 )}
               </div>
               {detailMsg && <div className={cn("mt-1.5 font-mono text-[11px] leading-relaxed", failure ? "text-danger" : "text-foreground")}>{detailMsg}</div>}
+              {supportingLines.length > 0 && (
+                <LogSnapshot
+                  lines={supportingLines}
+                  label={isRuntimeCrash ? "Termination output" : "Diagnostic output"}
+                />
+              )}
               {/* Crash-log snapshot is a one-shot follow=false read — the only log surface
                   that captures a crashing container's output (the Logs tab is live-only). */}
-              {logContext && isRuntimeCrash && failure && <CrashLog ctx={logContext} name={failure.name} />}
+              {logContext && isRuntimeCrash && failure && !capturedOutput && <CrashLog ctx={logContext} name={failure.name} />}
             </div>
           )}
 
@@ -140,6 +156,9 @@ export function SplitConsole({ rows, events, streaming, logContext }: SplitConso
             )}
             {visible.map((e) => {
               const lv = levelGlyph[e.level ?? DEFAULT_LEVEL] ?? levelGlyph[DEFAULT_LEVEL];
+              const eventFailure = e.resource_name && latestFailureEventByResource.get(e.resource_name) === e
+                ? failuresByResource.get(e.resource_name)
+                : undefined;
               return (
                 <div key={e.sequence} className="flex items-start gap-2.5 px-4 py-[5px] hover:bg-muted">
                   <span className="w-14 flex-none pt-0.5 font-mono text-[10.5px] tabular-nums text-fg-muted">
@@ -148,7 +167,7 @@ export function SplitConsole({ rows, events, streaming, logContext }: SplitConso
                   <span className={cn("w-3 flex-none text-center font-mono text-[11px]", lv.text)}>{lv.glyph}</span>
                   <span className="w-[90px] flex-none truncate pt-0.5 font-mono text-[10.5px] text-fg-muted">{e.resource_name || "release"}</span>
                   <span className="min-w-0 flex-1 break-words text-[12.5px] leading-[1.45] text-fg-2">
-                    {compactEventMessage(e)}
+                    {compactEventMessage(e, eventFailure)}
                     {(e.links ?? []).map((l, i) => {
                       const buildId = l.target?.[BuildLogsLinkTarget.BuildID];
                       return l.kind === ReleaseEventLinkKind.BuildLogs && buildId && logContext ? (

--- a/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/tests/split-console.test.tsx
+++ b/frontend/src/pages/stacks/components/editor/tabs/deployments/timeline/tests/split-console.test.tsx
@@ -10,10 +10,14 @@ vi.mock("../../build-logs-modal", () => ({
   ),
 }));
 import { SplitConsole, type ResourceRowVM } from "../split-console";
+import { fetchLogSnapshot } from "@/api/observability";
 import { BuildLogsLinkTarget, ReleaseEventLinkKind, ReleaseEventType, type ReleaseEvent } from "@/api/releases";
 import { ResourceFailureType, compactEventMessage } from "../../derive";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.mocked(fetchLogSnapshot).mockReset().mockResolvedValue([]);
+});
 
 const ev = (over: Partial<ReleaseEvent> = {}): ReleaseEvent => ({
   sequence: over.sequence ?? 1,
@@ -70,7 +74,7 @@ describe("SplitConsole", () => {
     // Release-scoped event carries the "release" column tag.
     expect(screen.getByText("release")).toBeInTheDocument();
     expect(screen.getByText("Release created")).toBeInTheDocument();
-    expect(screen.getByText("Failed to start — image pull failed")).toBeInTheDocument();
+    expect(screen.getByText("Failed to start — CrashLoopBackOff")).toBeInTheDocument();
   });
 
   it("badges the all-resources row with the resource count, not the event count", () => {
@@ -98,7 +102,122 @@ describe("SplitConsole", () => {
     expect(screen.getByText("3 restarts")).toBeInTheDocument();
     // Console filtered to worker's events only.
     expect(screen.queryByText("Release created")).not.toBeInTheDocument();
-    expect(screen.getByText("Failed to start — image pull failed")).toBeInTheDocument();
+    expect(screen.getByText("Failed to start — CrashLoopBackOff")).toBeInTheDocument();
+  });
+
+  it("shows an OOM diagnosis first and keeps captured termination output out of the activity line", async () => {
+    const terminationOutput = "allocation failed\nprocess shutting down";
+    const oomRows: ResourceRowVM[] = [{
+      name: "tooljet",
+      phase: "CrashLoopBackOff",
+      failure: {
+        name: "tooljet",
+        type: ResourceFailureType.Runtime,
+        stage: "runtime",
+        failureType: "out_of_memory",
+        reason: "OOMKilled",
+        message: terminationOutput,
+        exitCode: 137,
+        restartCount: 1,
+      },
+    }];
+    const oomEvents = [ev({
+      type: ReleaseEventType.ResourceFailed,
+      resource_name: "tooljet",
+      message: `tooljet failed to start: ${terminationOutput}`,
+      level: "error",
+    })];
+
+    render(<SplitConsole rows={oomRows} events={oomEvents} streaming={false} logContext={logContext} />);
+    expect(screen.getByText("Failed to start — Out of memory (OOMKilled), exit 137")).not.toHaveTextContent("allocation failed");
+
+    await userEvent.click(screen.getByRole("button", { name: /tooljet/ }));
+    expect(screen.getByText("Out of memory (OOMKilled)")).toBeInTheDocument();
+    expect(screen.getByText("exit 137")).toBeInTheDocument();
+    expect(screen.getByText("1 restart")).toBeInTheDocument();
+    expect(screen.getByText("Termination output")).toBeInTheDocument();
+    expect(screen.getByText((_, element) => element?.tagName === "PRE" && element.textContent === terminationOutput)).toBeInTheDocument();
+  });
+
+  it("fetches the crash-log snapshot only when captured termination output is absent", async () => {
+    vi.mocked(fetchLogSnapshot).mockResolvedValueOnce(["fallback crash log"]);
+    const crashRows: ResourceRowVM[] = [{
+      name: "worker",
+      phase: "CrashLoopBackOff",
+      failure: {
+        name: "worker",
+        type: ResourceFailureType.Runtime,
+        stage: "runtime",
+        failureType: "crash_loop",
+        reason: "CrashLoopBackOff",
+      },
+    }];
+
+    render(<SplitConsole rows={crashRows} events={[]} streaming logContext={logContext} />);
+    await userEvent.click(screen.getByRole("button", { name: /worker/ }));
+
+    expect(await screen.findByText("fallback crash log")).toBeInTheDocument();
+    expect(screen.queryByText("Termination output")).not.toBeInTheDocument();
+  });
+
+  it("uses captured output as the primary fallback when structured fields are absent", async () => {
+    const messageRows: ResourceRowVM[] = [{
+      name: "worker",
+      phase: "Error",
+      failure: {
+        name: "worker",
+        type: ResourceFailureType.Runtime,
+        stage: "runtime",
+        reason: undefined,
+        message: "captured termination output",
+      },
+    }];
+
+    render(<SplitConsole rows={messageRows} events={[]} streaming logContext={logContext} />);
+    await userEvent.click(screen.getByRole("button", { name: /worker/ }));
+
+    expect(screen.getByText("captured termination output")).toBeInTheDocument();
+    expect(screen.queryByText("Termination output")).not.toBeInTheDocument();
+  });
+
+  it("keeps historical failure events tied to their own recorded reason", () => {
+    const currentRows: ResourceRowVM[] = [{
+      name: "worker",
+      phase: "CrashLoopBackOff",
+      failure: {
+        name: "worker",
+        type: ResourceFailureType.Runtime,
+        stage: "runtime",
+        failureType: "out_of_memory",
+        reason: "OOMKilled",
+        exitCode: 137,
+      },
+    }];
+    const failureEvents = [
+      ev({
+        sequence: 1,
+        type: ReleaseEventType.ResourceFailed,
+        resource_name: "worker",
+        message: "worker failed to start: old image pull log tail",
+        metadata: { reason: "ImagePullBackOff" },
+        level: "error",
+      }),
+      ev({
+        sequence: 2,
+        type: ReleaseEventType.ResourceFailed,
+        resource_name: "worker",
+        message: "worker failed to start: current OOM log tail",
+        metadata: { reason: "OOMKilled" },
+        level: "error",
+      }),
+    ];
+
+    render(<SplitConsole rows={currentRows} events={failureEvents} streaming={false} />);
+
+    expect(screen.getByText("Failed to start — ImagePullBackOff")).toBeInTheDocument();
+    expect(screen.getByText("Failed to start — Out of memory (OOMKilled), exit 137")).toBeInTheDocument();
+    expect(screen.queryByText(/old image pull log tail/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/current OOM log tail/)).not.toBeInTheDocument();
   });
 
   it("clicking all resources zooms back out", async () => {


### PR DESCRIPTION
## 📝 What this does

The Deployments UI displayed captured container output as the primary error, which made an `OOMKilled` resource look like an application startup failure. Structured failure data now leads the diagnosis, while termination output remains available as supporting evidence.

## 🔀 Changes

- Format structured container failures as human-readable type plus Kubernetes reason, such as `Out of memory (OOMKilled)`
- Keep exit code and restart count visible in the selected-resource header
- Render captured termination output in a separate read-only snapshot and retain the fetched crash-log fallback when captured output is absent
- Use each `ResourceFailed` event's recorded reason so historical events are not relabeled with a later failure
- Preserve existing message-based behavior when structured failure fields are absent
- Add regression coverage for OOM, type-only and message-only failures, log fallbacks, and multiple failures on one resource

## 🧪 Verification

- `pnpm test:run -- --reporter=dot` — 193 files, 1606 tests passed
- `pnpm build` — passed
- `pnpm lint` — 0 errors (25 pre-existing warnings)
- Independent code review — ready to merge, no Critical/Important/Minor findings after fixes
