### PR TITLE
Fix: let the auth column scroll on short viewports

### DIFF
--- a/frontend/src/pages/auth/components/auth-shell.tsx
+++ b/frontend/src/pages/auth/components/auth-shell.tsx
@@ -41,7 +41,7 @@ export function AuthShell({ title, sub, below, children }: AuthShellProps) {
         <ThemeToggle />
       </header>
 
-      <div className="h-full overflow-y-auto">
+      <div className="h-full overflow-y-auto overflow-x-hidden">
         <main className="relative z-[1] mx-auto flex min-h-full w-full max-w-[428px] flex-col px-6 pb-10 pt-20">
           <div className="mt-auto text-center">
             <h1 className="text-[26px] font-semibold leading-tight tracking-tight">{title}</h1>

--- a/frontend/src/pages/auth/components/auth-shell.tsx
+++ b/frontend/src/pages/auth/components/auth-shell.tsx
@@ -14,9 +14,12 @@ interface AuthShellProps {
 // warm brand-tinted sky falling to the page ground — and the form sits in an
 // inset plate. The header is absolute chrome so the column centers on the
 // viewport, not on the leftover space under a flow header.
+// Global CSS clips body and #root (index.css: height 100vh, overflow hidden),
+// so the column scrolls in its own box. Sky and header stay outside that box,
+// or the horizon and the wordmark scroll away with the form.
 export function AuthShell({ title, sub, below, children }: AuthShellProps) {
   return (
-    <div className="relative flex min-h-svh flex-col overflow-hidden bg-background text-foreground">
+    <div className="relative h-full overflow-hidden bg-background text-foreground">
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-x-0 top-0 h-[52svh] bg-gradient-to-b from-brand-bg to-transparent"
@@ -38,20 +41,22 @@ export function AuthShell({ title, sub, below, children }: AuthShellProps) {
         <ThemeToggle />
       </header>
 
-      <main className="relative z-[1] mx-auto flex w-full max-w-[428px] flex-1 flex-col px-6 py-20">
-        <div className="mt-auto text-center">
-          <h1 className="text-[26px] font-semibold leading-tight tracking-tight">{title}</h1>
-          {sub && <p className="mx-auto mt-2.5 text-sm leading-relaxed text-muted-foreground">{sub}</p>}
-        </div>
+      <div className="h-full overflow-y-auto">
+        <main className="relative z-[1] mx-auto flex min-h-full w-full max-w-[428px] flex-col px-6 pb-10 pt-20">
+          <div className="mt-auto text-center">
+            <h1 className="text-[26px] font-semibold leading-tight tracking-tight">{title}</h1>
+            {sub && <p className="mx-auto mt-2.5 text-sm leading-relaxed text-muted-foreground">{sub}</p>}
+          </div>
 
-        {/* Pill controls inside a stadium plate — the plate is rounded like its contents. */}
-        <div className="mt-8 rounded-[36px] border border-border bg-card p-6 [&_button]:rounded-full [&_input]:rounded-full [&_input]:pl-4">
-          {children}
-        </div>
+          {/* Pill controls inside a stadium plate — the plate is rounded like its contents. */}
+          <div className="mt-8 rounded-[36px] border border-border bg-card p-6 [&_button]:rounded-full [&_input]:rounded-full [&_input]:pl-4">
+            {children}
+          </div>
 
-        {below && <div className="mt-6 text-center text-sm text-muted-foreground">{below}</div>}
-        <div className="mb-auto" aria-hidden="true" />
-      </main>
+          {below && <div className="mt-6 text-center text-sm text-muted-foreground">{below}</div>}
+          <div className="mb-auto" aria-hidden="true" />
+        </main>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 📝 What this does
The auth pages could not scroll at all, so on a 13-inch laptop the signup form lost its "Already have an account? Log in" link below the fold with no way to reach it. The column now scrolls in its own box.

## 🔀 Changes
- Gave the auth column a scroll container, since the global shell pins `body` and `#root` to `100vh` with `overflow: hidden`
- Kept the sky and the header outside that box so the horizon and wordmark stay put while the form scrolls
- Sized the shell against the fixed-height root instead of `svh`, which was shorter than its own parent on mobile Safari
- Trimmed the column's bottom padding, which the auto-margin centering absorbs whenever the page fits

## 🧪 How to test
- [x] Open the signup page in a window about 730px tall and scroll to reach the Log in link
- [x] Confirm the wordmark and theme toggle stay pinned while the form moves under them
- [x] Confirm no horizontal scrollbar appears and the clouds stay clipped at the edges
- [x] Open the same page at 900px tall and confirm it still centers with no scrolling

Measured at `/sign-up`: content is 809px, so a 731px viewport scrolls 78px and a 900px viewport does not scroll at all. Sign-in and the mobile viewport fit without scrolling.

Known limit: this makes the overflow reachable, it does not make signup fit a 13-inch laptop. Closing that last ~80px means tightening the plate's internal rhythm and pairing two fields onto one row, which is a design change worth its own PR.