### PR TITLE
Feature: render Turnstile in interaction-only mode

### DIFF
--- a/frontend/src/components/auth/turnstile-widget.tsx
+++ b/frontend/src/components/auth/turnstile-widget.tsx
@@ -16,6 +16,8 @@ export interface TurnstileRenderOptions {
   /* Default is a fixed 300px, narrower than the form's fields. */
   size?: "normal" | "flexible" | "compact";
   theme?: "light" | "dark" | "auto";
+  /* interaction-only: nothing paints unless Cloudflare needs a challenge. */
+  appearance?: "always" | "execute" | "interaction-only";
   callback: (token: string) => void;
   "expired-callback": () => void;
   "error-callback": () => void;
@@ -116,6 +118,7 @@ export const TurnstileWidget = forwardRef<TurnstileWidgetHandle, TurnstileWidget
             action,
             size: "flexible",
             theme: widgetTheme,
+            appearance: "interaction-only",
             callback: (token) => onTokenRef.current(token),
             "expired-callback": () => onTokenRef.current(""),
             "error-callback": () => {
@@ -140,14 +143,12 @@ export const TurnstileWidget = forwardRef<TurnstileWidgetHandle, TurnstileWidget
     }, [siteKey, action, widgetTheme]);
 
     return (
-      /* min-h reserves the height so the submit button doesn't jump when the
-         widget paints. Padding, not margin: the form's space-y-3 owns the
-         margins, so py-2 stacks to 20px of air here against the fields' 12px.
-         That air is the only separation available, since Cloudflare renders the
-         plate itself out of reach of our stylesheets. */
+      /* Empty in the common case, so it reserves no height. empty:hidden keeps
+         the form's space-y-3 from adding a gap for a box with nothing in it;
+         py-2 only applies once Cloudflare paints a challenge plate. */
       <div
         ref={containerRef}
-        className="cf-turnstile min-h-[65px] py-2"
+        className="cf-turnstile py-2 empty:hidden empty:p-0"
         data-sitekey={siteKey}
         data-action={action}
       />

--- a/frontend/src/pages/signup/components/tests/signup-form-turnstile.test.tsx
+++ b/frontend/src/pages/signup/components/tests/signup-form-turnstile.test.tsx
@@ -92,6 +92,7 @@ describe("SignupForm Turnstile integration", () => {
     });
     expect(renderOptions?.sitekey).toBe("public-site-key");
     expect(renderOptions?.action).toBe("turnstile-spin-v2");
+    expect(renderOptions?.appearance).toBe("interaction-only");
   });
 
   it("resets the widget after the signup request fails", async () => {


### PR DESCRIPTION
## 📝 What this does
Makes the Cloudflare Turnstile check on signup invisible in the common case. Visitors who don't trigger a challenge never see the widget, and the form no longer reserves a 65px block for something that usually paints nothing.

## 🔀 Changes
- Rendered the widget with `appearance: "interaction-only"` so the challenge plate only paints when Cloudflare asks for one
- Dropped the fixed height reservation and collapsed the container while it is empty
- Added the `appearance` option to the Turnstile render types

## 🧪 How to test
- [x] Enable Turnstile in the signup config and open the signup page
- [x] Confirm no challenge plate renders and the submit button enables once the token arrives
- [x] Sign up and confirm verification still passes server-side
- [x] Force a challenge (Cloudflare dashboard, interactive widget mode) and confirm the plate renders with spacing intact

Note: full invisibility also requires the widget mode for the cloud sitekey to be set to Invisible or Managed in the Cloudflare dashboard. This PR only covers the client side.