### PR TITLE
Fix: line the Turnstile widget up with the signup form

### DIFF
--- a/frontend/src/components/auth/turnstile-widget.tsx
+++ b/frontend/src/components/auth/turnstile-widget.tsx
@@ -15,8 +15,6 @@ export interface TurnstileRenderOptions {
   action: string;
   /* Default is a fixed 300px, narrower than the form's fields. */
   size?: "normal" | "flexible" | "compact";
-  /* "auto" follows prefers-color-scheme, which is exactly what ThemeProvider's
-     "system" does, so the two agree without us resolving the media query. */
   theme?: "light" | "dark" | "auto";
   callback: (token: string) => void;
   "expired-callback": () => void;
@@ -137,18 +135,16 @@ export const TurnstileWidget = forwardRef<TurnstileWidgetHandle, TurnstileWidget
           widgetIDRef.current = null;
         }
       };
-      /* widgetTheme is a dep because Turnstile has no setter for it: the only
-         way to repaint in the other theme is to remove and re-render. That
-         costs the visitor their token, so the challenge re-runs. Toggling the
-         theme mid-signup is rare and the re-run is usually invisible. */
+      /* widgetTheme is a dep because Turnstile has no setter for it: repainting
+         means remove and re-render, which costs the visitor their token. */
     }, [siteKey, action, widgetTheme]);
 
     return (
       /* min-h reserves the height so the submit button doesn't jump when the
-         iframe paints. Padding, not margin: the form's space-y-3 owns the
+         widget paints. Padding, not margin: the form's space-y-3 owns the
          margins, so py-2 stacks to 20px of air here against the fields' 12px.
-         That air is the only separation available; the plate's fill, border and
-         radius are inside a cross-origin iframe. */
+         That air is the only separation available, since Cloudflare renders the
+         plate itself out of reach of our stylesheets. */
       <div
         ref={containerRef}
         className="cf-turnstile min-h-[65px] py-2"

--- a/frontend/src/components/auth/turnstile-widget.tsx
+++ b/frontend/src/components/auth/turnstile-widget.tsx
@@ -4,6 +4,7 @@ import {
   useImperativeHandle,
   useRef,
 } from "react";
+import { useTheme } from "@/contexts/theme-provider";
 
 const turnstileScriptID = "cloudflare-turnstile-script";
 const turnstileScriptURL =
@@ -14,8 +15,8 @@ export interface TurnstileRenderOptions {
   action: string;
   /* Default is a fixed 300px, narrower than the form's fields. */
   size?: "normal" | "flexible" | "compact";
-  /* Default "auto" follows prefers-color-scheme. The app is light-only, so pin
-     it; pass the real theme through when dark mode ships. */
+  /* "auto" follows prefers-color-scheme, which is exactly what ThemeProvider's
+     "system" does, so the two agree without us resolving the media query. */
   theme?: "light" | "dark" | "auto";
   callback: (token: string) => void;
   "expired-callback": () => void;
@@ -86,6 +87,10 @@ export const TurnstileWidget = forwardRef<TurnstileWidgetHandle, TurnstileWidget
   function TurnstileWidget({ siteKey, action, onToken, onUnavailable }, ref) {
     const containerRef = useRef<HTMLDivElement>(null);
     const widgetIDRef = useRef<string | null>(null);
+    /* ThemeProvider's "system" and Turnstile's "auto" both mean
+       prefers-color-scheme, so the names map straight across. */
+    const { theme } = useTheme();
+    const widgetTheme = theme === "system" ? "auto" : theme;
     const onTokenRef = useRef(onToken);
     const onUnavailableRef = useRef(onUnavailable);
 
@@ -112,7 +117,7 @@ export const TurnstileWidget = forwardRef<TurnstileWidgetHandle, TurnstileWidget
             sitekey: siteKey,
             action,
             size: "flexible",
-            theme: "light",
+            theme: widgetTheme,
             callback: (token) => onTokenRef.current(token),
             "expired-callback": () => onTokenRef.current(""),
             "error-callback": () => {
@@ -132,7 +137,11 @@ export const TurnstileWidget = forwardRef<TurnstileWidgetHandle, TurnstileWidget
           widgetIDRef.current = null;
         }
       };
-    }, [siteKey, action]);
+      /* widgetTheme is a dep because Turnstile has no setter for it: the only
+         way to repaint in the other theme is to remove and re-render. That
+         costs the visitor their token, so the challenge re-runs. Toggling the
+         theme mid-signup is rare and the re-run is usually invisible. */
+    }, [siteKey, action, widgetTheme]);
 
     return (
       /* min-h reserves the height so the submit button doesn't jump when the

--- a/frontend/src/components/auth/turnstile-widget.tsx
+++ b/frontend/src/components/auth/turnstile-widget.tsx
@@ -12,6 +12,11 @@ const turnstileScriptURL =
 export interface TurnstileRenderOptions {
   sitekey: string;
   action: string;
+  /* Default is a fixed 300px, narrower than the form's fields. */
+  size?: "normal" | "flexible" | "compact";
+  /* Default "auto" follows prefers-color-scheme. The app is light-only, so pin
+     it; pass the real theme through when dark mode ships. */
+  theme?: "light" | "dark" | "auto";
   callback: (token: string) => void;
   "expired-callback": () => void;
   "error-callback": () => void;
@@ -106,6 +111,8 @@ export const TurnstileWidget = forwardRef<TurnstileWidgetHandle, TurnstileWidget
           widgetIDRef.current = api.render(containerRef.current, {
             sitekey: siteKey,
             action,
+            size: "flexible",
+            theme: "light",
             callback: (token) => onTokenRef.current(token),
             "expired-callback": () => onTokenRef.current(""),
             "error-callback": () => {
@@ -128,9 +135,14 @@ export const TurnstileWidget = forwardRef<TurnstileWidgetHandle, TurnstileWidget
     }, [siteKey, action]);
 
     return (
+      /* min-h reserves the height so the submit button doesn't jump when the
+         iframe paints. Padding, not margin: the form's space-y-3 owns the
+         margins, so py-2 stacks to 20px of air here against the fields' 12px.
+         That air is the only separation available; the plate's fill, border and
+         radius are inside a cross-origin iframe. */
       <div
         ref={containerRef}
-        className="cf-turnstile min-h-[65px]"
+        className="cf-turnstile min-h-[65px] py-2"
         data-sitekey={siteKey}
         data-action={action}
       />


### PR DESCRIPTION
## 📝 What this does

The Turnstile challenge on the signup form rendered at Cloudflare's fixed default width, so it sat narrower than every field around it and painted a white plate in dark mode. It now matches the form it lives in.

## 🔀 Changes

- Sized the widget to fill its container instead of Cloudflare's fixed 300px, so it matches the field width
- Passed the app's theme through, so the widget follows light, dark and system instead of always rendering light
- Gave the widget its own band of spacing so it reads as a step in the form rather than another field
- Reserved the widget's height so the submit button no longer jumps when the challenge paints

## 🧪 How to test

- [ ] Run the API server in cloud mode with a Turnstile test site key, then open the signup page
- [ ] Confirm the widget is the same width as the fields above it
- [ ] Toggle the theme from the header and confirm the widget follows
- [ ] Swap in the always-blocks test key and confirm signup stays disabled with the verification error
