### PR TITLE
Feature: expose Cloud compute access metrics

### DIFF
--- a/cmd/environment/env.go
+++ b/cmd/environment/env.go
@@ -402,6 +402,12 @@ func checkPersistedComputeTopology(ctx context.Context, mode config.ComputeMode,
 func (e *environmentImpl) setupObservability(context.Context) error {
 	e.Observability = observability.NewMetrics()
 	e.Observability.RegisterStackCollector(observability.NewDatabaseStackSnapshotSource(e.DBSession))
+	if e.Config.IsStackdomeCloud() {
+		e.Observability.RegisterComputeAccessCollector(
+			observability.NewDatabaseComputeAccessSnapshotSource(e.DBSession),
+			e.Config.StackdomeCloud.Access.MaxActiveSharedComputeLeases,
+		)
+	}
 	return nil
 }
 

--- a/cmd/environment/observability_test.go
+++ b/cmd/environment/observability_test.go
@@ -1,0 +1,116 @@
+package environment
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/Stackdome/stackdome/config"
+	"github.com/Stackdome/stackdome/pkg/db"
+	"github.com/Stackdome/stackdome/pkg/observability"
+	"github.com/glebarez/sqlite"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	dto "github.com/prometheus/client_model/go"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("compute access metrics registration", func() {
+	It("registers cloud compute access metrics with the configured capacity limit in cloud mode", func() {
+		session := newObservabilityTestSession()
+		DeferCleanup(session.Close)
+		applicationConfig := config.NewApplicationConfig()
+		applicationConfig.RuntimeMode = config.RuntimeModeStackdomeCloud
+		applicationConfig.StackdomeCloud = &config.StackdomeCloudConfig{
+			Access: config.StackdomeCloudComputeAccessConfig{MaxActiveSharedComputeLeases: 12},
+		}
+		testEnv := NewTestEnvironment(session, WithApplicationConfig(applicationConfig)).(*environmentImpl)
+
+		Expect(testEnv.setupObservability(context.Background())).To(Succeed())
+		families, err := testEnv.Observability.Gatherer().Gather()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(environmentMetricValue(
+			environmentFamilyNamed(families, observability.SharedComputeCapacityLimitMetricName),
+		)).To(Equal(float64(12)))
+		Expect(environmentFamilyNamed(families, observability.ComputeEntitlementsIssuedMetricName)).NotTo(BeNil())
+		Expect(environmentFamilyNamed(families, observability.ComputeEntitlementsExpiredMetricName)).NotTo(BeNil())
+		Expect(environmentFamilyNamed(families, observability.SharedComputeLeasesMetricName)).NotTo(BeNil())
+		Expect(environmentMetricValue(
+			environmentFamilyNamed(families, observability.ComputeAccessSnapshotSuccessMetricName),
+		)).To(Equal(float64(1)))
+	})
+
+	It("does not register cloud compute access metrics in self-hosted mode", func() {
+		session := newObservabilityTestSession()
+		DeferCleanup(session.Close)
+		applicationConfig := config.NewApplicationConfig()
+		applicationConfig.RuntimeMode = config.RuntimeModeSelfHosted
+		testEnv := NewTestEnvironment(session, WithApplicationConfig(applicationConfig)).(*environmentImpl)
+
+		Expect(testEnv.setupObservability(context.Background())).To(Succeed())
+		families, err := testEnv.Observability.Gatherer().Gather()
+		Expect(err).NotTo(HaveOccurred())
+		for _, name := range []string{
+			observability.ComputeEntitlementsIssuedMetricName,
+			observability.ComputeEntitlementsExpiredMetricName,
+			observability.SharedComputeLeasesMetricName,
+			observability.SharedComputeCapacityLimitMetricName,
+			observability.ComputeAccessSnapshotSuccessMetricName,
+		} {
+			Expect(environmentFamilyNamed(families, name)).To(BeNil(), "metric %s must not exist", name)
+		}
+	})
+})
+
+type observabilityTestSession struct {
+	database *gorm.DB
+}
+
+func newObservabilityTestSession() *observabilityTestSession {
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	Expect(err).NotTo(HaveOccurred())
+	for _, statement := range []string{
+		`CREATE TABLE stacks (id TEXT PRIMARY KEY, status BLOB, deletion_timestamp DATETIME)`,
+		`CREATE TABLE stack_resources (id TEXT PRIMARY KEY, status BLOB)`,
+		`CREATE TABLE compute_entitlements (id TEXT PRIMARY KEY, source TEXT NOT NULL, expires_at DATETIME)`,
+		`CREATE TABLE shared_compute_leases (id TEXT PRIMARY KEY, state TEXT NOT NULL)`,
+	} {
+		Expect(database.Exec(statement).Error).NotTo(HaveOccurred())
+	}
+	return &observabilityTestSession{database: database}
+}
+
+func (s *observabilityTestSession) Init(*config.DatabaseConfig) {}
+
+func (s *observabilityTestSession) DirectDB() *sql.DB {
+	database, _ := s.database.DB()
+	return database
+}
+
+func (s *observabilityTestSession) New(ctx context.Context) *gorm.DB {
+	if transaction := db.TxFromContext(ctx); transaction != nil {
+		return transaction
+	}
+	return s.database.WithContext(ctx)
+}
+
+func (s *observabilityTestSession) CheckConnection() error { return nil }
+
+func (s *observabilityTestSession) Close() error {
+	database, _ := s.database.DB()
+	return database.Close()
+}
+
+func environmentFamilyNamed(families []*dto.MetricFamily, name string) *dto.MetricFamily {
+	for _, family := range families {
+		if family.GetName() == name {
+			return family
+		}
+	}
+	return nil
+}
+
+func environmentMetricValue(family *dto.MetricFamily) float64 {
+	Expect(family).NotTo(BeNil())
+	Expect(family.Metric).To(HaveLen(1))
+	return family.Metric[0].GetGauge().GetValue()
+}

--- a/deploy/observability/grafana/alpha-overview.json
+++ b/deploy/observability/grafana/alpha-overview.json
@@ -700,6 +700,110 @@
       "targets": [{"expr": "workqueue_longest_running_processor_seconds", "legendFormat": "{{name}}", "refId": "A"}],
       "title": "Longest-running work",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 60},
+      "id": 29,
+      "panels": [],
+      "title": "Cloud compute access",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "All retained compute entitlement rows grouped by issuance source. Organization deletion is not supported, so this is the total-issued KPI.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "decimals": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 61},
+      "id": 30,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"expr": "sum(max by (source) (stackdome_cloud_compute_entitlements_issued))", "instant": false, "legendFormat": "Issued", "refId": "A"}],
+      "title": "Total entitlements issued",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Retained compute entitlements whose configured expiry time has passed according to PostgreSQL.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "decimals": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}]}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 61},
+      "id": 31,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"expr": "sum(max by (source) (stackdome_cloud_compute_entitlements_expired))", "instant": false, "legendFormat": "Expired", "refId": "A"}],
+      "title": "Expired entitlements",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Shared-compute leases currently granting active runtime access.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "decimals": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 61},
+      "id": 32,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"expr": "max(stackdome_cloud_shared_compute_leases{state=\"active\"})", "instant": false, "legendFormat": "Active", "refId": "A"}],
+      "title": "Active leases",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Reserved shared-compute capacity compared with the configured ceiling. Every lease except cleaned reserves capacity, matching admission enforcement.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "decimals": 0, "min": 0, "unit": "short"},
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "Reserved"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "Configured limit"}, "properties": [{"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}}]}
+        ]
+      },
+      "gridPos": {"h": 4, "w": 8, "x": 12, "y": 61},
+      "id": 33,
+      "options": {"displayMode": "gradient", "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": true, "sizing": "auto", "valueMode": "color"},
+      "targets": [
+        {"expr": "sum(max by (state) (stackdome_cloud_shared_compute_leases{state!=\"cleaned\"}))", "instant": false, "legendFormat": "Reserved", "refId": "A"},
+        {"expr": "max(stackdome_cloud_shared_compute_capacity_limit)", "instant": false, "legendFormat": "Configured limit", "refId": "B"}
+      ],
+      "title": "Reserved capacity",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Leases waiting for cleanup, being cleaned, or retained after a cleanup error. A growing value means cleanup is not keeping pace.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "decimals": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 20, "y": 61},
+      "id": 34,
+      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"expr": "sum(max by (state) (stackdome_cloud_shared_compute_leases{state=~\"cleanup_pending|cleaning|error\"}))", "instant": false, "legendFormat": "Cleanup backlog", "refId": "A"}],
+      "title": "Cleanup backlog",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Current shared-compute leases grouped by lifecycle state, including completed cleanup and cleanup failures.",
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "decimals": 0, "min": 0, "unit": "short"},
+        "overrides": [
+          {"matcher": {"id": "byName", "options": "active"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "cleanup_pending"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "cleaning"}, "properties": [{"id": "color", "value": {"fixedColor": "yellow", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "cleaned"}, "properties": [{"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}}]},
+          {"matcher": {"id": "byName", "options": "error"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]}
+        ]
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 65},
+      "id": 35,
+      "options": {"displayMode": "gradient", "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": true, "sizing": "auto", "valueMode": "color"},
+      "targets": [{"expr": "max by (state) (stackdome_cloud_shared_compute_leases)", "instant": false, "legendFormat": "{{state}}", "refId": "A"}],
+      "title": "Lease breakdown by state",
+      "type": "bargauge"
     }
   ],
   "refresh": "15s",
@@ -721,5 +825,5 @@
   "timezone": "browser",
   "title": "Stackdome Operations Overview",
   "uid": "stackdome-alpha-overview",
-  "version": 2
+  "version": 3
 }

--- a/deploy/observability/grafana/alpha-overview_test.sh
+++ b/deploy/observability/grafana/alpha-overview_test.sh
@@ -6,12 +6,22 @@ excluded_routes='/health|/metrics|.*stream.*'
 
 jq -e --arg excluded_routes "$excluded_routes" '
   . as $dashboard |
-  def panel($title): first($dashboard.panels[] | select(.title == $title));
+  def panel($title): ([$dashboard.panels[] | select(.title == $title)][0] // null);
   def require($condition; $message): if $condition then true else error($message) end;
   require(.time.from == "now-3h"; "dashboard must default to the last three hours") and
   require(.refresh == "15s"; "dashboard must refresh every 15 seconds") and
   require([.panels[].id] | all(. != null) and (length == (unique | length)); "panel IDs must be present and unique") and
   require(["Request rate", "5xx error rate", "In-flight requests", "Failed stacks", "Worker queue depth", "Snapshot collection", "Average latency", "p50 latency", "p95 latency", "p99 latency"] | all(. as $title | panel($title) != null); "overview and aggregate latency panels must be present") and
+  require(panel("Cloud compute access").type == "row"; "cloud compute access row must be present") and
+  require(["Total entitlements issued", "Expired entitlements", "Active leases", "Reserved capacity", "Cleanup backlog", "Lease breakdown by state"] | all(. as $title | panel($title) != null); "cloud compute access panels must be present") and
+  require((panel("Total entitlements issued").targets[0].expr | contains("stackdome_cloud_compute_entitlements_issued") and contains("max by (source)")); "total entitlements must aggregate replica-safe source gauges") and
+  require((panel("Expired entitlements").targets[0].expr | contains("stackdome_cloud_compute_entitlements_expired") and contains("max by (source)")); "expired entitlements must aggregate replica-safe source gauges") and
+  require(panel("Active leases").targets[0].expr | contains("stackdome_cloud_shared_compute_leases{state=\"active\"}"); "active leases must select the active lifecycle state") and
+  require((panel("Reserved capacity").targets[0].expr | contains("stackdome_cloud_shared_compute_leases{state!=\"cleaned\"}") and contains("max by (state)")); "reserved capacity must count every non-cleaned lease without multiplying replicas") and
+  require(panel("Reserved capacity").targets[1].expr | contains("stackdome_cloud_shared_compute_capacity_limit"); "reserved capacity must show the configured limit") and
+  require((panel("Cleanup backlog").targets[0].expr | contains("state=~\"cleanup_pending|cleaning|error\"") and contains("max by (state)")); "cleanup backlog must include pending, cleaning, and error leases") and
+  require(panel("Lease breakdown by state").targets[0].expr | contains("max by (state) (stackdome_cloud_shared_compute_leases)"); "lease breakdown must remain replica-safe and grouped by state") and
+  require(["Total entitlements issued", "Expired entitlements", "Active leases", "Reserved capacity", "Cleanup backlog"] | all(. as $title | (panel($title).targets[0].expr | contains("or vector(0)") | not)); "cloud snapshot panels must show missing data instead of converting collection failures to zero") and
   require(["Average latency", "p50 latency", "p95 latency", "p99 latency"] | all(. as $title | panel($title).targets[0].expr | contains($excluded_routes)); "aggregate latency panels must exclude internal and streaming routes") and
   require(panel("Average latency").targets[0].expr | contains("_sum") and contains("_count"); "average latency must divide histogram sum by count") and
   require(["p50 latency", "p95 latency", "p99 latency"] | all(. as $title | panel($title).targets[0].expr | contains("sum by (le)")); "percentiles must aggregate histogram buckets by le") and

--- a/pkg/observability/compute_access_collector.go
+++ b/pkg/observability/compute_access_collector.go
@@ -1,0 +1,235 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Stackdome/stackdome/pkg/computeaccess"
+	"github.com/Stackdome/stackdome/pkg/db"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	ComputeEntitlementsIssuedMetricName    = "stackdome_cloud_compute_entitlements_issued"
+	ComputeEntitlementsExpiredMetricName   = "stackdome_cloud_compute_entitlements_expired"
+	SharedComputeLeasesMetricName          = "stackdome_cloud_shared_compute_leases"
+	SharedComputeCapacityLimitMetricName   = "stackdome_cloud_shared_compute_capacity_limit"
+	ComputeAccessSnapshotSuccessMetricName = "stackdome_cloud_compute_access_snapshot_collection_success"
+
+	LabelSource = "source"
+
+	UnknownSource = "Unknown"
+
+	computeAccessSnapshotTimeout = 3 * time.Second
+)
+
+var supportedSharedComputeLeaseStates = []computeaccess.SharedComputeLeaseState{
+	computeaccess.SharedComputeLeaseStateActive,
+	computeaccess.SharedComputeLeaseStateCleanupPending,
+	computeaccess.SharedComputeLeaseStateCleaning,
+	computeaccess.SharedComputeLeaseStateCleaned,
+	computeaccess.SharedComputeLeaseStateError,
+}
+
+type ComputeEntitlementMetricCounts struct {
+	Issued  int64
+	Expired int64
+}
+
+type ComputeAccessMetricSnapshot struct {
+	EntitlementsBySource map[string]ComputeEntitlementMetricCounts
+	LeaseStates          map[string]int64
+}
+
+type ComputeAccessSnapshotSource interface {
+	Snapshot(context.Context) (ComputeAccessMetricSnapshot, error)
+}
+
+type ComputeAccessSnapshotSourceFunc func(context.Context) (ComputeAccessMetricSnapshot, error)
+
+func (f ComputeAccessSnapshotSourceFunc) Snapshot(ctx context.Context) (ComputeAccessMetricSnapshot, error) {
+	return f(ctx)
+}
+
+type databaseComputeAccessSnapshotSource struct {
+	session db.SessionFactory
+}
+
+func NewDatabaseComputeAccessSnapshotSource(session db.SessionFactory) ComputeAccessSnapshotSource {
+	return &databaseComputeAccessSnapshotSource{session: session}
+}
+
+func (s *databaseComputeAccessSnapshotSource) Snapshot(ctx context.Context) (ComputeAccessMetricSnapshot, error) {
+	var entitlementRows []computeEntitlementMetricRow
+	if err := s.session.New(ctx).Raw(computeEntitlementCountsQuery).Scan(&entitlementRows).Error; err != nil {
+		return ComputeAccessMetricSnapshot{}, fmt.Errorf("load compute entitlement counts: %w", err)
+	}
+
+	leaseStates, err := s.queryLeaseStates(ctx)
+	if err != nil {
+		return ComputeAccessMetricSnapshot{}, fmt.Errorf("load shared compute lease state counts: %w", err)
+	}
+
+	entitlements := make(map[string]ComputeEntitlementMetricCounts, len(entitlementRows))
+	for _, row := range entitlementRows {
+		entitlements[row.Source] = ComputeEntitlementMetricCounts{
+			Issued:  row.Issued,
+			Expired: row.Expired,
+		}
+	}
+	return ComputeAccessMetricSnapshot{
+		EntitlementsBySource: entitlements,
+		LeaseStates:          leaseStates,
+	}, nil
+}
+
+type computeEntitlementMetricRow struct {
+	Source  string
+	Issued  int64
+	Expired int64
+}
+
+func (s *databaseComputeAccessSnapshotSource) queryLeaseStates(ctx context.Context) (map[string]int64, error) {
+	var rows []metricCountRow
+	if err := s.session.New(ctx).Raw(sharedComputeLeaseStateCountsQuery).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	counts := make(map[string]int64, len(rows))
+	for _, row := range rows {
+		counts[row.Label] = row.Count
+	}
+	return counts, nil
+}
+
+const computeEntitlementCountsQuery = `
+	SELECT
+		source,
+		COUNT(*) AS issued,
+		SUM(CASE
+			WHEN expires_at IS NOT NULL AND expires_at <= CURRENT_TIMESTAMP THEN 1
+			ELSE 0
+		END) AS expired
+	FROM compute_entitlements
+	GROUP BY source
+`
+
+const sharedComputeLeaseStateCountsQuery = `
+	SELECT state AS label, COUNT(*) AS count
+	FROM shared_compute_leases
+	GROUP BY state
+`
+
+type computeAccessCollector struct {
+	source        ComputeAccessSnapshotSource
+	capacityLimit float64
+	entitlements  *prometheus.Desc
+	expired       *prometheus.Desc
+	leases        *prometheus.Desc
+	capacity      *prometheus.Desc
+	success       *prometheus.Desc
+}
+
+func newComputeAccessCollector(source ComputeAccessSnapshotSource, capacityLimit int) prometheus.Collector {
+	return &computeAccessCollector{
+		source:        source,
+		capacityLimit: float64(capacityLimit),
+		entitlements: prometheus.NewDesc(
+			ComputeEntitlementsIssuedMetricName,
+			"Total compute entitlements issued and retained, grouped by source.",
+			[]string{LabelSource}, nil,
+		),
+		expired: prometheus.NewDesc(
+			ComputeEntitlementsExpiredMetricName,
+			"Current retained compute entitlements past their expiry time, grouped by source.",
+			[]string{LabelSource}, nil,
+		),
+		leases: prometheus.NewDesc(
+			SharedComputeLeasesMetricName,
+			"Current shared-compute leases grouped by lifecycle state.",
+			[]string{LabelState}, nil,
+		),
+		capacity: prometheus.NewDesc(
+			SharedComputeCapacityLimitMetricName,
+			"Configured maximum number of non-cleaned shared-compute leases.",
+			nil, nil,
+		),
+		success: prometheus.NewDesc(
+			ComputeAccessSnapshotSuccessMetricName,
+			"Whether the latest cloud compute-access database snapshot succeeded.",
+			nil, nil,
+		),
+	}
+}
+
+func (c *computeAccessCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.entitlements
+	ch <- c.expired
+	ch <- c.leases
+	ch <- c.capacity
+	ch <- c.success
+}
+
+func (c *computeAccessCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(c.capacity, prometheus.GaugeValue, c.capacityLimit)
+
+	ctx, cancel := context.WithTimeout(context.Background(), computeAccessSnapshotTimeout)
+	defer cancel()
+	snapshot, err := c.source.Snapshot(ctx)
+	if err != nil {
+		ch <- prometheus.MustNewConstMetric(c.success, prometheus.GaugeValue, 0)
+		return
+	}
+
+	entitlements := boundedEntitlementCounts(snapshot.EntitlementsBySource)
+	for source, counts := range entitlements {
+		ch <- prometheus.MustNewConstMetric(c.entitlements, prometheus.GaugeValue, float64(counts.Issued), source)
+		ch <- prometheus.MustNewConstMetric(c.expired, prometheus.GaugeValue, float64(counts.Expired), source)
+	}
+	for state, count := range boundedLeaseStateCounts(snapshot.LeaseStates) {
+		ch <- prometheus.MustNewConstMetric(c.leases, prometheus.GaugeValue, float64(count), state)
+	}
+	ch <- prometheus.MustNewConstMetric(c.success, prometheus.GaugeValue, 1)
+}
+
+func boundedEntitlementCounts(counts map[string]ComputeEntitlementMetricCounts) map[string]ComputeEntitlementMetricCounts {
+	bounded := map[string]ComputeEntitlementMetricCounts{
+		string(computeaccess.ComputeEntitlementSourceTrial): {},
+	}
+	for source, count := range counts {
+		label := boundedComputeEntitlementSource(computeaccess.ComputeEntitlementSource(source))
+		current := bounded[label]
+		current.Issued += count.Issued
+		current.Expired += count.Expired
+		bounded[label] = current
+	}
+	return bounded
+}
+
+func boundedComputeEntitlementSource(source computeaccess.ComputeEntitlementSource) string {
+	if source == computeaccess.ComputeEntitlementSourceTrial {
+		return string(source)
+	}
+	return UnknownSource
+}
+
+func boundedLeaseStateCounts(counts map[string]int64) map[string]int64 {
+	bounded := make(map[string]int64, len(supportedSharedComputeLeaseStates)+1)
+	for _, state := range supportedSharedComputeLeaseStates {
+		bounded[string(state)] = 0
+	}
+	for state, count := range counts {
+		bounded[boundedSharedComputeLeaseState(computeaccess.SharedComputeLeaseState(state))] += count
+	}
+	return bounded
+}
+
+func boundedSharedComputeLeaseState(state computeaccess.SharedComputeLeaseState) string {
+	for _, supported := range supportedSharedComputeLeaseStates {
+		if state == supported {
+			return string(state)
+		}
+	}
+	return UnknownState
+}

--- a/pkg/observability/compute_access_collector_test.go
+++ b/pkg/observability/compute_access_collector_test.go
@@ -1,0 +1,148 @@
+package observability
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/Stackdome/stackdome/pkg/computeaccess"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var _ = Describe("cloud compute access snapshot metrics", func() {
+	It("publishes entitlement, lease, and configured capacity gauges with bounded labels", func() {
+		source := ComputeAccessSnapshotSourceFunc(func(context.Context) (ComputeAccessMetricSnapshot, error) {
+			return ComputeAccessMetricSnapshot{
+				EntitlementsBySource: map[string]ComputeEntitlementMetricCounts{
+					string(computeaccess.ComputeEntitlementSourceTrial): {Issued: 4, Expired: 2},
+					"unexpected-source": {Issued: 1, Expired: 1},
+				},
+				LeaseStates: map[string]int64{
+					string(computeaccess.SharedComputeLeaseStateActive):         2,
+					string(computeaccess.SharedComputeLeaseStateCleanupPending): 1,
+					string(computeaccess.SharedComputeLeaseStateCleaning):       1,
+					string(computeaccess.SharedComputeLeaseStateCleaned):        3,
+					string(computeaccess.SharedComputeLeaseStateError):          1,
+					"unexpected-state": 1,
+				},
+			}, nil
+		})
+		registry := prometheus.NewRegistry()
+		registry.MustRegister(newComputeAccessCollector(source, 10))
+
+		families, err := registry.Gather()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(metricValue(familyNamed(families, ComputeEntitlementsIssuedMetricName), map[string]string{
+			LabelSource: string(computeaccess.ComputeEntitlementSourceTrial),
+		})).To(Equal(float64(4)))
+		Expect(metricValue(familyNamed(families, ComputeEntitlementsIssuedMetricName), map[string]string{
+			LabelSource: UnknownSource,
+		})).To(Equal(float64(1)))
+		Expect(metricValue(familyNamed(families, ComputeEntitlementsExpiredMetricName), map[string]string{
+			LabelSource: string(computeaccess.ComputeEntitlementSourceTrial),
+		})).To(Equal(float64(2)))
+		Expect(metricValue(familyNamed(families, SharedComputeLeasesMetricName), map[string]string{
+			LabelState: string(computeaccess.SharedComputeLeaseStateActive),
+		})).To(Equal(float64(2)))
+		Expect(metricValue(familyNamed(families, SharedComputeLeasesMetricName), map[string]string{
+			LabelState: UnknownState,
+		})).To(Equal(float64(1)))
+		Expect(metricValue(familyNamed(families, SharedComputeCapacityLimitMetricName), nil)).To(Equal(float64(10)))
+		Expect(metricValue(familyNamed(families, ComputeAccessSnapshotSuccessMetricName), nil)).To(Equal(float64(1)))
+	})
+
+	It("reports collection failure without publishing database-derived gauges", func() {
+		source := ComputeAccessSnapshotSourceFunc(func(context.Context) (ComputeAccessMetricSnapshot, error) {
+			return ComputeAccessMetricSnapshot{}, stderrors.New("database unavailable")
+		})
+		registry := prometheus.NewRegistry()
+		registry.MustRegister(newComputeAccessCollector(source, 10))
+
+		families, err := registry.Gather()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(familyNamed(families, ComputeEntitlementsIssuedMetricName)).To(BeNil())
+		Expect(familyNamed(families, ComputeEntitlementsExpiredMetricName)).To(BeNil())
+		Expect(familyNamed(families, SharedComputeLeasesMetricName)).To(BeNil())
+		Expect(metricValue(familyNamed(families, SharedComputeCapacityLimitMetricName), nil)).To(Equal(float64(10)))
+		Expect(metricValue(familyNamed(families, ComputeAccessSnapshotSuccessMetricName), nil)).To(Equal(float64(0)))
+	})
+
+	It("publishes zero values for every currently supported source and lease state", func() {
+		source := ComputeAccessSnapshotSourceFunc(func(context.Context) (ComputeAccessMetricSnapshot, error) {
+			return ComputeAccessMetricSnapshot{}, nil
+		})
+		registry := prometheus.NewRegistry()
+		registry.MustRegister(newComputeAccessCollector(source, 10))
+
+		families, err := registry.Gather()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(metricValue(familyNamed(families, ComputeEntitlementsIssuedMetricName), map[string]string{
+			LabelSource: string(computeaccess.ComputeEntitlementSourceTrial),
+		})).To(BeZero())
+		Expect(metricValue(familyNamed(families, ComputeEntitlementsExpiredMetricName), map[string]string{
+			LabelSource: string(computeaccess.ComputeEntitlementSourceTrial),
+		})).To(BeZero())
+		for _, state := range []computeaccess.SharedComputeLeaseState{
+			computeaccess.SharedComputeLeaseStateActive,
+			computeaccess.SharedComputeLeaseStateCleanupPending,
+			computeaccess.SharedComputeLeaseStateCleaning,
+			computeaccess.SharedComputeLeaseStateCleaned,
+			computeaccess.SharedComputeLeaseStateError,
+		} {
+			Expect(metricValue(familyNamed(families, SharedComputeLeasesMetricName), map[string]string{
+				LabelState: string(state),
+			})).To(BeZero())
+		}
+	})
+
+	It("loads retained entitlements, database-expired entitlements, and lease states", func() {
+		session := newComputeAccessCollectorTestSession()
+		DeferCleanup(session.Close)
+		database := session.New(context.Background())
+		Expect(database.Exec(`
+			INSERT INTO compute_entitlements (id, source, expires_at) VALUES
+				('expired-trial', 'trial', '2000-01-01 00:00:00'),
+				('current-trial', 'trial', '2100-01-01 00:00:00'),
+				('unlimited-trial', 'trial', NULL)
+		`).Error).NotTo(HaveOccurred())
+		Expect(database.Exec(`
+			INSERT INTO shared_compute_leases (id, state) VALUES
+				('active-1', 'active'),
+				('active-2', 'active'),
+				('cleanup-pending', 'cleanup_pending'),
+				('cleaned', 'cleaned')
+		`).Error).NotTo(HaveOccurred())
+
+		snapshot, err := NewDatabaseComputeAccessSnapshotSource(session).Snapshot(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(snapshot.EntitlementsBySource).To(Equal(map[string]ComputeEntitlementMetricCounts{
+			string(computeaccess.ComputeEntitlementSourceTrial): {Issued: 3, Expired: 1},
+		}))
+		Expect(snapshot.LeaseStates).To(Equal(map[string]int64{
+			string(computeaccess.SharedComputeLeaseStateActive):         2,
+			string(computeaccess.SharedComputeLeaseStateCleanupPending): 1,
+			string(computeaccess.SharedComputeLeaseStateCleaned):        1,
+		}))
+	})
+})
+
+func newComputeAccessCollectorTestSession() *stackCollectorTestSession {
+	session := newStackCollectorTestSession()
+	database := session.New(context.Background())
+	Expect(database.Exec(`
+		CREATE TABLE compute_entitlements (
+			id TEXT PRIMARY KEY,
+			source TEXT NOT NULL,
+			expires_at DATETIME
+		)
+	`).Error).NotTo(HaveOccurred())
+	Expect(database.Exec(`
+		CREATE TABLE shared_compute_leases (
+			id TEXT PRIMARY KEY,
+			state TEXT NOT NULL
+		)
+	`).Error).NotTo(HaveOccurred())
+	return session
+}

--- a/pkg/observability/metrics.go
+++ b/pkg/observability/metrics.go
@@ -91,6 +91,10 @@ func (m *Metrics) RegisterStackCollector(source StackSnapshotSource) {
 	m.registry.MustRegister(newStackCollector(source))
 }
 
+func (m *Metrics) RegisterComputeAccessCollector(source ComputeAccessSnapshotSource, capacityLimit int) {
+	m.registry.MustRegister(newComputeAccessCollector(source, capacityLimit))
+}
+
 func (m *Metrics) ObserveHTTPRequest(method, route string, status int, elapsed time.Duration) {
 	method = boundedHTTPMethod(method)
 	m.httpRequests.WithLabelValues(method, route, strconv.Itoa(status)).Inc()


### PR DESCRIPTION
## Summary

- add a PostgreSQL-backed Prometheus collector for compute entitlements and shared-compute leases
- register Cloud compute-access metrics only when `runtime_mode` is `stackdome_cloud`
- add a Grafana Cloud compute access row for issued and expired entitlements, active leases, reserved capacity, cleanup backlog, and lease states
- keep reserved-capacity queries aligned with enforcement by counting every non-cleaned lease

## Metrics

- `stackdome_cloud_compute_entitlements_issued{source}`
- `stackdome_cloud_compute_entitlements_expired{source}`
- `stackdome_cloud_shared_compute_leases{state}`
- `stackdome_cloud_shared_compute_capacity_limit`
- `stackdome_cloud_compute_access_snapshot_collection_success`

## Scope

No database migration, cleanup-worker, alert-rule, infrastructure, or self-hosted behavior changes.

## Verification

- `mage test:unit`
- `mage lint`
- `go build ./cmd/...`
- `make observability-check`
- `git diff --check`
