### PR TITLE
Fix: offer the first-run tour to orgs 

### DIFF
--- a/frontend/src/pages/stacks/components/list/index.tsx
+++ b/frontend/src/pages/stacks/components/list/index.tsx
@@ -86,10 +86,15 @@ export default function StacksPage() {
     }
   }, [setStacks]);
 
-  // The demo exposes a public port, which used to be gated on the org having a
-  // domain. It is not: the backend waives that requirement whenever a platform
-  // base domain is configured, which is the case on Cloud, where a fresh org
-  // has no domain of its own and never would.
+  // The demo exposes a public port, and the org's own domain list has no
+  // bearing on whether that is allowed: the backend waives the requirement
+  // whenever a platform base domain is configured. Cloud configures one and
+  // adds the domain internally, so a Cloud org's list is empty by design.
+  //
+  // A self-hosted install with neither a base domain nor an org domain is the
+  // one case left where the tour is offered and Deploy then fails validation
+  // with "organisation has no domain configured". Gating that needs the base
+  // domain exposed on /api/v1/config, which the frontend cannot see today.
   const navigate = useNavigate();
   const tourOffered = useRef(false);
   const [welcomeOpen, setWelcomeOpen] = useState(false);

--- a/frontend/src/pages/stacks/components/list/index.tsx
+++ b/frontend/src/pages/stacks/components/list/index.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/components/ui/button";
 import { Navigate, useNavigate, useSearchParams } from "react-router-dom";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getStacksByOrg, deleteStack } from "@/api/stacks";
-import { getOrganization } from "@/api/organizations";
 import { buildHelloStackSeed } from "@/pages/stacks/lib/onboarding/hello-stack-seed";
 import { startCanvasStage, isTourDone, markTourDone } from "@/pages/stacks/lib/onboarding/tour";
 import { WelcomeDialog } from "@/pages/stacks/components/onboarding/welcome-dialog";
@@ -87,25 +86,18 @@ export default function StacksPage() {
     }
   }, [setStacks]);
 
-  // The demo exposes a public port, so an org without a domain cannot finish
-  // the tour.
+  // The demo exposes a public port, which used to be gated on the org having a
+  // domain. It is not: the backend waives that requirement whenever a platform
+  // base domain is configured, which is the case on Cloud, where a fresh org
+  // has no domain of its own and never would.
   const navigate = useNavigate();
   const tourOffered = useRef(false);
   const [welcomeOpen, setWelcomeOpen] = useState(false);
   useEffect(() => {
     if (isLoading || error || stacks.length > 0 || tourOffered.current) return;
     if (!canWriteAnyProject || isTourDone()) return;
-    const orgId = getCurrentOrganizationId();
-    if (!orgId) return;
     tourOffered.current = true;
-    getOrganization(orgId)
-      .then((org) => {
-        if ((org.domains ?? []).length === 0) return;
-        setWelcomeOpen(true);
-      })
-      .catch(() => {
-        // No tour on a failed lookup — the normal empty state still shows.
-      });
+    setWelcomeOpen(true);
   }, [isLoading, error, stacks, canWriteAnyProject]);
 
   const acceptTour = () => {

--- a/frontend/src/pages/stacks/components/list/tests/welcome-tour.test.tsx
+++ b/frontend/src/pages/stacks/components/list/tests/welcome-tour.test.tsx
@@ -47,9 +47,9 @@ describe("first-run tour offer", () => {
     vi.clearAllMocks();
   });
 
-  // The org this runs against has no domain, which is every org on Cloud: the
-  // platform base domain covers the demo's public port, so the offer stands.
-  it("offers the tour to an org with no stacks and no domain", async () => {
+  // Nothing here describes a domain, and that is the point: the offer no
+  // longer consults the organisation at all.
+  it("offers the tour on an empty dashboard", async () => {
     renderPage();
     await waitFor(() =>
       expect(document.querySelectorAll('[role="dialog"]').length).toBe(1),

--- a/frontend/src/pages/stacks/components/list/tests/welcome-tour.test.tsx
+++ b/frontend/src/pages/stacks/components/list/tests/welcome-tour.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+vi.mock("@/api/stacks", () => ({
+  getStacksByOrg: vi.fn(),
+  deleteStack: vi.fn(),
+}));
+vi.mock("@/hooks/use-preview-envs", () => ({
+  usePreviewEnvs: () => ({ envs: [], loading: false }),
+}));
+vi.mock("@/lib/common", () => ({
+  getCurrentOrganizationId: () => "org1",
+}));
+vi.mock("@/hooks/use-current-user", () => ({
+  useCurrentUser: () => ({ canWriteAnyProject: true, canWrite: () => true, isOrgAdmin: true }),
+}));
+vi.mock("@/pages/stacks/components/wizard/stack-create-wizard", () => ({
+  StackCreateWizard: () => null,
+}));
+
+import { getStacksByOrg } from "@/api/stacks";
+import { StackProvider } from "@/pages/stacks/contexts/stack-context";
+import StacksPage from "../index";
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/stacks"]}>
+      <StackProvider>
+        <Routes>
+          <Route path="/stacks" element={<StacksPage />} />
+        </Routes>
+      </StackProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("first-run tour offer", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(getStacksByOrg).mockResolvedValue({ items: [], total: 0 } as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  // The org this runs against has no domain, which is every org on Cloud: the
+  // platform base domain covers the demo's public port, so the offer stands.
+  it("offers the tour to an org with no stacks and no domain", async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(document.querySelectorAll('[role="dialog"]').length).toBe(1),
+    );
+  });
+
+  it("stays away once the tour has been retired", async () => {
+    localStorage.setItem("stackdome.onboarding-tour.done", "1");
+    renderPage();
+    await waitFor(() => expect(getStacksByOrg).toHaveBeenCalled());
+    expect(document.querySelectorAll('[role="dialog"]').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## 📝 What this does

The first-run welcome dialog never appeared for a Cloud signup. Reproduced from a session recording on `cloud.stackdome.com`: a 56-second-old org, no stacks, user is `OrgAdmin`, and the dialog stays shut. It was gated on the organisation having a domain of its own, which a Cloud org does not have and is not meant to have.

## 📎 References

- Gate that blocked it: `frontend/src/pages/stacks/components/list/index.tsx`
- Backend rule it was mirroring: `validateExposedPortDomain` in `pkg/validator/stackresource/referential_rules.go`

## 🔀 Changes

- Removed the `org.domains.length === 0` gate on the welcome dialog, so an org without a domain of its own is still offered the tour
- Removed the `getOrganization` lookup that existed only to feed that gate, along with its swallowing `.catch()` and the org-id guard that only mattered for the fetch
- Left the remaining gates untouched: no stacks yet, write access, and the tour not already retired
- Added `welcome-tour.test.tsx` covering the recorded state, so the gate cannot come back unnoticed

## 🧪 How to test

- [x] `npx vitest run src/pages/stacks/components/list/tests/` — 10 passed, including the two new cases
- [x] `tsc --noEmit` and `eslint` clean on the changed files
- [ ] Sign up fresh on Cloud and confirm the welcome dialog appears on the empty Stacks dashboard
- [ ] Dismiss with "I'll explore on my own", reload, and confirm it stays gone

## Why the gate was wrong

The demo stack exposes a public port, which is what the domain check was guarding. But the backend waives that requirement whenever a platform base domain is configured:

```go
if exposedIdx == -1 || v.platformBaseDomain != "" { return nil, nil }
```

Cloud configures one and adds the domain internally, so the org's own `domains` list has no bearing on whether the demo can go live. Signup creates an org and a default project and no domain, so that list stayed empty for every Cloud signup, permanently. Both exits from the check were silent, which is why nothing showed in the console.

## Known gap

A **self-hosted install with neither a platform base domain nor an org domain** is now offered the tour, and Deploy then fails validation with `organisation has no domain configured`. Before this change it saw no tour at all.

Closing that needs the base domain exposed on `/api/v1/config` so the gate can be `domains.length > 0 || platformDomain`; the frontend cannot see it today. Deliberately left for a follow-up rather than keeping a check that breaks every Cloud signup to protect one self-host configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)