### PR TITLE
Fix Mage local development bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test/cloudint/.cache/
 cluster_config.yaml
 database.yaml
 bin/
+.cache/
 dev_env.yaml
 
 .superpowers/

--- a/cmd/mage/main.go
+++ b/cmd/mage/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/magefile/mage/mage"
+)
+
+func main() {
+	os.Exit(mage.Main())
+}

--- a/hack/run_local.sh
+++ b/hack/run_local.sh
@@ -3,7 +3,7 @@
 # Run Stackdome locally for development.
 #
 # Bootstraps a complete local Stackdome environment:
-#   1. mage dev:setup (PostgreSQL + k3d cluster + operators + RBAC)
+#   1. ./mage dev:setup (PostgreSQL + k3d cluster + operators + RBAC)
 #   2. API server (built and run locally)
 #   3. User signup, cluster registration, org domain
 #   4. (Optional) Postgres addon deployment
@@ -14,13 +14,12 @@
 # restarted on each run.
 #
 # Prerequisites:
-#   - Go 1.22+
+#   - Go 1.25+
+#   - Node.js 20.12+
 #   - Docker
-#   - k3d (https://k3d.io)
-#   - kubectl
 #   - jq
-#   - mage (https://magefile.org)
-#   - helm
+#
+# k3d, kubectl, Helm, and Mage are bootstrapped by this repository.
 #
 # Usage:
 #   # Start environment only (no stack)
@@ -43,7 +42,7 @@
 #   CLOUD_MODE                 Set to "true" for stackdome_cloud + shared compute
 #   ORG_DOMAIN                 Organisation domain (default: stackdome.127.0.0.1.nip.io)
 #   ADDON_FILE                 Postgres addon JSON file (creates addon before stack)
-#   SKIP_INFRA                 Set to "true" to skip mage dev:setup (reuse existing)
+#   SKIP_INFRA                 Set to "true" to skip ./mage dev:setup (reuse existing)
 #   SKIP_API_SERVER            Set to "true" to skip building/starting the API server
 #   FORCE_CLUSTER_RECREATE     Set to "true" to delete and recreate k3d cluster
 #   FORCE_PG_RECREATE          Set to "true" to delete and recreate PostgreSQL container
@@ -66,6 +65,8 @@ SKIP_API_SERVER="${SKIP_API_SERVER:-false}"
 FORCE_CLUSTER_RECREATE="${FORCE_CLUSTER_RECREATE:-false}"
 FORCE_PG_RECREATE="${FORCE_PG_RECREATE:-false}"
 DEV_CONFIG="${API_SERVER_DIR}/dev_env.yaml"
+MAGE_CMD="${API_SERVER_DIR}/mage"
+STACKDOME_BIN_DIR="${HOME}/.cache/stackdome-api-server/bin"
 
 STACK_FILE="${1:-}"
 ADDON_FILE="${ADDON_FILE:-}"
@@ -81,6 +82,26 @@ log()  { echo -e "${GREEN}[+]${NC} $*"; }
 warn() { echo -e "${YELLOW}[!]${NC} $*"; }
 err()  { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
 info() { echo -e "${BLUE}[i]${NC} $*"; }
+
+version_at_least() {
+    local actual="${1#v}"
+    local required="${2#v}"
+    actual="${actual#go}"
+
+    local actual_major actual_minor actual_patch
+    local required_major required_minor required_patch
+    IFS=. read -r actual_major actual_minor actual_patch <<< "$actual"
+    IFS=. read -r required_major required_minor required_patch <<< "$required"
+
+    actual_patch="${actual_patch%%[^0-9]*}"
+    required_patch="${required_patch%%[^0-9]*}"
+    [[ "$actual_major" =~ ^[0-9]+$ && "$actual_minor" =~ ^[0-9]+$ && "$actual_patch" =~ ^[0-9]+$ ]] || return 1
+    [[ "$required_major" =~ ^[0-9]+$ && "$required_minor" =~ ^[0-9]+$ && "$required_patch" =~ ^[0-9]+$ ]] || return 1
+
+    (( actual_major > required_major )) ||
+        (( actual_major == required_major && actual_minor > required_minor )) ||
+        (( actual_major == required_major && actual_minor == required_minor && actual_patch >= required_patch ))
+}
 
 PG_CONTAINER_NAME="psql-stackdome-dev"
 
@@ -102,17 +123,49 @@ trap cleanup EXIT
 trap 'exit 0' INT TERM
 
 # ============================================================
-# Prerequisites
+# Tool bootstrap and prerequisites
 # ============================================================
+bootstrap_dev_tools() {
+    export PATH="${STACKDOME_BIN_DIR}:${PATH}"
+
+    log "Bootstrapping local development tools with Mage..."
+    (
+        cd "$API_SERVER_DIR"
+        "$MAGE_CMD" deps:dev
+    )
+}
+
 check_prerequisites() {
     log "Checking prerequisites..."
+
+    if ! command -v go &>/dev/null; then
+        err "Go 1.25+ is required. Install it from https://go.dev/dl/ and rerun this script."
+    fi
+    local go_version
+    go_version="$(go env GOVERSION 2>/dev/null || true)"
+    if ! version_at_least "$go_version" "1.25.0"; then
+        err "Go 1.25+ is required (found ${go_version:-unknown}). Install it from https://go.dev/dl/ and rerun this script."
+    fi
+
+    if ! command -v node &>/dev/null; then
+        err "Node.js 20.12+ is required. Install it from https://nodejs.org/ and rerun this script."
+    fi
+    local node_version
+    node_version="$(node --version 2>/dev/null || true)"
+    if ! version_at_least "$node_version" "20.12.0"; then
+        err "Node.js 20.12+ is required (found ${node_version:-unknown}). Install it from https://nodejs.org/ and rerun this script."
+    fi
+
+    if [[ ! -x "$MAGE_CMD" ]]; then
+        err "Mage launcher not found or not executable: ${MAGE_CMD}"
+    fi
 
     if [[ "$CLOUD_MODE" != "true" && "$CLOUD_MODE" != "false" ]]; then
         err "CLOUD_MODE must be either 'true' or 'false'"
     fi
 
     local missing=()
-    for cmd in go docker k3d kubectl jq mage helm; do
+    for cmd in docker jq; do
         if ! command -v "$cmd" &>/dev/null; then
             missing+=("$cmd")
         fi
@@ -137,13 +190,13 @@ check_prerequisites() {
 }
 
 # ============================================================
-# Step 1: Infrastructure (mage dev:setup)
+# Step 1: Infrastructure (./mage dev:setup)
 # ============================================================
 setup_infra() {
     if [[ "$SKIP_INFRA" == "true" ]]; then
         warn "Skipping infrastructure setup (SKIP_INFRA=true)"
         if [[ ! -f "$DEV_CONFIG" ]]; then
-            err "SKIP_INFRA=true but ${DEV_CONFIG} not found. Run mage dev:setup first."
+            err "SKIP_INFRA=true but ${DEV_CONFIG} not found. Run ./mage dev:setup first."
         fi
         return
     fi
@@ -160,13 +213,13 @@ setup_infra() {
         docker rm -f "$PG_CONTAINER_NAME" 2>/dev/null || true
     fi
 
-    log "Running mage dev:setup (PostgreSQL + k3d cluster + operators + RBAC)..."
+    log "Running ./mage dev:setup (PostgreSQL + k3d cluster + operators + RBAC)..."
     log "This may take 5-10 minutes on first run..."
     cd "$API_SERVER_DIR"
-    mage dev:setup
+    "$MAGE_CMD" dev:setup
 
     if [[ ! -f "$DEV_CONFIG" ]]; then
-        err "mage dev:setup completed but ${DEV_CONFIG} not found."
+        err "./mage dev:setup completed but ${DEV_CONFIG} not found."
     fi
     log "Infrastructure ready."
 }
@@ -200,8 +253,11 @@ start_api_server() {
         return
     fi
 
-    log "Building API server..."
+    log "Building frontend..."
     cd "$API_SERVER_DIR"
+    "$MAGE_CMD" buildFrontend
+
+    log "Building API server..."
     make binary
 
     if [[ -f "$API_SERVER_DIR/.env" ]]; then
@@ -593,7 +649,7 @@ EOF
     log "  kubectl --context k3d-${K3D_CLUSTER_NAME} get pods -A -w"
     log ""
     log "  # Tear down everything"
-    log "  mage dev:teardown"
+    log "  ./mage dev:teardown"
     log ""
 }
 
@@ -659,6 +715,7 @@ main() {
     log ""
 
     check_prerequisites
+    bootstrap_dev_tools
     setup_infra
     read_dev_config
     start_api_server
@@ -675,7 +732,7 @@ main() {
 
     log "Press Ctrl+C to stop the API server."
     log "Infrastructure (k3d + PostgreSQL) will remain running."
-    log "To tear down everything: mage dev:teardown"
+    log "To tear down everything: ./mage dev:teardown"
     wait "$API_SERVER_PID"
 }
 

--- a/mage
+++ b/mage
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+export MAGEFILE_CACHE="$SCRIPT_DIR/.cache/magefile"
+export GOFLAGS=""
+
+if [[ ! -x "bin/mage" || "cmd/mage/main.go" -nt "bin/mage" || "go.mod" -nt "bin/mage" || "go.sum" -nt "bin/mage" ]]; then
+  go build -o bin/mage ./cmd/mage
+fi
+
+exec ./bin/mage -v "$@"

--- a/magefile.go
+++ b/magefile.go
@@ -22,6 +22,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	"github.com/magefile/mage/target"
 	"github.com/mt-sre/devkube/dev"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -95,6 +96,7 @@ const (
 
 	// Versions
 	KindVersion      = "v0.20.0"
+	K3dVersion       = "v5.9.0"
 	YqVersion        = "v4.44.1"
 	HelmVersion      = "v3.14.0"
 	KubectlVersion   = "v1.29.0"
@@ -160,15 +162,36 @@ func mustGetEnv(key string) string {
 // BuildFrontend builds the Vite SPA into pkg/web/dist for //go:embed.
 // Skips `tsc -b` so unrelated type errors don't block the build.
 func BuildFrontend(ctx context.Context) error {
+	if _, err := exec.LookPath("node"); err != nil {
+		return fmt.Errorf("node not found on PATH; install Node.js >=20.12 from https://nodejs.org/")
+	}
+
+	changed, err := target.Dir("pkg/web/dist/index.html",
+		"frontend/src",
+		"frontend/public",
+		"frontend/index.html",
+		"frontend/package.json",
+		"frontend/pnpm-lock.yaml",
+		"frontend/vite.config.ts",
+		"frontend/tsconfig.json",
+		"frontend/tsconfig.app.json",
+		"frontend/tsconfig.node.json",
+	)
+	if err != nil {
+		return fmt.Errorf("checking frontend build freshness: %w", err)
+	}
+	if !changed {
+		fmt.Println("✓ Frontend bundle is up to date")
+		return nil
+	}
+
 	fmt.Println("Building frontend (pnpm install + vite build)...")
 	if err := installDep(ctx, "pnpm", PnpmVersion); err != nil {
 		return fmt.Errorf("failed to ensure pnpm: %w", err)
 	}
-	if _, err := exec.LookPath("node"); err != nil {
-		return fmt.Errorf("node not found on PATH (Node >=20.12 required, see frontend/package.json engines)")
-	}
 	pnpmBin := filepath.Join(binDir, "pnpm")
-	if err := sh.RunV(pnpmBin, "--prefix", "frontend", "install", "--frozen-lockfile"); err != nil {
+	if err := sh.RunWithV(map[string]string{"CI": "true"}, pnpmBin,
+		"--prefix", "frontend", "install", "--frozen-lockfile"); err != nil {
 		return fmt.Errorf("pnpm install failed: %w", err)
 	}
 	if err := sh.RunV(pnpmBin, "--prefix", "frontend", "exec", "vite", "build"); err != nil {
@@ -266,6 +289,29 @@ var Default = Build
 // Deps namespace for dependency management
 type Deps mg.Namespace
 
+// Dev installs the binary dependencies required by the local dev environment.
+func (Deps) Dev(ctx context.Context) error {
+	fmt.Println("Installing local dev environment dependencies...")
+
+	deps := []struct {
+		name    string
+		version string
+	}{
+		{"k3d", K3dVersion},
+		{"helm", HelmVersion},
+		{"kubectl", KubectlVersion},
+	}
+
+	for _, dep := range deps {
+		if err := installDep(ctx, dep.name, dep.version); err != nil {
+			return fmt.Errorf("failed to install %s: %w", dep.name, err)
+		}
+	}
+
+	fmt.Println("✅ Local dev environment dependencies installed")
+	return nil
+}
+
 // Install installs all required dependencies for integration testing
 func (Deps) Install(ctx context.Context) error {
 	fmt.Println("Installing integration test dependencies...")
@@ -325,10 +371,10 @@ func installDep(ctx context.Context, name, version string) error {
 
 	// Check if already installed
 	if _, err := os.Stat(binPath); err == nil {
-		// Verify it's executable
-		cmd := exec.CommandContext(ctx, binPath, "--version")
-		if err := cmd.Run(); err == nil {
-			fmt.Printf("✓ %s already installed\n", name)
+		// Verify it is executable and matches the requested pinned version.
+		cmd := exec.CommandContext(ctx, binPath, dependencyVersionArgs(name)...)
+		if output, err := cmd.CombinedOutput(); err == nil && dependencyVersionMatches(version, string(output)) {
+			fmt.Printf("✓ %s %s already installed\n", name, version)
 			return nil
 		}
 	}
@@ -339,6 +385,8 @@ func installDep(ctx context.Context, name, version string) error {
 	switch name {
 	case "kind":
 		return installKind(ctx, version)
+	case "k3d":
+		return installK3d(ctx, version)
 	case "yq":
 		return installYq(ctx, version)
 	case "helm":
@@ -350,6 +398,46 @@ func installDep(ctx context.Context, name, version string) error {
 	default:
 		return fmt.Errorf("unknown dependency: %s", name)
 	}
+}
+
+func dependencyVersionArgs(name string) []string {
+	switch name {
+	case "helm":
+		return []string{"version", "--short"}
+	case "kubectl":
+		return []string{"version", "--client"}
+	default:
+		return []string{"--version"}
+	}
+}
+
+func dependencyVersionMatches(expected, output string) bool {
+	expected = strings.TrimPrefix(expected, "v")
+	for _, field := range strings.Fields(output) {
+		candidate := strings.Trim(field, ",;()")
+		candidate = strings.TrimPrefix(candidate, "v")
+		candidate = strings.SplitN(candidate, "+", 2)[0]
+		if candidate == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func installK3d(ctx context.Context, version string) error {
+	url := fmt.Sprintf("https://github.com/k3d-io/k3d/releases/download/%s/k3d-%s-%s",
+		version, goOs, goArch)
+
+	binPath := filepath.Join(binDir, "k3d")
+	if err := downloadFile(ctx, url, binPath); err != nil {
+		return fmt.Errorf("failed to download k3d: %w", err)
+	}
+
+	if err := os.Chmod(binPath, 0755); err != nil {
+		return fmt.Errorf("failed to make k3d executable: %w", err)
+	}
+
+	return nil
 }
 
 func installKind(ctx context.Context, version string) error {
@@ -457,7 +545,7 @@ func installKubectl(ctx context.Context, version string) error {
 }
 
 func downloadFile(ctx context.Context, url, filepath string) error {
-	cmd := exec.CommandContext(ctx, "curl", "-L", "-o", filepath, url)
+	cmd := exec.CommandContext(ctx, "curl", "--fail", "--location", "--show-error", "--output", filepath, url)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("download failed: %w\nOutput: %s", err, output)
 	}
@@ -935,6 +1023,11 @@ func (Dev) Setup(ctx context.Context) error {
 	fmt.Println("========================================")
 	fmt.Println(" Setting up Stackdome dev environment")
 	fmt.Println("========================================")
+	fmt.Println()
+
+	if err := (Deps{}).Dev(ctx); err != nil {
+		return fmt.Errorf("failed to install dev dependencies: %w", err)
+	}
 	fmt.Println()
 
 	// Step 1: Load .env and get DB config


### PR DESCRIPTION
## Summary

- bootstrap Mage, k3d, Helm, and kubectl through repository-local Mage tooling
- build the frontend from `hack/run_local.sh` and skip it when Mage determines the bundle is current
- enforce Go and Node.js prerequisites and validate cached dependency versions

## Verification

- `bash -n hack/run_local.sh mage`
- `./mage buildFrontend` (full build when stale)
- `./mage buildFrontend` (no-op when current)
- `./mage deps:dev`
- `make binary`

Tests were not run or added, per request.