### PR TITLE
Fix public URL outputs to respect ingress TLS

### DIFF
--- a/cmd/environment/env.go
+++ b/cmd/environment/env.go
@@ -980,6 +980,10 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 		Logger:         e.Logger,
 	})
 
+	publicEndpoints := models.PublicEndpointConfig{
+		SharedCompute:      e.Config.ComputeMode == config.ComputeModeShared,
+		PlatformTLSEnabled: e.PlatformConfig.PlatformTLSEnabled,
+	}
 	releaseWorker := releaseworker.NewReleaseWorker(releaseworker.ReleaseWorkerSpec{
 		ReleaseService:       e.Services.StackReleaseService,
 		EventRecorder:        e.Services.ReleaseEventRecorder,
@@ -992,12 +996,12 @@ func (e *environmentImpl) initializeWorkerManager(ctx context.Context) error {
 		VolumeService:        e.Services.VolumeService,
 		CRBuilder: builders.NewClusterResourceBuilder(builders.ClusterResourceBuilderSpec{
 			CredentialResolver: e.Services.CredentialResolver,
-			ComputeMode:        e.Config.ComputeMode,
-			PlatformTLSEnabled: e.PlatformConfig.PlatformTLSEnabled,
+			PublicEndpoints:    publicEndpoints,
 			PlatformBaseDomain: e.PlatformConfig.BaseDomain,
 		}),
 		SecretBuilder: builders.NewSecretBuilder(builders.SecretBuilderSpec{}),
 		Resolver: stackdeploy.NewResolver(stackdeploy.ResolverSpec{
+			PublicEndpoints:      publicEndpoints,
 			VolumeService:        e.Services.VolumeService,
 			PostgresAddonService: e.Services.PostgresAddonService,
 			SecretService:        e.Services.SecretService,

--- a/pkg/builders/cluster_resource_builder.go
+++ b/pkg/builders/cluster_resource_builder.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Stackdome/stackdome/config"
 	"github.com/Stackdome/stackdome/pkg/credentials"
 	"github.com/Stackdome/stackdome/pkg/models"
 	"github.com/davecgh/go-spew/spew"
@@ -29,8 +28,7 @@ type ClusterResourceBuilder interface {
 type clusterResourceBuilder struct {
 	credentialResolver credentials.Resolver
 	platformBaseDomain string
-	computeMode        config.ComputeMode
-	platformTLSEnabled bool
+	publicEndpoints    models.PublicEndpointConfig
 }
 
 type ClusterResourceBuilderSpec struct {
@@ -38,16 +36,14 @@ type ClusterResourceBuilderSpec struct {
 	// auto-attach to image pull / push specs.
 	CredentialResolver credentials.Resolver
 	PlatformBaseDomain string
-	ComputeMode        config.ComputeMode
-	PlatformTLSEnabled bool
+	PublicEndpoints    models.PublicEndpointConfig
 }
 
 func NewClusterResourceBuilder(spec ClusterResourceBuilderSpec) ClusterResourceBuilder {
 	return &clusterResourceBuilder{
 		credentialResolver: spec.CredentialResolver,
 		platformBaseDomain: spec.PlatformBaseDomain,
-		computeMode:        spec.ComputeMode,
-		platformTLSEnabled: spec.PlatformTLSEnabled,
+		publicEndpoints:    spec.PublicEndpoints,
 	}
 }
 
@@ -488,16 +484,12 @@ func (b *clusterResourceBuilder) setPorts(resourceSpecCr *corev1alpha1.StackReso
 	if len(stackResource.Ports) > 0 {
 		resourceSpecCr.Ports = make([]corev1alpha1.Port, len(stackResource.Ports))
 		for i, port := range stackResource.Ports {
-			tlsEnabled := port.ExposedToPublic && shouldEnableTLS(port.ExposedFqdn)
-			if b.computeMode == config.ComputeModeShared && !b.platformTLSEnabled {
-				tlsEnabled = false
-			}
 			resourceSpecCr.Ports[i] = corev1alpha1.Port{
 				Name:           port.Name,
 				Number:         int32(port.Number),
 				Protocol:       strings.ToLower(port.Protocol),
 				ExposeToPublic: port.ExposedToPublic,
-				TLS:            tlsEnabled,
+				TLS:            b.publicEndpoints.UsesTLS(port),
 			}
 			if port.ExposedToPublic {
 				resourceSpecCr.Ports[i].FQDN = port.ExposedFqdn
@@ -520,19 +512,6 @@ func isDirectChildOfBaseDomain(fqdn, baseDomain string) bool {
 
 	child, found := strings.CutSuffix(fqdn, "."+baseDomain)
 	return found && child != "" && !strings.Contains(child, ".")
-}
-
-func shouldEnableTLS(fqdn string) bool {
-	if fqdn == "" {
-		return false
-	}
-	nonTLSDomains := []string{".nip.io", ".sslip.io", ".local", ".localhost"}
-	for _, suffix := range nonTLSDomains {
-		if strings.HasSuffix(fqdn, suffix) {
-			return false
-		}
-	}
-	return true
 }
 
 func setEnvVars(resourceSpecCr *corev1alpha1.StackResourceSpec, stackResource *models.StackResource) {

--- a/pkg/builders/cluster_resource_builder_test.go
+++ b/pkg/builders/cluster_resource_builder_test.go
@@ -14,34 +14,6 @@ import (
 	corev1alpha1 "stackdome.io/cluster-agent/api/core/v1alpha1"
 )
 
-func TestShouldEnableTLS(t *testing.T) {
-	tests := []struct {
-		name string
-		fqdn string
-		want bool
-	}{
-		{"empty string", "", false},
-		{"nip.io subdomain", "app.192-168-1-1.nip.io", false},
-		{"sslip.io subdomain", "app.10-0-0-1.sslip.io", false},
-		{"dot local", "myapp.local", false},
-		{"dot localhost", "myapp.localhost", false},
-		{"real domain", "app.example.com", true},
-		{"subdomain", "api.staging.example.com", true},
-		{"bare domain", "example.com", true},
-		{"io TLD not matching nip.io", "myapp.io", true},
-		{"domain ending in local but not .local suffix", "app.mylocal", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := shouldEnableTLS(tt.fqdn)
-			if got != tt.want {
-				t.Errorf("shouldEnableTLS(%q) = %v, want %v", tt.fqdn, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestHasCertManagerTLSPorts(t *testing.T) {
 	tests := []struct {
 		name string
@@ -157,8 +129,10 @@ var _ = Describe("clusterResourceBuilder platform wildcard TLS", func() {
 				fqdn = "api.customer.example.com"
 			}
 			builder := NewClusterResourceBuilder(ClusterResourceBuilderSpec{
-				ComputeMode:        computeMode,
-				PlatformTLSEnabled: platformTLSEnabled,
+				PublicEndpoints: models.PublicEndpointConfig{
+					SharedCompute:      computeMode == config.ComputeModeShared,
+					PlatformTLSEnabled: platformTLSEnabled,
+				},
 				PlatformBaseDomain: "cloud.stackdome.com",
 			})
 			resource := &models.StackResource{

--- a/pkg/models/output_descriptor.go
+++ b/pkg/models/output_descriptor.go
@@ -65,7 +65,7 @@ func stackResourceOutputKey(base, portName string, multiPort bool) string {
 	return base + "." + portName
 }
 
-func (r *StackResource) ToOutputMap() map[string]string {
+func (r *StackResource) ToOutputMap(publicEndpoints PublicEndpointConfig) map[string]string {
 	outputs := make(map[string]string)
 
 	host := r.InternalServiceHost()
@@ -84,7 +84,11 @@ func (r *StackResource) ToOutputMap() map[string]string {
 			continue
 		}
 		outputs[stackResourceOutputKey(OutputNamePublicHost, port.Name, multiPort)] = port.ExposedFqdn
-		outputs[stackResourceOutputKey(OutputNamePublicURL, port.Name, multiPort)] = "http://" + port.ExposedFqdn
+		scheme := "http://"
+		if publicEndpoints.UsesTLS(port) {
+			scheme = "https://"
+		}
+		outputs[stackResourceOutputKey(OutputNamePublicURL, port.Name, multiPort)] = scheme + port.ExposedFqdn
 	}
 
 	return outputs

--- a/pkg/models/output_descriptor_test.go
+++ b/pkg/models/output_descriptor_test.go
@@ -1,9 +1,55 @@
 package models
 
 import (
+	"testing"
+
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
 )
+
+func TestPublicURLOutputs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		config  PublicEndpointConfig
+		fqdn    string
+		public  bool
+		wantURL string
+	}{
+		{"shared TLS", PublicEndpointConfig{SharedCompute: true, PlatformTLSEnabled: true}, "web.example.com", true, "https://web.example.com"},
+		{"shared HTTP", PublicEndpointConfig{SharedCompute: true}, "web.example.com", true, "http://web.example.com"},
+		{"BYOC TLS", PublicEndpointConfig{}, "web.example.com", true, "https://web.example.com"},
+		{"local HTTP", PublicEndpointConfig{}, "web.local", true, "http://web.local"},
+		{"private port", PublicEndpointConfig{}, "web.example.com", false, ""},
+		{"unassigned hostname", PublicEndpointConfig{}, "", true, ""},
+	} {
+		for _, layout := range []string{"single", "multiple"} {
+			t.Run(tc.name+"/"+layout, func(t *testing.T) {
+				g := gomega.NewWithT(t)
+				r := &StackResource{Name: "web", Namespace: "app", Ports: Ports{
+					{Name: "http", Number: 8080, Protocol: PortProtocolHTTP, ExposedToPublic: tc.public, ExposedFqdn: tc.fqdn},
+				}}
+				suffix := ""
+				if layout == "multiple" {
+					r.Ports = append(r.Ports, Port{Name: "db", Number: 5432, Protocol: PortProtocolTCP})
+					suffix = ".http"
+				}
+				outputs := r.ToOutputMap(tc.config)
+				g.Expect(outputs[OutputNameURL+suffix]).To(gomega.Equal("http://web.app.svc:8080"))
+				if tc.wantURL == "" {
+					g.Expect(outputs).NotTo(gomega.HaveKey(OutputNamePublicURL + suffix))
+					g.Expect(outputs).NotTo(gomega.HaveKey(OutputNamePublicHost + suffix))
+				} else {
+					g.Expect(outputs[OutputNamePublicURL+suffix]).To(gomega.Equal(tc.wantURL))
+					g.Expect(outputs[OutputNamePublicHost+suffix]).To(gomega.Equal(tc.fqdn))
+				}
+				if layout == "multiple" {
+					g.Expect(outputs["url.db"]).To(gomega.Equal("web.app.svc:5432"))
+					g.Expect(outputs).NotTo(gomega.HaveKey("public_url.db"))
+				}
+			})
+		}
+	}
+}
 
 var _ = ginkgo.Describe("StackResource output naming", func() {
 	newResource := func(ports ...Port) *StackResource {
@@ -63,10 +109,10 @@ var _ = ginkgo.Describe("StackResource output naming", func() {
 			for _, d := range StackResourceOutputDescriptors(r) {
 				descNames[d.Name] = true
 			}
-			for k := range r.ToOutputMap() {
+			for k := range r.ToOutputMap(PublicEndpointConfig{}) {
 				gomega.Expect(descNames).To(gomega.HaveKey(k), "ToOutputMap key %q missing from descriptors", k)
 			}
-			gomega.Expect(len(r.ToOutputMap())).To(gomega.Equal(len(descNames)))
+			gomega.Expect(len(r.ToOutputMap(PublicEndpointConfig{}))).To(gomega.Equal(len(descNames)))
 		}
 	})
 
@@ -75,9 +121,9 @@ var _ = ginkgo.Describe("StackResource output naming", func() {
 			Port{Name: "3306", Number: 3306, Protocol: PortProtocolTCP},
 			Port{Name: "80", Number: 80, Protocol: PortProtocolHTTP, ExposedToPublic: true, ExposedFqdn: "web.example.com"},
 		)
-		m := r.ToOutputMap()
+		m := r.ToOutputMap(PublicEndpointConfig{})
 		gomega.Expect(m["url.3306"]).To(gomega.Equal("mysql:3306"))
 		gomega.Expect(m["url.80"]).To(gomega.Equal("http://mysql:80"))
-		gomega.Expect(m[OutputNamePublicURL+".80"]).To(gomega.Equal("http://web.example.com"))
+		gomega.Expect(m[OutputNamePublicURL+".80"]).To(gomega.Equal("https://web.example.com"))
 	})
 })

--- a/pkg/models/public_endpoint.go
+++ b/pkg/models/public_endpoint.go
@@ -1,0 +1,26 @@
+package models
+
+import "strings"
+
+// PublicEndpointConfig determines the configured ingress TLS behavior used by
+// both cluster resources and public URL outputs, independently of certificate
+// readiness or the application's internal protocol and port.
+type PublicEndpointConfig struct {
+	SharedCompute      bool
+	PlatformTLSEnabled bool
+}
+
+func (c PublicEndpointConfig) UsesTLS(port Port) bool {
+	if !port.ExposedToPublic || port.ExposedFqdn == "" {
+		return false
+	}
+	if c.SharedCompute && !c.PlatformTLSEnabled {
+		return false
+	}
+	for _, suffix := range []string{".nip.io", ".sslip.io", ".local", ".localhost"} {
+		if strings.HasSuffix(port.ExposedFqdn, suffix) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/models/public_endpoint_test.go
+++ b/pkg/models/public_endpoint_test.go
@@ -1,0 +1,31 @@
+package models
+
+import "testing"
+
+func TestPublicEndpointTLSHostnames(t *testing.T) {
+	tests := []struct {
+		name string
+		fqdn string
+		want bool
+	}{
+		{"empty string", "", false},
+		{"nip.io subdomain", "app.192-168-1-1.nip.io", false},
+		{"sslip.io subdomain", "app.10-0-0-1.sslip.io", false},
+		{"dot local", "myapp.local", false},
+		{"dot localhost", "myapp.localhost", false},
+		{"real domain", "app.example.com", true},
+		{"subdomain", "api.staging.example.com", true},
+		{"bare domain", "example.com", true},
+		{"io TLD not matching nip.io", "myapp.io", true},
+		{"domain ending in local but not .local suffix", "app.mylocal", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := (PublicEndpointConfig{}).UsesTLS(Port{ExposedToPublic: true, ExposedFqdn: tt.fqdn})
+			if got != tt.want {
+				t.Errorf("UsesTLS(%q) = %v, want %v", tt.fqdn, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/stackdeploy/env.go
+++ b/pkg/stackdeploy/env.go
@@ -7,20 +7,20 @@ import (
 	"github.com/Stackdome/stackdome/pkg/models"
 )
 
-func resolveSelfOutputEnvVars(stack *models.Stack) error {
+func (r *Resolver) resolveSelfOutputEnvVars(stack *models.Stack) error {
 	for _, resource := range stack.StackResources {
-		if err := resolveSelfOutputsForResource(resource); err != nil {
+		if err := r.resolveSelfOutputsForResource(resource); err != nil {
 			return fmt.Errorf("failed to resolve self output env vars for resource '%s': %w", resource.Name, err)
 		}
 	}
 	return nil
 }
 
-func resolveSelfOutputsForResource(resource *models.StackResource) error {
+func (r *Resolver) resolveSelfOutputsForResource(resource *models.StackResource) error {
 	if resource.ExecutionConfig == nil {
 		return nil
 	}
-	outputs := resource.ToOutputMap()
+	outputs := resource.ToOutputMap(r.publicEndpoints)
 	for i := range resource.ExecutionConfig.Env {
 		if resource.ExecutionConfig.Env[i].SelfOutput == "" {
 			continue
@@ -81,7 +81,7 @@ func (r *Resolver) resolveConnectionEnvVars(
 		if !ok {
 			return nil, fmt.Errorf("stack resource connection '%s' references unknown resource '%s'", connection.ID, connection.From.Name)
 		}
-		resolved, err := resolveConnectionMappings(connection, sourceResource.ToOutputMap())
+		resolved, err := resolveConnectionMappings(connection, sourceResource.ToOutputMap(r.publicEndpoints))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/stackdeploy/resolver.go
+++ b/pkg/stackdeploy/resolver.go
@@ -36,12 +36,14 @@ func (e DependencyNotReadyError) Error() string {
 }
 
 type ResolverSpec struct {
+	PublicEndpoints      models.PublicEndpointConfig
 	VolumeService        VolumeService
 	PostgresAddonService PostgresAddonService
 	SecretService        SecretService
 }
 
 type Resolver struct {
+	publicEndpoints      models.PublicEndpointConfig
 	volumeService        VolumeService
 	postgresAddonService PostgresAddonService
 	secretService        SecretService
@@ -49,6 +51,7 @@ type Resolver struct {
 
 func NewResolver(spec ResolverSpec) *Resolver {
 	return &Resolver{
+		publicEndpoints:      spec.PublicEndpoints,
 		volumeService:        spec.VolumeService,
 		postgresAddonService: spec.PostgresAddonService,
 		secretService:        spec.SecretService,
@@ -65,7 +68,7 @@ func (r *Resolver) Resolve(ctx context.Context, stack *models.Stack) (*models.St
 	if err := r.resolveVolumeConnections(ctx, effective); err != nil {
 		return nil, err
 	}
-	if err := resolveSelfOutputEnvVars(effective); err != nil {
+	if err := r.resolveSelfOutputEnvVars(effective); err != nil {
 		return nil, err
 	}
 	if err := r.resolveEnvConnections(ctx, effective); err != nil {

--- a/pkg/stackdeploy/resolver_test.go
+++ b/pkg/stackdeploy/resolver_test.go
@@ -5,11 +5,73 @@ import (
 	stderrors "errors"
 	"testing"
 
+	"github.com/Stackdome/stackdome/pkg/builders"
 	"github.com/Stackdome/stackdome/pkg/errors"
 	"github.com/Stackdome/stackdome/pkg/models"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 )
+
+func TestResolvePublicURLsMatchIngressTLS(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		config  models.PublicEndpointConfig
+		fqdn    string
+		wantTLS bool
+	}{
+		{"shared TLS", models.PublicEndpointConfig{SharedCompute: true, PlatformTLSEnabled: true}, "api.app.stackdome.com", true},
+		{"shared HTTP", models.PublicEndpointConfig{SharedCompute: true}, "api.app.stackdome.com", false},
+		{"BYOC TLS", models.PublicEndpointConfig{}, "api.example.com", true},
+		{"BYOC HTTP", models.PublicEndpointConfig{}, "api.127-0-0-1.nip.io", false},
+	} {
+		for _, layout := range []string{"single", "multiple"} {
+			t.Run(tc.name+"/"+layout, func(t *testing.T) {
+				g := NewWithT(t)
+				api := &models.StackResource{Name: "api", Namespace: "app", Ports: models.Ports{
+					{Name: "http", Number: 8080, Protocol: models.PortProtocolHTTP, ExposedToPublic: true, ExposedFqdn: tc.fqdn},
+				}, ExecutionConfig: &models.ExecutionConfig{}}
+				suffix := ""
+				if layout == "multiple" {
+					api.Ports = append(api.Ports, models.Port{Name: "local", Number: 9090, Protocol: models.PortProtocolHTTP, ExposedToPublic: true, ExposedFqdn: "api.local"})
+					suffix = ".http"
+					api.ExecutionConfig.Env = append(api.ExecutionConfig.Env, models.EnvVar{Name: "LOCAL_URL", SelfOutput: "public_url.local"})
+				}
+				api.ExecutionConfig.Env = append(api.ExecutionConfig.Env,
+					models.EnvVar{Name: "PUBLIC_URL", SelfOutput: models.OutputNamePublicURL + suffix},
+					models.EnvVar{Name: "INTERNAL_URL", SelfOutput: models.OutputNameURL + suffix},
+				)
+				stack := &models.Stack{StackResources: []*models.StackResource{api, {Name: "web"}}, Connections: models.StackConnections{{
+					ID: "api-web", Kind: models.ConnectionKindEnv,
+					From: models.TopologyNodeRef{Type: models.TopologyNodeTypeStackResource, Name: "api"},
+					To:   models.TopologyNodeRef{Type: models.TopologyNodeTypeStackResource, Name: "web"},
+					Mappings: []models.ConnectionMapping{
+						{Target: models.ConnectionTarget{Type: models.ConnectionTargetTypeEnv, Name: "API_URL"}, Value: models.ValueRef{Output: models.OutputNamePublicURL + suffix}},
+						{Target: models.ConnectionTarget{Type: models.ConnectionTargetTypeEnv, Name: "API_CALLBACK"}, Value: models.ValueRef{Template: "{{url}}/callback", Values: map[string]models.OutputValueRef{"url": {Output: models.OutputNamePublicURL + suffix}}}},
+					},
+				}}}
+				resolver := NewResolver(ResolverSpec{PublicEndpoints: tc.config})
+				effective, err := resolver.Resolve(context.Background(), stack)
+				g.Expect(err).NotTo(HaveOccurred())
+				wantURL := "http://" + tc.fqdn
+				if tc.wantTLS {
+					wantURL = "https://" + tc.fqdn
+				}
+				g.Expect(envValue(effective, "api", "PUBLIC_URL")).To(Equal(wantURL))
+				g.Expect(envValue(effective, "api", "INTERNAL_URL")).To(Equal("http://api.app.svc:8080"))
+				g.Expect(envValue(effective, "web", "API_URL")).To(Equal(wantURL))
+				g.Expect(envValue(effective, "web", "API_CALLBACK")).To(Equal(wantURL + "/callback"))
+				builder := builders.NewClusterResourceBuilder(builders.ClusterResourceBuilderSpec{PublicEndpoints: tc.config, PlatformBaseDomain: "app.stackdome.com"})
+				cr, err := builder.BuildStackResourceCR(effective.StackResources[0], "stack", "org")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cr.Spec.Ports[0].TLS).To(Equal(tc.wantTLS))
+				if layout == "multiple" {
+					g.Expect(envValue(effective, "api", "LOCAL_URL")).To(Equal("http://api.local"))
+					g.Expect(cr.Spec.Ports[1].TLS).To(BeFalse())
+				}
+			})
+		}
+	}
+}
 
 func TestResolveDoesNotMutateInputStack(t *testing.T) {
 	g := NewWithT(t)
@@ -37,7 +99,7 @@ func TestResolveDoesNotMutateInputStack(t *testing.T) {
 	effective, err := resolver.Resolve(context.Background(), stack)
 
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(effective.StackResources[0].ExecutionConfig.Env[0].Value).To(Equal("http://api.example.com"))
+	g.Expect(effective.StackResources[0].ExecutionConfig.Env[0].Value).To(Equal("https://api.example.com"))
 	g.Expect(stack.StackResources[0].ExecutionConfig.Env[0].Value).To(Equal(""))
 }
 
@@ -173,7 +235,7 @@ func TestResolveStackResourceEnvConnection(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(envValue(effective, "web", "API_HOST")).To(Equal("api.default.svc"))
 	g.Expect(envValue(effective, "web", "API_URL")).To(Equal("http://api.default.svc:8080"))
-	g.Expect(envValue(effective, "web", "API_PUBLIC_URL")).To(Equal("http://api.example.com"))
+	g.Expect(envValue(effective, "web", "API_PUBLIC_URL")).To(Equal("https://api.example.com"))
 	g.Expect(envValue(effective, "web", "API_TEMPLATE_URL")).To(Equal("http://api.example.com:8080"))
 	g.Expect(len(stack.StackResources[1].ExecutionConfig.Env)).To(Equal(0))
 }


### PR DESCRIPTION
Public URL outputs always used `http://`, so applications consuming `${self.public_url}` or resource-output connections received the wrong base URL when ingress TLS was configured.

Share the existing ingress TLS decision through `PublicEndpointConfig` and wire the same configuration into the cluster-resource builder and deployment resolver. Both `public_url` and `public_url.<port>` now use HTTPS when TLS is configured, while internal service URLs and HTTP-only deployments retain their existing behavior. The scheme reflects configured TLS, independently of certificate readiness.

Validation:
- Regression tests reproduced the HTTP/HTTPS mismatch before the fix.
- Coverage includes single-port and multi-port outputs, self environment variables, direct and template connections, mixed HTTP/HTTPS endpoints, and private or unassigned endpoints.
- `go test ./pkg/models ./pkg/builders ./pkg/stackdeploy ./pkg/worker/release ./cmd/environment`
- `go vet ./pkg/models ./pkg/builders ./pkg/stackdeploy ./pkg/worker/release ./cmd/environment`
- Formatting and diff checks passed; independent code review found no issues.

Fixes #285.
