### PR TITLE
Fix: give the web-resource tour step a Next button

### DIFF
--- a/frontend/src/pages/stacks/lib/onboarding/tests/tour.test.ts
+++ b/frontend/src/pages/stacks/lib/onboarding/tests/tour.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { openWebResource } from "@/pages/stacks/lib/onboarding/tour";
+
+describe("openWebResource", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function renderWebNode() {
+    const node = document.createElement("div");
+    node.className = "react-flow__node";
+    node.dataset.id = "resource:web";
+    const onClick = vi.fn();
+    node.addEventListener("click", onClick);
+    document.body.append(node);
+    return onClick;
+  }
+
+  it("clicks the web card when the drawer is closed", () => {
+    const onClick = renderWebNode();
+    openWebResource();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when the drawer is already open", () => {
+    const onClick = renderWebNode();
+    const drawer = document.createElement("div");
+    drawer.dataset.testid = "resource-drawer";
+    document.body.append(drawer);
+
+    openWebResource();
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/stacks/lib/onboarding/tour.ts
+++ b/frontend/src/pages/stacks/lib/onboarding/tour.ts
@@ -51,13 +51,23 @@ export function startCanvasStage(): void {
   stage = "canvas";
 }
 
+const WEB_NODE_SELECTOR = '.react-flow__node[data-id="resource:web"]';
+const DRAWER_SELECTOR = '[data-testid="resource-drawer"]';
+
+/** Idempotent — driver.js routes both the card click and the Next button
+    through the same hook, and the card may already be open. */
+export function openWebResource(): void {
+  if (document.querySelector(DRAWER_SELECTOR)) return;
+  document.querySelector<HTMLElement>(WEB_NODE_SELECTOR)?.click();
+}
+
 /** Drawer tabs in render order; the tour drives them by position. */
 const DRAWER_TABS = ["configuration", "deployment", "environment"] as const;
 
 /** Radix tabs activate on mousedown, so a bare click() does nothing. */
 function showDrawerTab(tab: (typeof DRAWER_TABS)[number]): void {
   const tabs = document.querySelectorAll<HTMLButtonElement>(
-    '[data-testid="resource-drawer"] [role="tab"]',
+    `${DRAWER_SELECTOR} [role="tab"]`,
   );
   tabs[DRAWER_TABS.indexOf(tab)]?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
 }
@@ -77,19 +87,22 @@ export function runCanvasTour(): void {
         },
       },
       {
-        element: '.react-flow__node[data-id="resource:web"]',
+        element: WEB_NODE_SELECTOR,
         popover: {
           title: "The web resource",
           description:
             "This one runs a ready-made container image. Click the card to look inside.",
           side: "bottom",
-          showButtons: ["close"],
+          onNextClick: () => {
+            openWebResource();
+            d.moveNext();
+          },
         },
         disableActiveInteraction: false,
         advanceOnClick: true,
       },
       {
-        element: '[data-testid="resource-drawer"]',
+        element: DRAWER_SELECTOR,
         waitForElement: 2000,
         popover: {
           title: "Configuration",
@@ -104,7 +117,7 @@ export function runCanvasTour(): void {
         },
       },
       {
-        element: '[data-testid="resource-drawer"]',
+        element: DRAWER_SELECTOR,
         popover: {
           title: "Deployment",
           description:
@@ -118,7 +131,7 @@ export function runCanvasTour(): void {
         },
       },
       {
-        element: '[data-testid="resource-drawer"]',
+        element: DRAWER_SELECTOR,
         popover: {
           title: "Environment",
           description:
@@ -127,7 +140,7 @@ export function runCanvasTour(): void {
           align: "center",
           onNextClick: () => {
             document
-              .querySelector<HTMLButtonElement>('[data-testid="resource-drawer"] [aria-label="Close"]')
+              .querySelector<HTMLButtonElement>(`${DRAWER_SELECTOR} [aria-label="Close"]`)
               ?.click();
             setTimeout(() => d.moveNext(), 300);
           },


### PR DESCRIPTION
## 📝 What this does

The onboarding tour's web-resource step only offered a Close button. If a user didn't realise the highlighted card was itself the click target, there was no way forward, and closing there marks the tour done for good. This adds a Next button to that step.

## 🔀 Changes

- Added a Next button to the web-resource tour step, which opens the card and advances.
- Routed the card click and the Next button through one `onNextClick` hook, guarded so a click that already opened the drawer isn't repeated.
- Pulled the web-node and resource-drawer selectors into constants, replacing five literal copies.
- Added tests covering both branches of the open-card guard.

## 🧪 How to test

- [x] Clear `stackdome.onboarding-tour.done` from localStorage and reload the stacks list.
- [x] Start the tour and advance to the web-resource step — the popover now reads `2 of 7` with a Next button.
- [x] Press Next — the drawer opens on `web` and the tour moves to the Configuration step (`3 of 7`).
- [x] Restart the tour and click the card instead — same result, exactly one drawer opens and the tour still lands on `3 of 7`.
- [x] Walk the rest of the tour — steps 3 through 7 advance as before, and the drawer closes on the way to the worker step.

Verified against a local dev server with the demo seed. The deploy step (`7 of 7`) was not exercised, since it deploys a real workload to the cluster; it is unchanged by this PR and still Close-only by design.
